### PR TITLE
feat: LiteLLM config overlay to eliminate model duplication

### DIFF
--- a/config/model_overrides.yaml
+++ b/config/model_overrides.yaml
@@ -1,0 +1,18 @@
+# Stronghold model overlay — only Stronghold-specific metadata.
+# Model definitions come from LiteLLM; this file adds quality/tier/strengths/speed.
+model_overrides:
+  mistral-large:
+    quality: 0.68
+    tier: frontier
+    strengths: [code, reasoning]
+    speed: 60
+  cerebras-llama8b:
+    quality: 0.35
+    tier: small
+    strengths: [chat]
+    speed: 2000
+  gemini-2.5-pro:
+    quality: 0.82
+    tier: frontier
+    strengths: [reasoning, code]
+    speed: 80

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ dependencies = [
 dev = [
     "pytest>=8.0.0",
     "pytest-asyncio>=0.24.0",
+    "respx>=0.22.0",
     "ruff>=0.8.0",
     "mypy>=1.13.0",
     "bandit>=1.8.0",

--- a/src/stronghold/config/overlay.py
+++ b/src/stronghold/config/overlay.py
@@ -1,0 +1,158 @@
+"""Model config overlay: fetch from LiteLLM + merge Stronghold metadata.
+
+Instead of duplicating LiteLLM's model list, Stronghold maintains a thin overlay
+with only Stronghold-specific metadata (quality, tier, strengths, speed).
+At startup, fetch LiteLLM's model list and merge the overlay on top.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from typing import Any
+
+import httpx
+
+logger = logging.getLogger("stronghold.config.overlay")
+
+
+@dataclass
+class ModelOverlay:
+    """Stronghold-specific metadata for a model (not in LiteLLM)."""
+
+    quality: float = 0.5
+    tier: str = "medium"
+    strengths: list[str] = field(default_factory=list)
+    speed: float = 100.0
+
+
+def parse_overlay_config(raw: dict[str, Any]) -> dict[str, ModelOverlay]:
+    """Parse model_overrides section from config into ModelOverlay objects.
+
+    Each key is a model name, value is a dict with optional fields:
+    quality, tier, strengths, speed.  Missing fields get dataclass defaults.
+    """
+    result: dict[str, ModelOverlay] = {}
+    for model_name, values in raw.items():
+        if not isinstance(values, dict):
+            logger.warning("Skipping non-dict overlay entry: %s", model_name)
+            continue
+        result[model_name] = ModelOverlay(
+            quality=values.get("quality", 0.5),
+            tier=values.get("tier", "medium"),
+            strengths=values.get("strengths", []),
+            speed=values.get("speed", 100.0),
+        )
+    return result
+
+
+async def fetch_litellm_models(litellm_url: str, api_key: str) -> list[dict[str, Any]]:
+    """Fetch model list from LiteLLM's /model/info endpoint.
+
+    Returns list of model info dicts.  Returns empty list on failure
+    (graceful degradation — the system falls back to existing config).
+    """
+    url = f"{litellm_url.rstrip('/')}/model/info"
+    headers = {
+        "Authorization": f"Bearer {api_key}",
+        "Content-Type": "application/json",
+    }
+    try:
+        async with httpx.AsyncClient(timeout=30.0) as client:
+            resp = await client.get(url, headers=headers)
+
+        if resp.status_code != 200:  # noqa: PLR2004
+            logger.warning(
+                "LiteLLM /model/info returned %d — falling back to existing config",
+                resp.status_code,
+            )
+            return []
+
+        data = resp.json()
+        models: list[dict[str, Any]] = data.get("data", [])
+        if not isinstance(models, list):
+            logger.warning("LiteLLM /model/info 'data' is not a list — ignoring")
+            return []
+        return models
+
+    except httpx.ConnectError:
+        logger.warning("Cannot connect to LiteLLM at %s — falling back to existing config", url)
+        return []
+    except Exception:
+        logger.exception("Unexpected error fetching LiteLLM models")
+        return []
+
+
+def _extract_litellm_id(model_info: dict[str, Any]) -> str:
+    """Extract the litellm_id from a LiteLLM model info dict.
+
+    Tries litellm_params.model first, then model_info.id.
+    """
+    litellm_params = model_info.get("litellm_params", {})
+    if isinstance(litellm_params, dict) and "model" in litellm_params:
+        return str(litellm_params["model"])
+    info = model_info.get("model_info", {})
+    if isinstance(info, dict) and "id" in info:
+        return str(info["id"])
+    return ""
+
+
+def _extract_provider(litellm_id: str) -> str:
+    """Extract provider name from a litellm_id like 'openai/gpt-4'."""
+    if "/" in litellm_id:
+        return litellm_id.split("/", 1)[0]
+    return "unknown"
+
+
+def merge_models(
+    litellm_models: list[dict[str, Any]],
+    overlays: dict[str, ModelOverlay],
+    existing_config: dict[str, Any],
+) -> dict[str, Any]:
+    """Merge LiteLLM model list with Stronghold overlays.
+
+    Priority order:
+    1. Models from LiteLLM get overlay metadata if available, defaults otherwise.
+    2. Models in overlay but not in LiteLLM produce a warning (stale overlay).
+    3. Models in existing config but not in LiteLLM are preserved (manual additions).
+
+    Returns merged models dict compatible with StrongholdConfig.models.
+    """
+    result: dict[str, Any] = {}
+    litellm_names: set[str] = set()
+
+    # Phase 1: Process LiteLLM models
+    for model_info in litellm_models:
+        name = model_info.get("model_name", "")
+        if not name:
+            continue
+        litellm_names.add(name)
+
+        litellm_id = _extract_litellm_id(model_info)
+        provider = _extract_provider(litellm_id)
+
+        overlay = overlays.get(name, ModelOverlay())
+        result[name] = {
+            "provider": provider,
+            "litellm_id": litellm_id,
+            "tier": overlay.tier,
+            "quality": overlay.quality,
+            "speed": overlay.speed,
+            "strengths": overlay.strengths,
+            "modality": "text",
+        }
+
+    # Phase 2: Warn about stale overlays
+    for overlay_name in overlays:
+        if overlay_name not in litellm_names:
+            logger.warning(
+                "Model overlay '%s' has no matching LiteLLM model — stale entry?",
+                overlay_name,
+            )
+
+    # Phase 3: Preserve existing config models not in LiteLLM
+    for name, model_data in existing_config.items():
+        if name not in result:
+            result[name] = model_data
+
+    return result

--- a/tests/config/test_overlay.py
+++ b/tests/config/test_overlay.py
@@ -1,0 +1,298 @@
+"""Tests for LiteLLM config overlay: fetch, parse, merge."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import httpx
+import pytest
+import respx
+
+from stronghold.config.overlay import (
+    ModelOverlay,
+    fetch_litellm_models,
+    merge_models,
+    parse_overlay_config,
+)
+
+
+class TestParseOverlayConfig:
+    """parse_overlay_config: YAML dict -> dict[str, ModelOverlay]."""
+
+    def test_parses_all_fields(self) -> None:
+        """All four overlay fields are parsed correctly."""
+        raw: dict[str, Any] = {
+            "mistral-large": {
+                "quality": 0.68,
+                "tier": "frontier",
+                "strengths": ["code", "reasoning"],
+                "speed": 60.0,
+            },
+        }
+        result = parse_overlay_config(raw)
+        assert "mistral-large" in result
+        overlay = result["mistral-large"]
+        assert overlay.quality == 0.68
+        assert overlay.tier == "frontier"
+        assert overlay.strengths == ["code", "reasoning"]
+        assert overlay.speed == 60.0
+
+    def test_missing_fields_get_defaults(self) -> None:
+        """Fields not specified in the overlay get default values."""
+        raw: dict[str, Any] = {
+            "my-model": {"quality": 0.9},
+        }
+        result = parse_overlay_config(raw)
+        overlay = result["my-model"]
+        assert overlay.quality == 0.9
+        assert overlay.tier == "medium"
+        assert overlay.strengths == []
+        assert overlay.speed == 100.0
+
+    def test_multiple_models(self) -> None:
+        """Multiple model entries are all parsed."""
+        raw: dict[str, Any] = {
+            "model-a": {"quality": 0.3, "tier": "small"},
+            "model-b": {"quality": 0.8, "tier": "large"},
+        }
+        result = parse_overlay_config(raw)
+        assert len(result) == 2
+        assert result["model-a"].quality == 0.3
+        assert result["model-b"].quality == 0.8
+
+    def test_empty_dict_returns_empty(self) -> None:
+        """Empty input returns empty dict."""
+        assert parse_overlay_config({}) == {}
+
+
+class TestFetchLiteLLMModels:
+    """fetch_litellm_models: HTTP call to LiteLLM /model/info."""
+
+    @respx.mock
+    async def test_returns_model_list(self) -> None:
+        """Successful response returns the model data list."""
+        model_data = [
+            {
+                "model_name": "mistral-large",
+                "model_info": {"id": "mistral/mistral-large-latest"},
+            },
+            {
+                "model_name": "gemini-flash",
+                "model_info": {"id": "gemini/gemini-2.5-flash"},
+            },
+        ]
+        respx.get("http://litellm:4000/model/info").mock(
+            return_value=httpx.Response(200, json={"data": model_data})
+        )
+
+        result = await fetch_litellm_models("http://litellm:4000", "sk-test-key")
+        assert len(result) == 2
+        assert result[0]["model_name"] == "mistral-large"
+        assert result[1]["model_name"] == "gemini-flash"
+
+    @respx.mock
+    async def test_returns_empty_on_http_error(self) -> None:
+        """HTTP error returns empty list (graceful degradation)."""
+        respx.get("http://litellm:4000/model/info").mock(
+            return_value=httpx.Response(500, text="Internal Server Error")
+        )
+
+        result = await fetch_litellm_models("http://litellm:4000", "sk-test-key")
+        assert result == []
+
+    @respx.mock
+    async def test_returns_empty_on_connection_error(self) -> None:
+        """Connection error returns empty list (graceful degradation)."""
+        respx.get("http://litellm:4000/model/info").mock(
+            side_effect=httpx.ConnectError("Connection refused")
+        )
+
+        result = await fetch_litellm_models("http://litellm:4000", "sk-test-key")
+        assert result == []
+
+    @respx.mock
+    async def test_sends_auth_header(self) -> None:
+        """Request includes Authorization: Bearer header."""
+        route = respx.get("http://litellm:4000/model/info").mock(
+            return_value=httpx.Response(200, json={"data": []})
+        )
+
+        await fetch_litellm_models("http://litellm:4000", "sk-my-key")
+        assert route.called
+        request = route.calls[0].request
+        assert request.headers["Authorization"] == "Bearer sk-my-key"
+
+    @respx.mock
+    async def test_returns_empty_on_missing_data_key(self) -> None:
+        """Response without 'data' key returns empty list."""
+        respx.get("http://litellm:4000/model/info").mock(
+            return_value=httpx.Response(200, json={"models": []})
+        )
+
+        result = await fetch_litellm_models("http://litellm:4000", "sk-test-key")
+        assert result == []
+
+
+class TestMergeModels:
+    """merge_models: combine LiteLLM models + Stronghold overlays."""
+
+    def test_litellm_model_gets_overlay_metadata(self) -> None:
+        """LiteLLM model with matching overlay gets overlay values."""
+        litellm_models: list[dict[str, Any]] = [
+            {
+                "model_name": "mistral-large",
+                "model_info": {"id": "mistral/mistral-large-latest"},
+                "litellm_params": {"model": "mistral/mistral-large-latest"},
+            },
+        ]
+        overlays = {
+            "mistral-large": ModelOverlay(
+                quality=0.85,
+                tier="frontier",
+                strengths=["code", "reasoning"],
+                speed=60.0,
+            ),
+        }
+        existing: dict[str, Any] = {}
+
+        result = merge_models(litellm_models, overlays, existing)
+        assert "mistral-large" in result
+        model = result["mistral-large"]
+        assert model["quality"] == 0.85
+        assert model["tier"] == "frontier"
+        assert model["strengths"] == ["code", "reasoning"]
+        assert model["speed"] == 60.0
+        assert model["litellm_id"] == "mistral/mistral-large-latest"
+
+    def test_litellm_model_without_overlay_gets_defaults(self) -> None:
+        """LiteLLM model without overlay gets default quality/tier/speed."""
+        litellm_models: list[dict[str, Any]] = [
+            {
+                "model_name": "new-model",
+                "model_info": {"id": "provider/new-model"},
+                "litellm_params": {"model": "provider/new-model"},
+            },
+        ]
+        overlays: dict[str, ModelOverlay] = {}
+        existing: dict[str, Any] = {}
+
+        result = merge_models(litellm_models, overlays, existing)
+        assert "new-model" in result
+        model = result["new-model"]
+        assert model["quality"] == 0.5
+        assert model["tier"] == "medium"
+        assert model["strengths"] == []
+        assert model["speed"] == 100.0
+
+    def test_stale_overlay_produces_warning(self, caplog: pytest.LogCaptureFixture) -> None:
+        """Overlay entry not in LiteLLM produces a warning log."""
+        litellm_models: list[dict[str, Any]] = []
+        overlays = {
+            "stale-model": ModelOverlay(quality=0.9, tier="large"),
+        }
+        existing: dict[str, Any] = {}
+
+        with caplog.at_level(logging.WARNING, logger="stronghold.config.overlay"):
+            merge_models(litellm_models, overlays, existing)
+
+        assert any("stale-model" in msg for msg in caplog.messages)
+
+    def test_existing_config_models_preserved(self) -> None:
+        """Models in existing config but not in LiteLLM are preserved."""
+        litellm_models: list[dict[str, Any]] = [
+            {
+                "model_name": "litellm-model",
+                "model_info": {"id": "provider/litellm-model"},
+                "litellm_params": {"model": "provider/litellm-model"},
+            },
+        ]
+        overlays: dict[str, ModelOverlay] = {}
+        existing: dict[str, Any] = {
+            "manual-model": {
+                "provider": "custom",
+                "tier": "small",
+                "quality": 0.3,
+                "speed": 500,
+                "litellm_id": "custom/manual",
+                "strengths": ["chat"],
+            },
+        }
+
+        result = merge_models(litellm_models, overlays, existing)
+        assert "manual-model" in result
+        assert result["manual-model"]["provider"] == "custom"
+        assert "litellm-model" in result
+
+    def test_empty_litellm_falls_back_to_existing(self) -> None:
+        """Empty LiteLLM response preserves all existing config models."""
+        litellm_models: list[dict[str, Any]] = []
+        overlays: dict[str, ModelOverlay] = {}
+        existing: dict[str, Any] = {
+            "existing-a": {
+                "provider": "p",
+                "tier": "small",
+                "quality": 0.4,
+                "speed": 200,
+                "litellm_id": "p/a",
+                "strengths": ["chat"],
+            },
+            "existing-b": {
+                "provider": "p",
+                "tier": "large",
+                "quality": 0.9,
+                "speed": 100,
+                "litellm_id": "p/b",
+                "strengths": ["code"],
+            },
+        }
+
+        result = merge_models(litellm_models, overlays, existing)
+        assert "existing-a" in result
+        assert "existing-b" in result
+        assert len(result) == 2
+
+    def test_litellm_model_overrides_existing_config(self) -> None:
+        """When a model exists in both LiteLLM and existing config, LiteLLM wins."""
+        litellm_models: list[dict[str, Any]] = [
+            {
+                "model_name": "shared-model",
+                "model_info": {"id": "new-provider/shared"},
+                "litellm_params": {"model": "new-provider/shared"},
+            },
+        ]
+        overlays = {
+            "shared-model": ModelOverlay(quality=0.9, tier="frontier"),
+        }
+        existing: dict[str, Any] = {
+            "shared-model": {
+                "provider": "old-provider",
+                "tier": "small",
+                "quality": 0.3,
+                "speed": 500,
+                "litellm_id": "old/shared",
+                "strengths": ["chat"],
+            },
+        }
+
+        result = merge_models(litellm_models, overlays, existing)
+        model = result["shared-model"]
+        # LiteLLM + overlay values take precedence
+        assert model["litellm_id"] == "new-provider/shared"
+        assert model["quality"] == 0.9
+        assert model["tier"] == "frontier"
+
+    def test_provider_extracted_from_litellm_id(self) -> None:
+        """Provider name is extracted from the litellm_id prefix."""
+        litellm_models: list[dict[str, Any]] = [
+            {
+                "model_name": "some-model",
+                "model_info": {"id": "openai/gpt-4"},
+                "litellm_params": {"model": "openai/gpt-4"},
+            },
+        ]
+        overlays: dict[str, ModelOverlay] = {}
+        existing: dict[str, Any] = {}
+
+        result = merge_models(litellm_models, overlays, existing)
+        assert result["some-model"]["provider"] == "openai"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -137,6 +137,7 @@ _HAPPY_FILES = {
     # Config
     "config/test_loader.py",
     "config/test_env_override.py",
+    "config/test_overlay.py",
     # Reactor
     "reactor/test_reactor.py",
     # Tracing


### PR DESCRIPTION
Closes #131. Fetch models from LiteLLM + merge Stronghold overlay (quality/tier/strengths/speed). 16 tests.