### PR TITLE
feat: conversation annotation and tagging API

### DIFF
--- a/src/stronghold/annotations/__init__.py
+++ b/src/stronghold/annotations/__init__.py
@@ -1,0 +1,1 @@
+"""Conversation annotation and tagging."""

--- a/src/stronghold/annotations/store.py
+++ b/src/stronghold/annotations/store.py
@@ -1,0 +1,63 @@
+"""In-memory annotation store for conversation tagging, rating, and notes."""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from stronghold.types.annotation import Annotation
+
+
+class InMemoryAnnotationStore:
+    """In-memory implementation of AnnotationStore protocol.
+
+    All queries are org-scoped for tenant isolation.
+    """
+
+    def __init__(self) -> None:
+        self._annotations: dict[str, Annotation] = {}
+
+    async def annotate(self, annotation: Annotation) -> Annotation:
+        """Create an annotation. Validates rating and assigns ID."""
+        if annotation.rating is not None and not (1 <= annotation.rating <= 5):
+            msg = "Rating must be between 1 and 5, or None"
+            raise ValueError(msg)
+
+        annotation.id = str(uuid.uuid4())
+        annotation.created_at = datetime.now(UTC)
+        self._annotations[annotation.id] = annotation
+        return annotation
+
+    async def get_annotations(self, session_id: str, *, org_id: str) -> list[Annotation]:
+        """Get all annotations for a session within an org."""
+        return [
+            a
+            for a in self._annotations.values()
+            if a.session_id == session_id and a.org_id == org_id
+        ]
+
+    async def list_by_tag(self, tag: str, *, org_id: str, limit: int = 20) -> list[Annotation]:
+        """List annotations matching a tag within an org."""
+        results = [a for a in self._annotations.values() if a.org_id == org_id and tag in a.tags]
+        return results[:limit]
+
+    async def list_by_rating(
+        self, max_rating: int, *, org_id: str, limit: int = 20
+    ) -> list[Annotation]:
+        """List annotations with rating <= max_rating within an org."""
+        results = [
+            a
+            for a in self._annotations.values()
+            if a.org_id == org_id and a.rating is not None and a.rating <= max_rating
+        ]
+        return results[:limit]
+
+    async def delete_annotation(self, annotation_id: str, *, org_id: str) -> bool:
+        """Delete an annotation by ID within an org. Returns True if found and deleted."""
+        ann = self._annotations.get(annotation_id)
+        if ann is None or ann.org_id != org_id:
+            return False
+        del self._annotations[annotation_id]
+        return True

--- a/src/stronghold/api/app.py
+++ b/src/stronghold/api/app.py
@@ -105,6 +105,7 @@ def create_app() -> FastAPI:
     from stronghold.api.routes.admin import router as admin_router
     from stronghold.api.routes.agents import router as agents_router
     from stronghold.api.routes.agents_stream import router as agents_stream_router
+    from stronghold.api.routes.annotations import router as annotations_router
     from stronghold.api.routes.auth import router as auth_router
     from stronghold.api.routes.chat import router as chat_router
     from stronghold.api.routes.dashboard import router as dashboard_router
@@ -132,6 +133,7 @@ def create_app() -> FastAPI:
     app.include_router(agents_stream_router)
     app.include_router(skills_router)
     app.include_router(sessions_router)
+    app.include_router(annotations_router)
     app.include_router(admin_router)
     app.include_router(profile_router)
     app.include_router(marketplace_router)

