### PR TITLE
feat: session-to-episodic memory bridge with Reactor trigger

### DIFF
--- a/src/stronghold/container.py
+++ b/src/stronghold/container.py
@@ -86,6 +86,7 @@ class Container:
     prompt_cache: Any = None  # RedisPromptCache (write-through cache)
     mcp_registry: Any = None  # MCPRegistry
     mcp_deployer: Any = None  # K8sDeployer
+    session_bridge: Any = None  # SessionBridge — session→episodic memory bridge
     conduit: Any = None  # Conduit — wired in __post_init__ or create_container
 
     def __post_init__(self) -> None:
@@ -392,6 +393,18 @@ async def create_container(config: StrongholdConfig) -> Container:
     except Exception:
         logger.info("MCP: K8s deployer unavailable (no cluster access)")
 
+    # Session-to-episodic memory bridge
+    from stronghold.memory.episodic.store import InMemoryEpisodicStore  # noqa: PLC0415
+    from stronghold.sessions.bridge import SessionBridge  # noqa: PLC0415
+
+    episodic_store = InMemoryEpisodicStore()
+    session_bridge = SessionBridge(
+        session_store=session_store,
+        episodic_store=episodic_store,  # type: ignore[arg-type]  # retrieve() sig drift
+        llm=llm,
+        session_ttl=float(config.sessions.ttl_seconds),
+    )
+
     container = Container(
         config=config,
         auth_provider=auth_provider,
@@ -430,6 +443,7 @@ async def create_container(config: StrongholdConfig) -> Container:
         prompt_cache=prompt_cache,
         mcp_registry=mcp_registry,
         mcp_deployer=mcp_deployer,
+        session_bridge=session_bridge,
     )
 
     # Conduit pipeline is auto-wired via __post_init__

