### PR TITLE
feat: HMAC-SHA256 request signing for internal service calls

### DIFF
--- a/src/stronghold/security/hmac.py
+++ b/src/stronghold/security/hmac.py
@@ -1,0 +1,131 @@
+"""HMAC-SHA256 request signing and verification for internal service calls.
+
+Provides two public functions:
+  - ``sign_request`` — creates signature headers for an outbound request.
+  - ``verify_request`` — validates signature and checks timestamp freshness.
+
+Signing payload format::
+
+    {METHOD}\\n{PATH}\\n{TIMESTAMP}\\n{BODY_BYTES}
+
+Headers produced / consumed:
+  - ``X-Stronghold-Signature: sha256=<hex_digest>``
+  - ``X-Stronghold-Timestamp: <unix_epoch_float>``
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import time
+
+__all__ = [
+    "DEFAULT_MAX_AGE",
+    "HEADER_SIGNATURE",
+    "HEADER_TIMESTAMP",
+    "sign_request",
+    "verify_request",
+]
+
+HEADER_SIGNATURE = "X-Stronghold-Signature"
+HEADER_TIMESTAMP = "X-Stronghold-Timestamp"
+DEFAULT_MAX_AGE: float = 60  # seconds
+
+
+def _build_payload(method: str, path: str, timestamp: float, body: bytes) -> bytes:
+    """Construct the canonical signing payload."""
+    prefix = f"{method}\n{path}\n{timestamp}\n".encode()
+    return prefix + body
+
+
+def sign_request(
+    *,
+    secret: str,
+    method: str,
+    path: str,
+    body: bytes = b"",
+    timestamp: float | None = None,
+) -> dict[str, str]:
+    """Create HMAC-SHA256 signature headers for an outbound request.
+
+    Returns a dict with ``X-Stronghold-Signature`` and ``X-Stronghold-Timestamp``
+    headers suitable for attaching to an HTTP request.
+
+    Args:
+        secret: Shared secret for the target backend.
+        method: HTTP method (e.g. ``"POST"``).
+        path: Request path (e.g. ``"/v1/chat/completions"``).
+        body: Raw request body bytes. Defaults to empty.
+        timestamp: Unix epoch float. Defaults to ``time.time()``.
+
+    Returns:
+        Dict with two header entries.
+    """
+    if timestamp is None:
+        timestamp = time.time()
+
+    payload = _build_payload(method, path, timestamp, body)
+    digest = hmac.new(secret.encode(), payload, hashlib.sha256).hexdigest()
+
+    return {
+        HEADER_SIGNATURE: f"sha256={digest}",
+        HEADER_TIMESTAMP: str(timestamp),
+    }
+
+
+def verify_request(
+    *,
+    secret: str,
+    method: str,
+    path: str,
+    body: bytes = b"",
+    signature_header: str,
+    timestamp_header: str,
+    max_age: float = DEFAULT_MAX_AGE,
+) -> bool:
+    """Verify HMAC-SHA256 signature and timestamp freshness.
+
+    Returns ``True`` when the signature is valid **and** the timestamp is
+    within *max_age* seconds of the current time.
+
+    Raises:
+        ValueError: If the signature is invalid, the timestamp is stale /
+            too far in the future, or the header format is malformed.
+
+    Args:
+        secret: Shared secret for this backend.
+        method: HTTP method used in the original request.
+        path: Request path used in the original request.
+        body: Raw request body bytes. Defaults to empty.
+        signature_header: Value of ``X-Stronghold-Signature`` header.
+        timestamp_header: Value of ``X-Stronghold-Timestamp`` header.
+        max_age: Maximum allowed age in seconds (default 60).
+    """
+    # ── Validate header format ──────────────────────────────────────
+    if not signature_header.startswith("sha256="):
+        msg = "Signature header must start with 'sha256=' prefix"
+        raise ValueError(msg)
+
+    # ── Parse timestamp ─────────────────────────────────────────────
+    try:
+        timestamp = float(timestamp_header)
+    except (ValueError, TypeError) as exc:
+        msg = f"Timestamp header is not a valid number: {timestamp_header!r}"
+        raise ValueError(msg) from exc
+
+    # ── Check freshness ─────────────────────────────────────────────
+    age = abs(time.time() - timestamp)
+    if age > max_age:
+        msg = f"Timestamp is stale: {age:.1f}s old, max allowed is {max_age:.1f}s"
+        raise ValueError(msg)
+
+    # ── Recompute and compare (constant-time) ───────────────────────
+    payload = _build_payload(method, path, timestamp, body)
+    expected = hmac.new(secret.encode(), payload, hashlib.sha256).hexdigest()
+
+    received = signature_header.removeprefix("sha256=")
+    if not hmac.compare_digest(expected, received):
+        msg = "Signature mismatch"
+        raise ValueError(msg)
+
+    return True

--- a/tests/security/test_hmac.py
+++ b/tests/security/test_hmac.py
@@ -1,0 +1,342 @@
+"""Tests for HMAC-SHA256 request signing and verification."""
+
+from __future__ import annotations
+
+import time
+
+import pytest
+
+from stronghold.security.hmac import (
+    DEFAULT_MAX_AGE,
+    HEADER_SIGNATURE,
+    HEADER_TIMESTAMP,
+    sign_request,
+    verify_request,
+)
+
+
+class TestSignAndVerifyRoundTrip:
+    """Sign a request and verify it succeeds."""
+
+    def test_sign_then_verify_succeeds(self) -> None:
+        secret = "test-shared-secret"
+        method = "POST"
+        path = "/v1/chat/completions"
+        body = b'{"message": "hello"}'
+
+        headers = sign_request(
+            secret=secret,
+            method=method,
+            path=path,
+            body=body,
+        )
+        assert verify_request(
+            secret=secret,
+            method=method,
+            path=path,
+            body=body,
+            signature_header=headers[HEADER_SIGNATURE],
+            timestamp_header=headers[HEADER_TIMESTAMP],
+        )
+
+    def test_empty_body_roundtrip(self) -> None:
+        secret = "test-shared-secret"
+        headers = sign_request(secret=secret, method="GET", path="/health")
+        assert verify_request(
+            secret=secret,
+            method="GET",
+            path="/health",
+            body=b"",
+            signature_header=headers[HEADER_SIGNATURE],
+            timestamp_header=headers[HEADER_TIMESTAMP],
+        )
+
+
+class TestTamperedPayload:
+    """Tampered payloads must fail verification."""
+
+    def test_tampered_body_fails(self) -> None:
+        secret = "test-shared-secret"
+        headers = sign_request(
+            secret=secret,
+            method="POST",
+            path="/api",
+            body=b"original",
+        )
+        with pytest.raises(ValueError, match="[Ss]ignature"):
+            verify_request(
+                secret=secret,
+                method="POST",
+                path="/api",
+                body=b"tampered",
+                signature_header=headers[HEADER_SIGNATURE],
+                timestamp_header=headers[HEADER_TIMESTAMP],
+            )
+
+    def test_tampered_path_fails(self) -> None:
+        secret = "test-shared-secret"
+        headers = sign_request(
+            secret=secret,
+            method="POST",
+            path="/api/v1",
+            body=b"data",
+        )
+        with pytest.raises(ValueError, match="[Ss]ignature"):
+            verify_request(
+                secret=secret,
+                method="POST",
+                path="/api/v2",
+                body=b"data",
+                signature_header=headers[HEADER_SIGNATURE],
+                timestamp_header=headers[HEADER_TIMESTAMP],
+            )
+
+    def test_tampered_method_fails(self) -> None:
+        secret = "test-shared-secret"
+        headers = sign_request(
+            secret=secret,
+            method="POST",
+            path="/api",
+            body=b"data",
+        )
+        with pytest.raises(ValueError, match="[Ss]ignature"):
+            verify_request(
+                secret=secret,
+                method="GET",
+                path="/api",
+                body=b"data",
+                signature_header=headers[HEADER_SIGNATURE],
+                timestamp_header=headers[HEADER_TIMESTAMP],
+            )
+
+
+class TestTimestampValidation:
+    """Timestamp freshness checks."""
+
+    def test_expired_timestamp_fails(self) -> None:
+        secret = "test-shared-secret"
+        old_ts = time.time() - 120  # 120 seconds ago, well beyond 60s default
+        headers = sign_request(
+            secret=secret,
+            method="GET",
+            path="/health",
+            timestamp=old_ts,
+        )
+        with pytest.raises(ValueError, match="[Tt]imestamp"):
+            verify_request(
+                secret=secret,
+                method="GET",
+                path="/health",
+                signature_header=headers[HEADER_SIGNATURE],
+                timestamp_header=headers[HEADER_TIMESTAMP],
+            )
+
+    def test_future_timestamp_within_window_succeeds(self) -> None:
+        secret = "test-shared-secret"
+        future_ts = time.time() + 30  # 30 seconds in the future, within 60s window
+        headers = sign_request(
+            secret=secret,
+            method="GET",
+            path="/health",
+            timestamp=future_ts,
+        )
+        assert verify_request(
+            secret=secret,
+            method="GET",
+            path="/health",
+            signature_header=headers[HEADER_SIGNATURE],
+            timestamp_header=headers[HEADER_TIMESTAMP],
+        )
+
+    def test_future_timestamp_beyond_window_fails(self) -> None:
+        secret = "test-shared-secret"
+        future_ts = time.time() + 120  # 120 seconds in the future, beyond 60s window
+        headers = sign_request(
+            secret=secret,
+            method="GET",
+            path="/health",
+            timestamp=future_ts,
+        )
+        with pytest.raises(ValueError, match="[Tt]imestamp"):
+            verify_request(
+                secret=secret,
+                method="GET",
+                path="/health",
+                signature_header=headers[HEADER_SIGNATURE],
+                timestamp_header=headers[HEADER_TIMESTAMP],
+            )
+
+    def test_custom_max_age(self) -> None:
+        secret = "test-shared-secret"
+        old_ts = time.time() - 90  # 90 seconds ago
+        headers = sign_request(
+            secret=secret,
+            method="GET",
+            path="/health",
+            timestamp=old_ts,
+        )
+        # Should fail with default 60s window
+        with pytest.raises(ValueError, match="[Tt]imestamp"):
+            verify_request(
+                secret=secret,
+                method="GET",
+                path="/health",
+                signature_header=headers[HEADER_SIGNATURE],
+                timestamp_header=headers[HEADER_TIMESTAMP],
+                max_age=60,
+            )
+        # Should succeed with 120s window
+        assert verify_request(
+            secret=secret,
+            method="GET",
+            path="/health",
+            signature_header=headers[HEADER_SIGNATURE],
+            timestamp_header=headers[HEADER_TIMESTAMP],
+            max_age=120,
+        )
+
+
+class TestWrongSecret:
+    """Wrong secret must fail verification."""
+
+    def test_wrong_secret_fails(self) -> None:
+        headers = sign_request(
+            secret="secret-one",
+            method="POST",
+            path="/api",
+            body=b"data",
+        )
+        with pytest.raises(ValueError, match="[Ss]ignature"):
+            verify_request(
+                secret="secret-two",
+                method="POST",
+                path="/api",
+                body=b"data",
+                signature_header=headers[HEADER_SIGNATURE],
+                timestamp_header=headers[HEADER_TIMESTAMP],
+            )
+
+
+class TestMalformedHeaders:
+    """Malformed signature headers raise ValueError."""
+
+    def test_missing_sha256_prefix(self) -> None:
+        headers = sign_request(
+            secret="test-secret",
+            method="GET",
+            path="/health",
+        )
+        # Strip the "sha256=" prefix
+        raw_hex = headers[HEADER_SIGNATURE].removeprefix("sha256=")
+        with pytest.raises(ValueError, match="sha256="):
+            verify_request(
+                secret="test-secret",
+                method="GET",
+                path="/health",
+                signature_header=raw_hex,
+                timestamp_header=headers[HEADER_TIMESTAMP],
+            )
+
+    def test_empty_signature_header(self) -> None:
+        headers = sign_request(
+            secret="test-secret",
+            method="GET",
+            path="/health",
+        )
+        with pytest.raises(ValueError):
+            verify_request(
+                secret="test-secret",
+                method="GET",
+                path="/health",
+                signature_header="",
+                timestamp_header=headers[HEADER_TIMESTAMP],
+            )
+
+    def test_non_numeric_timestamp(self) -> None:
+        headers = sign_request(
+            secret="test-secret",
+            method="GET",
+            path="/health",
+        )
+        with pytest.raises(ValueError, match="[Tt]imestamp"):
+            verify_request(
+                secret="test-secret",
+                method="GET",
+                path="/health",
+                signature_header=headers[HEADER_SIGNATURE],
+                timestamp_header="not-a-number",
+            )
+
+
+class TestSignRequestOutput:
+    """sign_request returns correct header keys and format."""
+
+    def test_returns_correct_header_keys(self) -> None:
+        headers = sign_request(
+            secret="test-secret",
+            method="GET",
+            path="/health",
+        )
+        assert HEADER_SIGNATURE in headers
+        assert HEADER_TIMESTAMP in headers
+        assert len(headers) == 2
+
+    def test_signature_has_sha256_prefix(self) -> None:
+        headers = sign_request(
+            secret="test-secret",
+            method="GET",
+            path="/health",
+        )
+        assert headers[HEADER_SIGNATURE].startswith("sha256=")
+
+    def test_timestamp_is_numeric(self) -> None:
+        headers = sign_request(
+            secret="test-secret",
+            method="GET",
+            path="/health",
+        )
+        float(headers[HEADER_TIMESTAMP])  # Should not raise
+
+    def test_explicit_timestamp_used(self) -> None:
+        headers = sign_request(
+            secret="test-secret",
+            method="GET",
+            path="/health",
+            timestamp=1234567890.0,
+        )
+        assert headers[HEADER_TIMESTAMP] == "1234567890.0"
+
+    def test_signature_is_hex_string(self) -> None:
+        headers = sign_request(
+            secret="test-secret",
+            method="GET",
+            path="/health",
+        )
+        hex_part = headers[HEADER_SIGNATURE].removeprefix("sha256=")
+        # SHA-256 hex digest is 64 characters
+        assert len(hex_part) == 64
+        int(hex_part, 16)  # Should not raise — valid hex
+
+
+class TestConstantTimeComparison:
+    """Verify uses hmac.compare_digest for constant-time comparison."""
+
+    def test_verification_uses_constant_time_comparison(self) -> None:
+        """We verify this by checking the module uses hmac.compare_digest.
+
+        Since we can't easily test timing properties in a unit test,
+        we inspect the source to ensure compare_digest is used.
+        """
+        import inspect
+
+        from stronghold.security import hmac as hmac_mod
+
+        source = inspect.getsource(hmac_mod.verify_request)
+        assert "compare_digest" in source
+
+
+class TestDefaultMaxAge:
+    """DEFAULT_MAX_AGE constant is 60 seconds."""
+
+    def test_default_max_age_value(self) -> None:
+        assert DEFAULT_MAX_AGE == 60


### PR DESCRIPTION
## Summary
- Add `sign_request()` and `verify_request()` functions for HMAC-SHA256 request signing
- Constant-time comparison via `hmac.compare_digest()` prevents timing attacks
- Timestamp nonce with configurable max age (default 60s) prevents replay attacks

## Linked Issue
Closes #133

## Changes
- `src/stronghold/security/hmac.py` — signing/verification module (131 lines, stdlib only)
- `tests/security/test_hmac.py` — 20 tests covering roundtrip, tampering, expiry, malformed headers

## Quality Gate
- [x] pytest — 20/20 new tests pass, full suite clean
- [x] ruff check — clean
- [x] ruff format — clean
- [x] mypy --strict — clean

## Acceptance Criteria Status
- [x] All outbound tool calls signable with HMAC-SHA256
- [x] Timestamp nonce prevents replay (60s window)
- [x] Per-backend shared secrets supported (secret param per call)
- [x] Inbound verification available as function (middleware integration in follow-up)

## Notes for Reviewer
Pure utility module — no integration into request pipeline yet. That comes when tool executor and middleware are wired (follow-up work). Zero external dependencies, stdlib only.