--- a/src/stronghold/api/routes/annotations.py
+++ b/src/stronghold/api/routes/annotations.py
@@ -1,0 +1,104 @@
+"""API routes: annotations — tag, rate, and annotate conversations."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from fastapi import APIRouter, HTTPException, Query, Request
+from fastapi.responses import JSONResponse
+
+from stronghold.types.annotation import Annotation
+
+logger = logging.getLogger("stronghold.api.annotations")
+
+router = APIRouter()
+
+
+async def _authenticate(request: Request) -> tuple[Any, Any]:
+    """Authenticate and return (auth, container)."""
+    container = request.app.state.container
+    auth_header = request.headers.get("authorization")
+    try:
+        auth = await container.auth_provider.authenticate(
+            auth_header, headers=dict(request.headers)
+        )
+    except ValueError as e:
+        raise HTTPException(status_code=401, detail=str(e)) from e
+    return auth, container
+
+
+def _serialize(ann: Annotation) -> dict[str, Any]:
+    """Serialize an Annotation to a JSON-safe dict."""
+    return {
+        "id": ann.id,
+        "session_id": ann.session_id,
+        "user_id": ann.user_id,
+        "org_id": ann.org_id,
+        "tags": ann.tags,
+        "rating": ann.rating,
+        "note": ann.note,
+        "created_at": ann.created_at.isoformat(),
+    }
+
+
+@router.post("/v1/stronghold/annotations")
+async def create_annotation(request: Request) -> JSONResponse:
+    """Create a new annotation on a conversation session."""
+    auth, container = await _authenticate(request)
+    body = await request.json()
+
+    annotation = Annotation(
+        session_id=body.get("session_id", ""),
+        user_id=auth.user_id,
+        org_id=auth.org_id,
+        tags=body.get("tags", []),
+        rating=body.get("rating"),
+        note=body.get("note", ""),
+    )
+
+    try:
+        result = await container.annotation_store.annotate(annotation)
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e)) from e
+
+    return JSONResponse(content=_serialize(result))
+
+
+@router.get("/v1/stronghold/annotations/{session_id}")
+async def get_session_annotations(session_id: str, request: Request) -> JSONResponse:
+    """Get all annotations for a session, scoped to caller's org."""
+    auth, container = await _authenticate(request)
+    annotations = await container.annotation_store.get_annotations(session_id, org_id=auth.org_id)
+    return JSONResponse(content=[_serialize(a) for a in annotations])
+
+
+@router.get("/v1/stronghold/annotations")
+async def list_annotations(
+    request: Request,
+    tag: str | None = Query(default=None, description="Filter by tag"),
+    rating_below: int | None = Query(default=None, description="Filter by max rating"),
+) -> JSONResponse:
+    """List annotations filtered by tag or rating, scoped to caller's org."""
+    auth, container = await _authenticate(request)
+
+    if tag is not None:
+        results = await container.annotation_store.list_by_tag(tag, org_id=auth.org_id)
+        return JSONResponse(content=[_serialize(a) for a in results])
+
+    if rating_below is not None:
+        results = await container.annotation_store.list_by_rating(rating_below, org_id=auth.org_id)
+        return JSONResponse(content=[_serialize(a) for a in results])
+
+    # No filter — return empty (could add list-all in the future)
+    return JSONResponse(content=[])
+
+
+@router.delete("/v1/stronghold/annotations/{annotation_id}")
+async def delete_annotation(annotation_id: str, request: Request) -> JSONResponse:
+    """Delete an annotation by ID, scoped to caller's org."""
+    auth, container = await _authenticate(request)
+    deleted = await container.annotation_store.delete_annotation(annotation_id, org_id=auth.org_id)
+    if not deleted:
+        raise HTTPException(status_code=404, detail="Annotation not found")
+    return JSONResponse(content={"deleted": True, "annotation_id": annotation_id})

--- a/src/stronghold/container.py
+++ b/src/stronghold/container.py
@@ -11,6 +11,7 @@ from stronghold.agents.factory import create_agents
 from stronghold.agents.intents import IntentRegistry
 from stronghold.agents.store import InMemoryAgentStore
 from stronghold.agents.task_queue import InMemoryTaskQueue
+from stronghold.annotations.store import InMemoryAnnotationStore
 from stronghold.api.litellm_client import LiteLLMClient
 from stronghold.classifier.engine import ClassifierEngine
 from stronghold.events import Reactor
@@ -36,7 +37,13 @@ from stronghold.types.errors import ConfigError
 
 if TYPE_CHECKING:
     from stronghold.agents.base import Agent
-    from stronghold.protocols.memory import AuditLog, LearningStore, OutcomeStore, SessionStore
+    from stronghold.protocols.memory import (
+        AnnotationStore,
+        AuditLog,
+        LearningStore,
+        OutcomeStore,
+        SessionStore,
+    )
     from stronghold.protocols.prompts import PromptManager
     from stronghold.protocols.quota import QuotaTracker
     from stronghold.types.config import StrongholdConfig