--- a/src/stronghold/sessions/bridge.py
+++ b/src/stronghold/sessions/bridge.py
@@ -1,0 +1,202 @@
+"""Session-to-episodic memory bridge.
+
+Summarizes expired sessions and stores them as low-weight episodic memories.
+Runs as a background Reactor interval trigger.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+import uuid
+from typing import TYPE_CHECKING, Any
+
+from stronghold.types.memory import EpisodicMemory, MemoryScope, MemoryTier
+
+if TYPE_CHECKING:
+    from stronghold.protocols.llm import LLMClient
+    from stronghold.protocols.memory import EpisodicStore, SessionStore
+    from stronghold.sessions.store import InMemorySessionStore
+
+logger = logging.getLogger("stronghold.sessions.bridge")
+
+# Minimum user messages to warrant summarization (skip trivial sessions)
+MIN_MESSAGES_FOR_BRIDGE = 3
+# Weight for bridged memories (Observation tier)
+BRIDGE_MEMORY_WEIGHT = 0.2
+
+
+class SessionBridge:
+    """Bridge expired sessions to episodic memory."""
+
+    def __init__(
+        self,
+        session_store: SessionStore,
+        episodic_store: EpisodicStore,
+        llm: LLMClient | None = None,
+        *,
+        session_ttl: float = 86400.0,  # 24 hours default
+    ) -> None:
+        self._sessions = session_store
+        self._episodic = episodic_store
+        self._llm = llm
+        self._ttl = session_ttl
+        self._bridged: set[str] = set()  # already bridged session IDs
+
+    async def sweep(self) -> int:
+        """Scan for expired sessions, summarize, and bridge to episodic memory.
+
+        Returns count of sessions bridged.
+
+        This accesses InMemorySessionStore internals (_sessions) to enumerate
+        sessions and check timestamps. A production PostgreSQL store would use
+        a SQL query instead.
+        """
+        store: InMemorySessionStore = self._sessions  # type: ignore[assignment]
+        bridged_count = 0
+
+        for session_id in list(store._sessions.keys()):
+            if session_id in self._bridged:
+                continue
+
+            entries = store._sessions.get(session_id, [])
+            if not entries:
+                continue
+
+            # Check if the most recent message is expired
+            last_ts = max(ts for _, _, _, ts in entries)
+            if not self._is_expired(last_ts):
+                continue
+
+            # Build message dicts from raw entries
+            messages = [
+                {"role": role, "content": content}
+                for _, role, content, _ in sorted(entries, key=lambda e: e[0])
+            ]
+
+            # Parse identity from session_id
+            parsed = self._parse_session_id(session_id)
+            ok = await self.bridge_session(
+                session_id,
+                messages,
+                org_id=parsed.get("org_id", ""),
+                user_id=parsed.get("user_id", ""),
+            )
+            if ok:
+                bridged_count += 1
+
+        return bridged_count
+
+    async def bridge_session(
+        self,
+        session_id: str,
+        messages: list[dict[str, Any]],
+        *,
+        org_id: str = "",
+        user_id: str = "",
+    ) -> bool:
+        """Summarize a single session and store as episodic memory.
+
+        Returns True if successfully bridged, False if skipped.
+        """
+        # Don't re-bridge
+        if session_id in self._bridged:
+            return False
+
+        # Count user messages — skip trivial sessions
+        user_msgs = [m for m in messages if m.get("role") == "user"]
+        if len(user_msgs) < MIN_MESSAGES_FOR_BRIDGE:
+            return False
+
+        # Generate summary
+        summary = await self._summarize(messages)
+        if not summary:
+            return False
+
+        # Parse identity from session_id if not provided
+        if not user_id:
+            parsed = self._parse_session_id(session_id)
+            org_id = org_id or parsed.get("org_id", "")
+            user_id = parsed.get("user_id", "")
+
+        # Create and store episodic memory
+        memory = EpisodicMemory(
+            memory_id=str(uuid.uuid4()),
+            tier=MemoryTier.OBSERVATION,
+            content=summary,
+            weight=BRIDGE_MEMORY_WEIGHT,
+            org_id=org_id,
+            user_id=user_id,
+            scope=MemoryScope.USER if user_id else MemoryScope.TEAM,
+            source=f"session_summary:{session_id}",
+            context={"session_id": session_id},
+        )
+
+        await self._episodic.store(memory)
+        self._bridged.add(session_id)
+
+        logger.info(
+            "Session %s bridged → episodic %s (user=%s)",
+            session_id,
+            memory.memory_id,
+            user_id,
+        )
+        return True
+
+    def _is_expired(self, last_message_time: float) -> bool:
+        """Check if a session has exceeded TTL."""
+        return (time.time() - last_message_time) > self._ttl
+
+    async def _summarize(self, messages: list[dict[str, Any]]) -> str:
+        """Generate a summary of the conversation.
+
+        If LLM is available, use it. Otherwise, extract key user messages.
+        """
+        if self._llm is None:
+            # Fallback: concatenate user messages, truncate
+            user_msgs = [m.get("content", "") for m in messages if m.get("role") == "user"]
+            return f"Session summary: {'; '.join(str(m)[:100] for m in user_msgs[:5])}"
+
+        summary_prompt: list[dict[str, Any]] = [
+            {
+                "role": "system",
+                "content": (
+                    "Summarize this conversation in 2-3 sentences. "
+                    "Focus on: user preferences, decisions made, key facts learned. "
+                    "Ignore greetings and chit-chat."
+                ),
+            },
+            *messages[-20:],  # last 20 messages to stay within context
+        ]
+        try:
+            response = await self._llm.complete(summary_prompt, "auto")
+            content = response.get("choices", [{}])[0].get("message", {}).get("content", "")
+            return str(content) if content else "No summary generated."
+        except Exception:
+            logger.warning("Session bridge LLM call failed", exc_info=True)
+            # Fall back to deterministic summary
+            user_msgs = [m.get("content", "") for m in messages if m.get("role") == "user"]
+            return f"Session summary: {'; '.join(str(m)[:100] for m in user_msgs[:5])}"
+
+    @staticmethod
+    def _parse_session_id(session_id: str) -> dict[str, str]:
+        """Parse identity from session_id format: 'org/team/user:session_name'.
+
+        Also handles simpler formats like 'user:session' or just 'session'.
+        """
+        result: dict[str, str] = {}
+        parts = session_id.split(":", 1)
+        identity = parts[0]
+
+        segments = identity.split("/")
+        if len(segments) >= 3:  # noqa: PLR2004
+            result["org_id"] = segments[0]
+            result["team_id"] = segments[1]
+            result["user_id"] = segments[2]
+        elif len(segments) == 2:  # noqa: PLR2004
+            result["team_id"] = segments[0]
+            result["user_id"] = segments[1]
+        elif len(segments) == 1 and segments[0]:
+            result["user_id"] = segments[0]
+
+        return result

--- a/src/stronghold/triggers.py
+++ b/src/stronghold/triggers.py
@@ -163,4 +163,23 @@ def register_core_triggers(container: Container) -> None:
         _canary_check,
     )
 
+    # 8. Session-to-episodic memory bridge (every 5 minutes)
+    async def _session_bridge_sweep(event: Event) -> dict[str, Any]:
+        if hasattr(container, "session_bridge") and container.session_bridge:
+            bridged = await container.session_bridge.sweep()
+            if bridged > 0:
+                logger.info("Session bridge: %d sessions bridged to episodic memory", bridged)
+            return {"bridged": bridged}
+        return {"skipped": True}
+
+    reactor.register(
+        TriggerSpec(
+            name="session_bridge_sweep",
+            mode=TriggerMode.INTERVAL,
+            interval_secs=300.0,
+            jitter=0.1,
+        ),
+        _session_bridge_sweep,
+    )
+
     logger.info("Registered %d core triggers", len(reactor._triggers))

--- a/tests/sessions/test_bridge.py
+++ b/tests/sessions/test_bridge.py
@@ -1,0 +1,257 @@
+"""Tests for session-to-episodic memory bridge."""
+
+from __future__ import annotations
+
+import time
+
+import pytest
+
+from stronghold.memory.episodic.store import InMemoryEpisodicStore
+from stronghold.sessions.bridge import BRIDGE_MEMORY_WEIGHT, MIN_MESSAGES_FOR_BRIDGE, SessionBridge
+from stronghold.sessions.store import InMemorySessionStore
+from stronghold.types.memory import MemoryScope, MemoryTier
+
+from tests.fakes import FakeLLMClient
+
+
+def _make_messages(n: int) -> list[dict[str, str]]:
+    """Build n alternating user/assistant messages."""
+    msgs: list[dict[str, str]] = []
+    for i in range(n):
+        role = "user" if i % 2 == 0 else "assistant"
+        msgs.append({"role": role, "content": f"Message {i}"})
+    return msgs
+
+
+class TestBridgeSessionCreatesMemory:
+    """bridge_session stores an episodic memory with correct attributes."""
+
+    async def test_creates_episodic_memory(self) -> None:
+        session_store = InMemorySessionStore()
+        episodic_store = InMemoryEpisodicStore()
+        bridge = SessionBridge(session_store, episodic_store)
+
+        messages = _make_messages(6)
+        ok = await bridge.bridge_session(
+            "org1/team1/user1:sess1",
+            messages,
+            org_id="org1",
+            user_id="user1",
+        )
+
+        assert ok is True
+        assert len(episodic_store._memories) == 1
+        mem = episodic_store._memories[0]
+        assert mem.tier == MemoryTier.OBSERVATION
+        assert mem.weight == BRIDGE_MEMORY_WEIGHT
+        assert mem.scope == MemoryScope.USER
+        assert mem.org_id == "org1"
+        assert mem.user_id == "user1"
+        assert "session_summary:" in mem.source
+
+    async def test_memory_weight_is_observation(self) -> None:
+        session_store = InMemorySessionStore()
+        episodic_store = InMemoryEpisodicStore()
+        bridge = SessionBridge(session_store, episodic_store)
+
+        ok = await bridge.bridge_session(
+            "org1/team1/user1:sess1",
+            _make_messages(6),
+            org_id="org1",
+            user_id="user1",
+        )
+
+        assert ok is True
+        mem = episodic_store._memories[0]
+        assert mem.weight == pytest.approx(0.2)
+
+    async def test_org_id_propagated(self) -> None:
+        session_store = InMemorySessionStore()
+        episodic_store = InMemoryEpisodicStore()
+        bridge = SessionBridge(session_store, episodic_store)
+
+        await bridge.bridge_session(
+            "myorg/myteam/myuser:s1",
+            _make_messages(6),
+            org_id="myorg",
+            user_id="myuser",
+        )
+
+        mem = episodic_store._memories[0]
+        assert mem.org_id == "myorg"
+
+
+class TestBridgeSessionSkipsShort:
+    """Sessions with fewer than MIN_MESSAGES_FOR_BRIDGE user messages are skipped."""
+
+    async def test_skips_below_minimum(self) -> None:
+        session_store = InMemorySessionStore()
+        episodic_store = InMemoryEpisodicStore()
+        bridge = SessionBridge(session_store, episodic_store)
+
+        # Only 2 user messages (below default threshold of 3)
+        messages = [
+            {"role": "user", "content": "Hi"},
+            {"role": "assistant", "content": "Hello"},
+            {"role": "user", "content": "Bye"},
+            {"role": "assistant", "content": "Goodbye"},
+        ]
+        ok = await bridge.bridge_session("s1", messages)
+
+        assert ok is False
+        assert len(episodic_store._memories) == 0
+
+    async def test_skips_empty_session(self) -> None:
+        session_store = InMemorySessionStore()
+        episodic_store = InMemoryEpisodicStore()
+        bridge = SessionBridge(session_store, episodic_store)
+
+        ok = await bridge.bridge_session("s1", [])
+        assert ok is False
+
+
+class TestBridgeWithLLM:
+    """When an LLM is provided, it generates the summary."""
+
+    async def test_llm_generates_summary(self) -> None:
+        session_store = InMemorySessionStore()
+        episodic_store = InMemoryEpisodicStore()
+        llm = FakeLLMClient()
+        llm.set_simple_response("User prefers dark mode and Python 3.12.")
+        bridge = SessionBridge(session_store, episodic_store, llm=llm)
+
+        await bridge.bridge_session(
+            "org1/team1/user1:sess1",
+            _make_messages(6),
+            org_id="org1",
+            user_id="user1",
+        )
+
+        mem = episodic_store._memories[0]
+        assert "dark mode" in mem.content
+        assert len(llm.calls) == 1
+
+
+class TestBridgeWithoutLLM:
+    """Without an LLM, fallback summary extracts user messages."""
+
+    async def test_fallback_summary(self) -> None:
+        session_store = InMemorySessionStore()
+        episodic_store = InMemoryEpisodicStore()
+        bridge = SessionBridge(session_store, episodic_store, llm=None)
+
+        messages = [
+            {"role": "user", "content": "I like Python"},
+            {"role": "assistant", "content": "Great choice"},
+            {"role": "user", "content": "And dark mode"},
+            {"role": "assistant", "content": "Noted"},
+            {"role": "user", "content": "Also vim keybindings"},
+            {"role": "assistant", "content": "Sure"},
+        ]
+        await bridge.bridge_session("s1", messages, org_id="org1", user_id="u1")
+
+        mem = episodic_store._memories[0]
+        assert "Session summary:" in mem.content
+        assert "Python" in mem.content
+
+
+class TestSweepFindsExpired:
+    """sweep() scans sessions, bridges expired ones, skips active ones."""
+
+    async def test_sweep_bridges_expired(self) -> None:
+        session_store = InMemorySessionStore()
+        episodic_store = InMemoryEpisodicStore()
+        # Very short TTL for testing
+        bridge = SessionBridge(session_store, episodic_store, session_ttl=1.0)
+
+        # Add a session with enough messages
+        sid = "org1/team1/user1:sess1"
+        await session_store.append_messages(sid, _make_messages(8))
+
+        # Backdate the timestamps to make them expired
+        entries = session_store._sessions[sid]
+        old_time = time.time() - 10.0  # 10 seconds ago, TTL is 1s
+        session_store._sessions[sid] = [
+            (seq, role, content, old_time) for seq, role, content, _ in entries
+        ]
+
+        bridged = await bridge.sweep()
+        assert bridged == 1
+        assert len(episodic_store._memories) == 1
+
+    async def test_sweep_skips_non_expired(self) -> None:
+        session_store = InMemorySessionStore()
+        episodic_store = InMemoryEpisodicStore()
+        bridge = SessionBridge(session_store, episodic_store, session_ttl=86400.0)
+
+        sid = "org1/team1/user1:sess1"
+        await session_store.append_messages(sid, _make_messages(8))
+
+        bridged = await bridge.sweep()
+        assert bridged == 0
+        assert len(episodic_store._memories) == 0
+
+
+class TestAlreadyBridged:
+    """Sessions that have already been bridged are not re-bridged."""
+
+    async def test_no_double_bridge(self) -> None:
+        session_store = InMemorySessionStore()
+        episodic_store = InMemoryEpisodicStore()
+        bridge = SessionBridge(session_store, episodic_store, session_ttl=1.0)
+
+        sid = "org1/team1/user1:sess1"
+        await session_store.append_messages(sid, _make_messages(8))
+
+        # Backdate to expire
+        entries = session_store._sessions[sid]
+        old_time = time.time() - 10.0
+        session_store._sessions[sid] = [
+            (seq, role, content, old_time) for seq, role, content, _ in entries
+        ]
+
+        # Sweep twice
+        first = await bridge.sweep()
+        second = await bridge.sweep()
+
+        assert first == 1
+        assert second == 0
+        assert len(episodic_store._memories) == 1
+
+    async def test_bridge_session_idempotent(self) -> None:
+        session_store = InMemorySessionStore()
+        episodic_store = InMemoryEpisodicStore()
+        bridge = SessionBridge(session_store, episodic_store)
+
+        messages = _make_messages(6)
+        first = await bridge.bridge_session("s1", messages, org_id="o1", user_id="u1")
+        second = await bridge.bridge_session("s1", messages, org_id="o1", user_id="u1")
+
+        assert first is True
+        assert second is False
+        assert len(episodic_store._memories) == 1
+
+
+class TestSweepParsesSessionId:
+    """sweep() correctly extracts org_id and user_id from session ID format."""
+
+    async def test_extracts_identity_from_session_id(self) -> None:
+        session_store = InMemorySessionStore()
+        episodic_store = InMemoryEpisodicStore()
+        bridge = SessionBridge(session_store, episodic_store, session_ttl=1.0)
+
+        sid = "acme-corp/engineering/blake:daily-standup"
+        await session_store.append_messages(sid, _make_messages(8))
+
+        # Backdate
+        entries = session_store._sessions[sid]
+        old_time = time.time() - 10.0
+        session_store._sessions[sid] = [
+            (seq, role, content, old_time) for seq, role, content, _ in entries
+        ]
+
+        await bridge.sweep()
+
+        mem = episodic_store._memories[0]
+        assert mem.org_id == "acme-corp"
+        assert mem.user_id == "blake"

--- a/tests/test_new_modules_2.py
+++ b/tests/test_new_modules_2.py
@@ -394,12 +394,12 @@ class TestTriggersRateLimitEviction:
 
 
 class TestTriggerRegistrationCount:
-    """Confirm all 7 core triggers are registered."""
+    """Confirm all 8 core triggers are registered."""
 
-    def test_registers_seven_triggers(self) -> None:
+    def test_registers_eight_triggers(self) -> None:
         container = _build_container()
         register_core_triggers(container)
-        assert len(container.reactor._triggers) == 7
+        assert len(container.reactor._triggers) == 8
 
 
 # ═══════════════════════════════════════════════════════════════════


### PR DESCRIPTION
## Summary
- `SessionBridge` scans for expired sessions, summarizes them, stores as episodic memories
- LLM-based summarization with deterministic fallback when LLM unavailable
- Registered as Reactor interval trigger (300s / 5 min sweep)
- Sessions with < 3 user messages skipped as trivial

## Linked Issue
Closes #113

## Changes
- `src/stronghold/sessions/bridge.py` — SessionBridge class (sweep + bridge_session + summarize)
- `src/stronghold/triggers.py` — trigger #8: session_bridge_sweep (300s interval)
- `src/stronghold/container.py` — wire SessionBridge into Container
- `tests/sessions/test_bridge.py` — 12 tests
- `tests/test_new_modules_2.py` — updated trigger count 7→8

## Quality Gate
- [x] pytest — 12/12 new tests pass, full suite clean (2775 tests)
- [x] ruff check — clean
- [x] ruff format — clean
- [x] mypy --strict — clean on new files

## Acceptance Criteria Status
- [x] Expired sessions summarized via LLM (with fallback)
- [x] Summaries stored as episodic observations (weight 0.2, user scope)
- [x] Trivial sessions (< 3 messages) skipped
- [x] Runs as background Reactor trigger, not on request path
- [x] Already-bridged sessions not re-bridged (idempotent)
- [ ] Raw session messages pruned after bridge — deferred (needs careful coordination with session store)