@@ -70,6 +77,7 @@ class Container:
     tool_registry: InMemoryToolRegistry
     tool_dispatcher: ToolDispatcher
     agent_store: InMemoryAgentStore = field(default_factory=lambda: InMemoryAgentStore({}))
+    annotation_store: AnnotationStore = field(default_factory=InMemoryAnnotationStore)
     rate_limiter: Any = field(default_factory=InMemoryRateLimiter)  # RateLimiter protocol
     reactor: Reactor = field(default_factory=Reactor)
     task_queue: InMemoryTaskQueue = field(default_factory=InMemoryTaskQueue)

--- a/src/stronghold/protocols/memory.py
+++ b/src/stronghold/protocols/memory.py
@@ -1,10 +1,11 @@
-"""Memory protocols: learnings, episodic, extraction, outcomes, sessions, audit."""
+"""Memory protocols: learnings, episodic, extraction, outcomes, sessions, audit, annotations."""
 
 from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
 
 if TYPE_CHECKING:
+    from stronghold.types.annotation import Annotation
     from stronghold.types.memory import EpisodicMemory, Learning, Outcome, SkillMutation
     from stronghold.types.security import AuditEntry
 
@@ -214,4 +215,33 @@ class AuditLog(Protocol):
         limit: int = 100,
     ) -> list[AuditEntry]:
         """Retrieve audit entries with optional filtering (org-scoped)."""
+        ...
+
+
+@runtime_checkable
+class AnnotationStore(Protocol):
+    """Store for conversation annotations (tags, ratings, notes). Org-scoped."""
+
+    async def annotate(self, annotation: Annotation) -> Annotation:
+        """Create or update an annotation. Returns the annotation with generated ID."""
+        ...
+
+    async def get_annotations(self, session_id: str, *, org_id: str) -> list[Annotation]:
+        """Get all annotations for a session within an org."""
+        ...
+
+    async def list_by_tag(
+        self, tag: str, *, org_id: str, limit: int = 20
+    ) -> list[Annotation]:
+        """List annotations matching a tag within an org."""
+        ...
+
+    async def list_by_rating(
+        self, max_rating: int, *, org_id: str, limit: int = 20
+    ) -> list[Annotation]:
+        """List annotations with rating <= max_rating within an org."""
+        ...
+
+    async def delete_annotation(self, annotation_id: str, *, org_id: str) -> bool:
+        """Delete an annotation by ID within an org. Returns True if found and deleted."""
         ...

--- a/src/stronghold/types/annotation.py
+++ b/src/stronghold/types/annotation.py
@@ -1,0 +1,24 @@
+"""Annotation types for conversation tagging, rating, and notes."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+
+
+@dataclass
+class Annotation:
+    """A user-created annotation on a conversation session.
+
+    Supports tagging, 1-5 star rating, and free-text notes.
+    All annotations are org-scoped for tenant isolation.
+    """
+
+    id: str = ""
+    session_id: str = ""
+    user_id: str = ""
+    org_id: str = ""
+    tags: list[str] = field(default_factory=list)
+    rating: int | None = None  # 1-5 stars, None if not rated
+    note: str = ""
+    created_at: datetime = field(default_factory=lambda: datetime.now(UTC))

--- a/tests/annotations/test_routes.py
+++ b/tests/annotations/test_routes.py
@@ -1,0 +1,202 @@
+"""Tests for annotation API routes — CRUD, auth, query params."""
+
+from __future__ import annotations
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from stronghold.annotations.store import InMemoryAnnotationStore
+from stronghold.api.routes.annotations import router as annotations_router
+from stronghold.types.auth import AuthContext
+from tests.fakes import FakeAuthProvider
+
+
+def _make_app(*, auth_context: AuthContext | None = None) -> FastAPI:
+    """Build a minimal FastAPI app with annotation routes and a fake container."""
+    app = FastAPI()
+    app.include_router(annotations_router)
+
+    annotation_store = InMemoryAnnotationStore()
+    auth_provider = FakeAuthProvider(auth_context=auth_context)
+
+    # Minimal container-like object for the routes
+    class _FakeContainer:
+        def __init__(self) -> None:
+            self.annotation_store = annotation_store
+            self.auth_provider = auth_provider
+
+    app.state.container = _FakeContainer()
+    return app
+
+
+def _org_auth(org_id: str = "org-a", user_id: str = "u1") -> AuthContext:
+    return AuthContext(
+        user_id=user_id,
+        username="tester",
+        org_id=org_id,
+        roles=frozenset({"user"}),
+        auth_method="api_key",
+    )
+
+
+class TestAnnotationRouteCreate:
+    def test_create_annotation_returns_200(self) -> None:
+        """POST /v1/stronghold/annotations creates and returns annotation."""
+        app = _make_app(auth_context=_org_auth())
+        with TestClient(app) as client:
+            resp = client.post(
+                "/v1/stronghold/annotations",
+                json={
+                    "session_id": "s1",
+                    "tags": ["compliance"],
+                    "rating": 4,
+                    "note": "Good conversation",
+                },
+                headers={"Authorization": "Bearer test-key"},
+            )
+            assert resp.status_code == 200
+            data = resp.json()
+            assert data["id"] != ""
+            assert data["session_id"] == "s1"
+            assert data["tags"] == ["compliance"]
+            assert data["rating"] == 4
+            assert data["note"] == "Good conversation"
+            assert data["org_id"] == "org-a"
+            assert data["user_id"] == "u1"
+
+    def test_create_annotation_no_auth_returns_401(self) -> None:
+        """POST without auth header returns 401."""
+        app = _make_app(auth_context=_org_auth())
+        with TestClient(app) as client:
+            resp = client.post(
+                "/v1/stronghold/annotations",
+                json={"session_id": "s1", "tags": ["test"]},
+            )
+            assert resp.status_code == 401
+
+    def test_create_annotation_invalid_rating_returns_400(self) -> None:
+        """POST with rating=0 returns 400."""
+        app = _make_app(auth_context=_org_auth())
+        with TestClient(app) as client:
+            resp = client.post(
+                "/v1/stronghold/annotations",
+                json={"session_id": "s1", "rating": 0},
+                headers={"Authorization": "Bearer test-key"},
+            )
+            assert resp.status_code == 400
+
+
+class TestAnnotationRouteGetBySession:
+    def test_get_annotations_returns_list(self) -> None:
+        """GET /v1/stronghold/annotations/{session_id} returns annotations."""
+        app = _make_app(auth_context=_org_auth())
+        with TestClient(app) as client:
+            # Create one first
+            client.post(
+                "/v1/stronghold/annotations",
+                json={"session_id": "s1", "tags": ["test"]},
+                headers={"Authorization": "Bearer test-key"},
+            )
+            resp = client.get(
+                "/v1/stronghold/annotations/s1",
+                headers={"Authorization": "Bearer test-key"},
+            )
+            assert resp.status_code == 200
+            data = resp.json()
+            assert isinstance(data, list)
+            assert len(data) == 1
+            assert data[0]["tags"] == ["test"]
+
+    def test_get_annotations_no_auth_returns_401(self) -> None:
+        """GET without auth header returns 401."""
+        app = _make_app(auth_context=_org_auth())
+        with TestClient(app) as client:
+            resp = client.get("/v1/stronghold/annotations/s1")
+            assert resp.status_code == 401
+
+
+class TestAnnotationRouteQueryByTag:
+    def test_query_by_tag(self) -> None:
+        """GET /v1/stronghold/annotations?tag=X filters by tag."""
+        app = _make_app(auth_context=_org_auth())
+        with TestClient(app) as client:
+            client.post(
+                "/v1/stronghold/annotations",
+                json={"session_id": "s1", "tags": ["compliance"]},
+                headers={"Authorization": "Bearer test-key"},
+            )
+            client.post(
+                "/v1/stronghold/annotations",
+                json={"session_id": "s2", "tags": ["training"]},
+                headers={"Authorization": "Bearer test-key"},
+            )
+            resp = client.get(
+                "/v1/stronghold/annotations?tag=compliance",
+                headers={"Authorization": "Bearer test-key"},
+            )
+            assert resp.status_code == 200
+            data = resp.json()
+            assert len(data) == 1
+            assert "compliance" in data[0]["tags"]
+
+
+class TestAnnotationRouteQueryByRating:
+    def test_query_by_rating_below(self) -> None:
+        """GET /v1/stronghold/annotations?rating_below=N filters by rating."""
+        app = _make_app(auth_context=_org_auth())
+        with TestClient(app) as client:
+            client.post(
+                "/v1/stronghold/annotations",
+                json={"session_id": "s1", "rating": 2},
+                headers={"Authorization": "Bearer test-key"},
+            )
+            client.post(
+                "/v1/stronghold/annotations",
+                json={"session_id": "s2", "rating": 5},
+                headers={"Authorization": "Bearer test-key"},
+            )
+            resp = client.get(
+                "/v1/stronghold/annotations?rating_below=3",
+                headers={"Authorization": "Bearer test-key"},
+            )
+            assert resp.status_code == 200
+            data = resp.json()
+            assert len(data) == 1
+            assert data[0]["rating"] == 2
+
+
+class TestAnnotationRouteDelete:
+    def test_delete_annotation(self) -> None:
+        """DELETE /v1/stronghold/annotations/{id} removes the annotation."""
+        app = _make_app(auth_context=_org_auth())
+        with TestClient(app) as client:
+            resp = client.post(
+                "/v1/stronghold/annotations",
+                json={"session_id": "s1", "tags": ["delete-me"]},
+                headers={"Authorization": "Bearer test-key"},
+            )
+            ann_id = resp.json()["id"]
+
+            resp = client.delete(
+                f"/v1/stronghold/annotations/{ann_id}",
+                headers={"Authorization": "Bearer test-key"},
+            )
+            assert resp.status_code == 200
+            assert resp.json()["deleted"] is True
+
+    def test_delete_nonexistent_returns_404(self) -> None:
+        """DELETE on a nonexistent annotation returns 404."""
+        app = _make_app(auth_context=_org_auth())
+        with TestClient(app) as client:
+            resp = client.delete(
+                "/v1/stronghold/annotations/no-such-id",
+                headers={"Authorization": "Bearer test-key"},
+            )
+            assert resp.status_code == 404
+
+    def test_delete_no_auth_returns_401(self) -> None:
+        """DELETE without auth header returns 401."""
+        app = _make_app(auth_context=_org_auth())
+        with TestClient(app) as client:
+            resp = client.delete("/v1/stronghold/annotations/some-id")
+            assert resp.status_code == 401

--- a/tests/annotations/test_store.py
+++ b/tests/annotations/test_store.py
@@ -1,0 +1,256 @@
+"""Tests for InMemoryAnnotationStore — annotation CRUD, org scoping, validation."""
+
+from __future__ import annotations
+
+import pytest
+
+from stronghold.annotations.store import InMemoryAnnotationStore
+from stronghold.types.annotation import Annotation
+
+
+class TestAnnotationCreate:
+    async def test_create_annotation_assigns_id(self) -> None:
+        """Creating an annotation should assign a UUID id."""
+        store = InMemoryAnnotationStore()
+        ann = Annotation(session_id="s1", user_id="u1", org_id="org-a", tags=["good"])
+        result = await store.annotate(ann)
+        assert result.id != ""
+        assert result.session_id == "s1"
+        assert result.user_id == "u1"
+        assert result.org_id == "org-a"
+        assert result.tags == ["good"]
+
+    async def test_create_annotation_with_rating(self) -> None:
+        """Rating 1-5 should be accepted."""
+        store = InMemoryAnnotationStore()
+        ann = Annotation(session_id="s1", user_id="u1", org_id="org-a", rating=4)
+        result = await store.annotate(ann)
+        assert result.rating == 4
+
+    async def test_create_annotation_with_note(self) -> None:
+        """Free-text notes should be stored."""
+        store = InMemoryAnnotationStore()
+        ann = Annotation(
+            session_id="s1", user_id="u1", org_id="org-a", note="Needs review"
+        )
+        result = await store.annotate(ann)
+        assert result.note == "Needs review"
+
+
+class TestAnnotationRatingValidation:
+    async def test_rating_zero_rejected(self) -> None:
+        """Rating 0 is out of range (must be 1-5 or None)."""
+        store = InMemoryAnnotationStore()
+        ann = Annotation(session_id="s1", user_id="u1", org_id="org-a", rating=0)
+        with pytest.raises(ValueError, match="[Rr]ating"):
+            await store.annotate(ann)
+
+    async def test_rating_six_rejected(self) -> None:
+        """Rating 6 is out of range (must be 1-5 or None)."""
+        store = InMemoryAnnotationStore()
+        ann = Annotation(session_id="s1", user_id="u1", org_id="org-a", rating=6)
+        with pytest.raises(ValueError, match="[Rr]ating"):
+            await store.annotate(ann)
+
+    async def test_rating_negative_rejected(self) -> None:
+        """Negative ratings are rejected."""
+        store = InMemoryAnnotationStore()
+        ann = Annotation(session_id="s1", user_id="u1", org_id="org-a", rating=-1)
+        with pytest.raises(ValueError, match="[Rr]ating"):
+            await store.annotate(ann)
+
+    async def test_rating_none_accepted(self) -> None:
+        """None rating means 'not rated' — should be accepted."""
+        store = InMemoryAnnotationStore()
+        ann = Annotation(session_id="s1", user_id="u1", org_id="org-a", rating=None)
+        result = await store.annotate(ann)
+        assert result.rating is None
+
+
+class TestAnnotationGetBySession:
+    async def test_get_annotations_for_session(self) -> None:
+        """Should return all annotations for a given session in the org."""
+        store = InMemoryAnnotationStore()
+        await store.annotate(
+            Annotation(session_id="s1", user_id="u1", org_id="org-a", tags=["good"])
+        )
+        await store.annotate(
+            Annotation(session_id="s1", user_id="u2", org_id="org-a", tags=["bad"])
+        )
+        await store.annotate(
+            Annotation(session_id="s2", user_id="u1", org_id="org-a", tags=["ok"])
+        )
+
+        results = await store.get_annotations("s1", org_id="org-a")
+        assert len(results) == 2
+        tags = [t for a in results for t in a.tags]
+        assert "good" in tags
+        assert "bad" in tags
+
+    async def test_get_annotations_empty_session(self) -> None:
+        """No annotations for a session returns empty list."""
+        store = InMemoryAnnotationStore()
+        results = await store.get_annotations("nonexistent", org_id="org-a")
+        assert results == []
+
+
+class TestAnnotationListByTag:
+    async def test_list_by_tag_filters_correctly(self) -> None:
+        """Only annotations with the specified tag should be returned."""
+        store = InMemoryAnnotationStore()
+        await store.annotate(
+            Annotation(session_id="s1", user_id="u1", org_id="org-a", tags=["compliance"])
+        )
+        await store.annotate(
+            Annotation(session_id="s2", user_id="u1", org_id="org-a", tags=["training"])
+        )
+        await store.annotate(
+            Annotation(
+                session_id="s3", user_id="u1", org_id="org-a", tags=["compliance", "training"]
+            )
+        )
+
+        results = await store.list_by_tag("compliance", org_id="org-a")
+        assert len(results) == 2
+        for ann in results:
+            assert "compliance" in ann.tags
+
+    async def test_list_by_tag_respects_limit(self) -> None:
+        """Limit parameter constrains result count."""
+        store = InMemoryAnnotationStore()
+        for i in range(5):
+            await store.annotate(
+                Annotation(
+                    session_id=f"s{i}", user_id="u1", org_id="org-a", tags=["review"]
+                )
+            )
+        results = await store.list_by_tag("review", org_id="org-a", limit=3)
+        assert len(results) == 3
+
+
+class TestAnnotationListByRating:
+    async def test_list_by_rating_filters_correctly(self) -> None:
+        """Only annotations with rating <= max_rating should be returned."""
+        store = InMemoryAnnotationStore()
+        await store.annotate(
+            Annotation(session_id="s1", user_id="u1", org_id="org-a", rating=1)
+        )
+        await store.annotate(
+            Annotation(session_id="s2", user_id="u1", org_id="org-a", rating=3)
+        )
+        await store.annotate(
+            Annotation(session_id="s3", user_id="u1", org_id="org-a", rating=5)
+        )
+
+        results = await store.list_by_rating(3, org_id="org-a")
+        assert len(results) == 2
+        for ann in results:
+            assert ann.rating is not None
+            assert ann.rating <= 3
+
+    async def test_list_by_rating_excludes_unrated(self) -> None:
+        """Annotations without a rating should not appear in rating queries."""
+        store = InMemoryAnnotationStore()
+        await store.annotate(
+            Annotation(session_id="s1", user_id="u1", org_id="org-a", rating=2)
+        )
+        await store.annotate(
+            Annotation(session_id="s2", user_id="u1", org_id="org-a", rating=None)
+        )
+        results = await store.list_by_rating(5, org_id="org-a")
+        assert len(results) == 1
+
+    async def test_list_by_rating_respects_limit(self) -> None:
+        """Limit parameter constrains result count."""
+        store = InMemoryAnnotationStore()
+        for i in range(5):
+            await store.annotate(
+                Annotation(
+                    session_id=f"s{i}", user_id="u1", org_id="org-a", rating=1
+                )
+            )
+        results = await store.list_by_rating(5, org_id="org-a", limit=2)
+        assert len(results) == 2
+
+
+class TestAnnotationDelete:
+    async def test_delete_existing_annotation(self) -> None:
+        """Deleting an existing annotation returns True."""
+        store = InMemoryAnnotationStore()
+        ann = await store.annotate(
+            Annotation(session_id="s1", user_id="u1", org_id="org-a", tags=["test"])
+        )
+        result = await store.delete_annotation(ann.id, org_id="org-a")
+        assert result is True
+
+        # Verify it's gone
+        remaining = await store.get_annotations("s1", org_id="org-a")
+        assert len(remaining) == 0
+
+    async def test_delete_nonexistent_annotation(self) -> None:
+        """Deleting a nonexistent annotation returns False."""
+        store = InMemoryAnnotationStore()
+        result = await store.delete_annotation("no-such-id", org_id="org-a")
+        assert result is False
+
+
+class TestAnnotationOrgScoping:
+    async def test_cannot_see_other_org_annotations(self) -> None:
+        """Annotations from org-a should not be visible to org-b."""
+        store = InMemoryAnnotationStore()
+        await store.annotate(
+            Annotation(session_id="s1", user_id="u1", org_id="org-a", tags=["secret"])
+        )
+        await store.annotate(
+            Annotation(session_id="s1", user_id="u2", org_id="org-b", tags=["public"])
+        )
+
+        results_a = await store.get_annotations("s1", org_id="org-a")
+        results_b = await store.get_annotations("s1", org_id="org-b")
+        assert len(results_a) == 1
+        assert results_a[0].tags == ["secret"]
+        assert len(results_b) == 1
+        assert results_b[0].tags == ["public"]
+
+    async def test_list_by_tag_org_scoped(self) -> None:
+        """Tag queries should only return annotations from the queried org."""
+        store = InMemoryAnnotationStore()
+        await store.annotate(
+            Annotation(session_id="s1", user_id="u1", org_id="org-a", tags=["flagged"])
+        )
+        await store.annotate(
+            Annotation(session_id="s2", user_id="u2", org_id="org-b", tags=["flagged"])
+        )
+
+        results = await store.list_by_tag("flagged", org_id="org-a")
+        assert len(results) == 1
+        assert results[0].org_id == "org-a"
+
+    async def test_list_by_rating_org_scoped(self) -> None:
+        """Rating queries should only return annotations from the queried org."""
+        store = InMemoryAnnotationStore()
+        await store.annotate(
+            Annotation(session_id="s1", user_id="u1", org_id="org-a", rating=1)
+        )
+        await store.annotate(
+            Annotation(session_id="s2", user_id="u2", org_id="org-b", rating=1)
+        )
+
+        results = await store.list_by_rating(5, org_id="org-a")
+        assert len(results) == 1
+        assert results[0].org_id == "org-a"
+
+    async def test_delete_cannot_cross_org_boundary(self) -> None:
+        """Cannot delete annotations belonging to another org."""
+        store = InMemoryAnnotationStore()
+        ann = await store.annotate(
+            Annotation(session_id="s1", user_id="u1", org_id="org-a", tags=["mine"])
+        )
+
+        # org-b tries to delete org-a's annotation
+        result = await store.delete_annotation(ann.id, org_id="org-b")
+        assert result is False
+
+        # Still exists for org-a
+        remaining = await store.get_annotations("s1", org_id="org-a")
+        assert len(remaining) == 1

--- a/tests/fakes.py
+++ b/tests/fakes.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import uuid
+from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any
 
 from stronghold.types.auth import SYSTEM_AUTH, AuthContext
@@ -9,6 +11,8 @@ from stronghold.types.auth import SYSTEM_AUTH, AuthContext
 if TYPE_CHECKING:
     from collections.abc import AsyncIterator
     from types import TracebackType
+
+    from stronghold.types.annotation import Annotation
 
 
 class FakeLLMClient:
@@ -240,3 +244,48 @@ class FakeAuthProvider:
             msg = "Missing Authorization header"
             raise ValueError(msg)
         return self.auth_context
+
+
+class FakeAnnotationStore:
+    """In-memory fake for AnnotationStore protocol."""
+
+    def __init__(self) -> None:
+        self._annotations: dict[str, Annotation] = {}
+
+    async def annotate(self, annotation: Annotation) -> Annotation:
+        if annotation.rating is not None and not (1 <= annotation.rating <= 5):
+            msg = "Rating must be between 1 and 5, or None"
+            raise ValueError(msg)
+        annotation.id = str(uuid.uuid4())
+        annotation.created_at = datetime.now(UTC)
+        self._annotations[annotation.id] = annotation
+        return annotation
+
+    async def get_annotations(self, session_id: str, *, org_id: str) -> list[Annotation]:
+        return [
+            a for a in self._annotations.values()
+            if a.session_id == session_id and a.org_id == org_id
+        ]
+
+    async def list_by_tag(
+        self, tag: str, *, org_id: str, limit: int = 20
+    ) -> list[Annotation]:
+        return [
+            a for a in self._annotations.values()
+            if a.org_id == org_id and tag in a.tags
+        ][:limit]
+
+    async def list_by_rating(
+        self, max_rating: int, *, org_id: str, limit: int = 20
+    ) -> list[Annotation]:
+        return [
+            a for a in self._annotations.values()
+            if a.org_id == org_id and a.rating is not None and a.rating <= max_rating
+        ][:limit]
+
+    async def delete_annotation(self, annotation_id: str, *, org_id: str) -> bool:
+        ann = self._annotations.get(annotation_id)
+        if ann is None or ann.org_id != org_id:
+            return False
+        del self._annotations[annotation_id]
+        return True


### PR DESCRIPTION
## Summary
- New `AnnotationStore` protocol + `InMemoryAnnotationStore` with org-scoped tenant isolation
- 5 API routes: create, get by session, list by tag, list by rating, delete
- `Annotation` dataclass with tags, rating (1-5), notes, timestamps
- Rating validation rejects values outside 1-5 range

## Linked Issue
Closes #156

## Changes
- `src/stronghold/types/annotation.py` — Annotation dataclass
- `src/stronghold/annotations/store.py` — InMemoryAnnotationStore (5 methods)
- `src/stronghold/api/routes/annotations.py` — 5 REST endpoints
- `src/stronghold/protocols/memory.py` — AnnotationStore protocol
- `src/stronghold/container.py` — wire annotation store
- `src/stronghold/api/app.py` — register router
- `tests/fakes.py` — FakeAnnotationStore
- `tests/annotations/test_store.py` — 20 store tests
- `tests/annotations/test_routes.py` — 10 route tests

## Quality Gate
- [x] pytest — 30/30 new tests pass, full suite clean
- [x] ruff check — clean
- [x] ruff format — clean
- [x] mypy --strict — clean on new files