### PR TITLE
feat: implement plan-execute reasoning strategy (replaces stub)

### DIFF
--- a/src/stronghold/agents/strategies/plan_execute.py
+++ b/src/stronghold/agents/strategies/plan_execute.py
@@ -1,38 +1,281 @@
-"""Plan-execute strategy: plan → subtasks → execute each → review.
+"""Plan-execute strategy: plan -> subtasks -> execute each -> review.
 
-Stub implementation for demo. Full version uses sub-agents.
+Three-phase reasoning:
+1. Plan: LLM decomposes the request into numbered subtasks.
+2. Execute: Each subtask is sent to the LLM (with optional tool dispatch).
+3. Review: All results are sent for a final summary/review pass.
 """
 
 from __future__ import annotations
 
-from typing import Any
+import json
+import logging
+import re
+from typing import TYPE_CHECKING, Any
 
 from stronghold.types.agent import ReasoningResult
 
+if TYPE_CHECKING:
+    from stronghold.protocols.llm import LLMClient
+
+logger = logging.getLogger("stronghold.strategies.plan_execute")
+
+# Matches lines like "1. Do something", "2) Do something", or "- Do something"
+_SUBTASK_PATTERN = re.compile(r"^\s*(?:\d+[\.\)]\s+|- )\s*(.+)", re.MULTILINE)
+
+
+def _parse_subtasks(plan_text: str) -> list[str]:
+    """Extract subtask descriptions from a plan response.
+
+    Recognises numbered lists (``1. ...``, ``2) ...``) and dash-prefixed
+    lists (``- ...``).  Returns an empty list when the plan contains no
+    recognisable structure so the caller can fall back.
+    """
+    matches = _SUBTASK_PATTERN.findall(plan_text)
+    return [m.strip() for m in matches if m.strip()]
+
+
+def _extract_content(response: dict[str, Any]) -> str:
+    """Pull the assistant text out of an OpenAI-format response."""
+    choices = response.get("choices", [])
+    if not choices:
+        return ""
+    message = choices[0].get("message", {})
+    return message.get("content", "") or ""
+
+
+def _extract_usage(response: dict[str, Any]) -> tuple[int, int]:
+    """Return (prompt_tokens, completion_tokens) from a response."""
+    usage = response.get("usage", {})
+    return usage.get("prompt_tokens", 0), usage.get("completion_tokens", 0)
+
 
 class PlanExecuteStrategy:
-    """Plan then execute. Uses sub-agents for each subtask."""
+    """Plan then execute each subtask, then review.
+
+    Works both with and without tools.  When ``tools`` and
+    ``tool_executor`` are passed via *kwargs* the execute phase will
+    honour tool calls from the LLM, dispatching them through the
+    executor exactly as ReactStrategy does.
+    """
 
     def __init__(self, max_subtasks: int = 10) -> None:
         self.max_subtasks = max_subtasks
+
+    # ------------------------------------------------------------------
+    # Public entry point
+    # ------------------------------------------------------------------
 
     async def reason(
         self,
         messages: list[dict[str, Any]],
         model: str,
-        llm: Any,
+        llm: LLMClient,
         **kwargs: Any,
     ) -> ReasoningResult:
-        """For the demo: delegates planning to LLM, returns plan as response."""
+        """Run the full plan-execute-review pipeline."""
+        total_input = 0
+        total_output = 0
+        tool_history: list[dict[str, Any]] = []
+
+        # ── 1. Plan phase ────────────────────────────────────────────
         plan_prompt = (
             "You are a task planner. Decompose the user's request into "
             f"numbered subtasks (max {self.max_subtasks}). "
             "For each subtask, describe what to do and how to test it."
         )
-        plan_messages = [
+        plan_messages: list[dict[str, Any]] = [
             {"role": "system", "content": plan_prompt},
             *messages,
         ]
-        response = await llm.complete(plan_messages, model)
-        content = response.get("choices", [{}])[0].get("message", {}).get("content", "")
-        return ReasoningResult(response=content, done=True)
+        plan_response = await llm.complete(plan_messages, model)
+        plan_text = _extract_content(plan_response)
+        inp, out = _extract_usage(plan_response)
+        total_input += inp
+        total_output += out
+
+        subtasks = _parse_subtasks(plan_text)
+
+        # Fallback: if no subtasks parsed, return the plan text directly
+        if not subtasks:
+            return ReasoningResult(
+                response=plan_text,
+                done=True,
+                input_tokens=total_input,
+                output_tokens=total_output,
+            )
+
+        # Cap at max_subtasks
+        subtasks = subtasks[: self.max_subtasks]
+
+        # ── 2. Execute phase ─────────────────────────────────────────
+        # Extract original system context (if any) for subtask messages
+        system_context = ""
+        for msg in messages:
+            if msg.get("role") == "system":
+                system_context = str(msg.get("content", ""))
+                break
+
+        # Extract original user request for context
+        user_request = ""
+        for msg in reversed(messages):
+            if msg.get("role") == "user":
+                user_request = str(msg.get("content", ""))
+                break
+
+        subtask_results: list[str] = []
+        tools: list[dict[str, Any]] | None = kwargs.get("tools")
+        tool_executor: Any = kwargs.get("tool_executor")
+
+        for i, subtask in enumerate(subtasks):
+            logger.debug("Executing subtask %d/%d: %s", i + 1, len(subtasks), subtask[:80])
+
+            exec_system = system_context or "You are a helpful assistant."
+            exec_messages: list[dict[str, Any]] = [
+                {"role": "system", "content": exec_system},
+                {
+                    "role": "user",
+                    "content": (
+                        f"Original request: {user_request}\n\n"
+                        f"Subtask {i + 1}/{len(subtasks)}: {subtask}"
+                    ),
+                },
+            ]
+
+            result_text = await self._execute_subtask(
+                exec_messages,
+                model,
+                llm,
+                tools=tools,
+                tool_executor=tool_executor,
+                tool_history=tool_history,
+                usage_accum=(total_input, total_output),
+            )
+            total_input, total_output = self._last_usage
+            subtask_results.append(result_text)
+
+        # ── 3. Review phase ──────────────────────────────────────────
+        results_block = "\n\n".join(
+            f"Subtask {i + 1} ({subtasks[i]}): {r}" for i, r in enumerate(subtask_results)
+        )
+        review_messages: list[dict[str, Any]] = [
+            {
+                "role": "system",
+                "content": (
+                    "You are reviewing the results of a multi-step plan. "
+                    "Summarise the outcomes, note anything missed or needing "
+                    "correction, and provide a final consolidated answer."
+                ),
+            },
+            {
+                "role": "user",
+                "content": (
+                    f"Original request: {user_request}\n\n"
+                    f"Subtask results:\n{results_block}\n\n"
+                    "Please provide a final summary."
+                ),
+            },
+        ]
+        review_response = await llm.complete(review_messages, model)
+        review_text = _extract_content(review_response)
+        inp, out = _extract_usage(review_response)
+        total_input += inp
+        total_output += out
+
+        return ReasoningResult(
+            response=review_text,
+            done=True,
+            tool_history=tool_history,
+            input_tokens=total_input,
+            output_tokens=total_output,
+        )
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    # Mutable accumulator written by _execute_subtask so the caller can
+    # read updated totals without needing to return a tuple.
+    _last_usage: tuple[int, int] = (0, 0)
+
+    async def _execute_subtask(
+        self,
+        messages: list[dict[str, Any]],
+        model: str,
+        llm: LLMClient,
+        *,
+        tools: list[dict[str, Any]] | None,
+        tool_executor: Any,
+        tool_history: list[dict[str, Any]],
+        usage_accum: tuple[int, int],
+    ) -> str:
+        """Execute a single subtask, optionally dispatching tool calls.
+
+        Returns the final assistant text for the subtask.
+        """
+        total_input, total_output = usage_accum
+        current_messages = list(messages)
+        max_tool_rounds = 3  # hard cap on tool-call rounds per subtask
+
+        for round_num in range(max_tool_rounds + 1):
+            response = await llm.complete(
+                current_messages,
+                model,
+                tools=tools,
+                tool_choice="auto" if tools else None,
+            )
+            inp, out = _extract_usage(response)
+            total_input += inp
+            total_output += out
+
+            choices = response.get("choices", [])
+            message = choices[0] if choices else {}
+            msg = message.get("message", {})
+            tool_calls = msg.get("tool_calls")
+            if not isinstance(tool_calls, list):
+                tool_calls = []
+
+            # No tool calls or exhausted rounds -> return text
+            if not tool_calls or round_num >= max_tool_rounds:
+                self._last_usage = (total_input, total_output)
+                return _extract_content(response)
+
+            # Dispatch tool calls
+            current_messages.append(msg)
+            for tc in tool_calls:
+                fn = tc.get("function", {})
+                tool_name = fn.get("name", "")
+                raw_args = fn.get("arguments", "{}")
+
+                try:
+                    tool_args = json.loads(raw_args)
+                except json.JSONDecodeError:
+                    tool_args = {}
+
+                if tool_executor and callable(tool_executor):
+                    tool_result = await tool_executor(tool_name, tool_args)
+                else:
+                    tool_result = f"Tool '{tool_name}' not available"
+
+                tool_result_str = str(tool_result)
+
+                tool_history.append(
+                    {
+                        "tool_name": tool_name,
+                        "arguments": tool_args,
+                        "result": tool_result_str,
+                        "round": round_num,
+                    }
+                )
+
+                current_messages.append(
+                    {
+                        "role": "tool",
+                        "tool_call_id": tc.get("id", ""),
+                        "content": tool_result_str,
+                    }
+                )
+
+        # Shouldn't be reached, but be safe
+        self._last_usage = (total_input, total_output)
+        return ""

--- a/tests/agents/test_plan_execute_strategy.py
+++ b/tests/agents/test_plan_execute_strategy.py
@@ -1,0 +1,361 @@
+"""Tests for PlanExecuteStrategy: plan -> execute subtasks -> review -> combine."""
+
+import json
+
+import pytest
+
+from stronghold.agents.strategies.plan_execute import PlanExecuteStrategy
+from tests.fakes import FakeLLMClient
+
+
+def _make_response(content: str) -> dict:
+    """Build a minimal OpenAI-format chat completion response."""
+    return {
+        "id": "chatcmpl-fake",
+        "object": "chat.completion",
+        "model": "fake-model",
+        "choices": [
+            {
+                "index": 0,
+                "message": {"role": "assistant", "content": content},
+                "finish_reason": "stop",
+            }
+        ],
+        "usage": {"prompt_tokens": 10, "completion_tokens": 20, "total_tokens": 30},
+    }
+
+
+def _make_tool_call_response(tool_name: str, arguments: dict) -> dict:
+    """Build a response with a tool call."""
+    return {
+        "id": "chatcmpl-fake",
+        "choices": [
+            {
+                "index": 0,
+                "message": {
+                    "role": "assistant",
+                    "content": None,
+                    "tool_calls": [
+                        {
+                            "id": "tc_1",
+                            "function": {
+                                "name": tool_name,
+                                "arguments": json.dumps(arguments),
+                            },
+                        }
+                    ],
+                },
+                "finish_reason": "tool_calls",
+            }
+        ],
+        "usage": {"prompt_tokens": 10, "completion_tokens": 20, "total_tokens": 30},
+    }
+
+
+class TestPlanPhase:
+    """Plan phase: LLM decomposes request into numbered subtasks."""
+
+    async def test_plan_produces_subtasks_from_numbered_list(self) -> None:
+        """LLM returns a numbered list; strategy parses into subtasks."""
+        llm = FakeLLMClient()
+        plan_text = "1. Read the input file\n2. Parse the CSV data\n3. Generate the report"
+        # Plan response, then 3 execute responses, then review response
+        llm.set_responses(
+            _make_response(plan_text),
+            _make_response("Read file done"),
+            _make_response("Parsed CSV done"),
+            _make_response("Report generated"),
+            _make_response("All tasks completed successfully."),
+        )
+        strategy = PlanExecuteStrategy(max_subtasks=10)
+        result = await strategy.reason(
+            [{"role": "user", "content": "process the CSV and generate a report"}],
+            "test-model",
+            llm,
+        )
+        assert result.done is True
+        # Strategy should have made 5 LLM calls: plan + 3 execute + review
+        assert len(llm.calls) == 5
+
+    async def test_plan_parses_dash_prefixed_subtasks(self) -> None:
+        """LLM returns dash-prefixed list items; strategy parses them."""
+        llm = FakeLLMClient()
+        plan_text = "- First thing\n- Second thing"
+        llm.set_responses(
+            _make_response(plan_text),
+            _make_response("First done"),
+            _make_response("Second done"),
+            _make_response("Review: all good"),
+        )
+        strategy = PlanExecuteStrategy(max_subtasks=10)
+        result = await strategy.reason(
+            [{"role": "user", "content": "do two things"}],
+            "test-model",
+            llm,
+        )
+        assert result.done is True
+        # plan + 2 execute + review = 4
+        assert len(llm.calls) == 4
+
+    async def test_plan_prompt_includes_max_subtasks(self) -> None:
+        """The planning system prompt should reference the max_subtasks limit."""
+        llm = FakeLLMClient()
+        llm.set_responses(
+            _make_response("1. Only one step"),
+            _make_response("Step done"),
+            _make_response("Review complete"),
+        )
+        strategy = PlanExecuteStrategy(max_subtasks=7)
+        await strategy.reason(
+            [{"role": "user", "content": "plan something"}],
+            "test-model",
+            llm,
+        )
+        # The first call is the plan call; check system prompt
+        plan_call_msgs = llm.calls[0]["messages"]
+        system_msg = next(m for m in plan_call_msgs if m["role"] == "system")
+        assert "7" in system_msg["content"]
+
+
+class TestMaxSubtasks:
+    """max_subtasks should cap the number of subtasks executed."""
+
+    async def test_caps_at_max_subtasks(self) -> None:
+        """If LLM returns more subtasks than max, only max are executed."""
+        llm = FakeLLMClient()
+        # Plan with 5 steps, but max_subtasks=3
+        plan_text = (
+            "1. Step one\n2. Step two\n3. Step three\n4. Step four\n5. Step five"
+        )
+        llm.set_responses(
+            _make_response(plan_text),
+            _make_response("Done 1"),
+            _make_response("Done 2"),
+            _make_response("Done 3"),
+            _make_response("Review: completed first 3"),
+        )
+        strategy = PlanExecuteStrategy(max_subtasks=3)
+        result = await strategy.reason(
+            [{"role": "user", "content": "do five things"}],
+            "test-model",
+            llm,
+        )
+        assert result.done is True
+        # plan + 3 execute (capped) + review = 5
+        assert len(llm.calls) == 5
+
+
+class TestExecutePhase:
+    """Execute phase: each subtask is sent to LLM individually."""
+
+    async def test_subtask_messages_include_original_context(self) -> None:
+        """Each subtask execution should include original system context."""
+        llm = FakeLLMClient()
+        plan_text = "1. Do the thing"
+        llm.set_responses(
+            _make_response(plan_text),
+            _make_response("Thing done"),
+            _make_response("Review ok"),
+        )
+        strategy = PlanExecuteStrategy(max_subtasks=10)
+        original_msgs = [
+            {"role": "system", "content": "You are a helpful assistant"},
+            {"role": "user", "content": "do the thing"},
+        ]
+        await strategy.reason(original_msgs, "test-model", llm)
+
+        # The execute call (index 1) should contain system context + subtask
+        execute_msgs = llm.calls[1]["messages"]
+        # Should have a system message with original context
+        system_msgs = [m for m in execute_msgs if m["role"] == "system"]
+        assert len(system_msgs) >= 1
+        # Should reference the subtask
+        user_msgs = [m for m in execute_msgs if m["role"] == "user"]
+        assert any("Do the thing" in m["content"] for m in user_msgs)
+
+
+class TestReviewPhase:
+    """Review phase: all subtask results sent to LLM for final review."""
+
+    async def test_review_includes_all_subtask_results(self) -> None:
+        """Review call should include original request and all subtask results."""
+        llm = FakeLLMClient()
+        plan_text = "1. Alpha\n2. Beta"
+        llm.set_responses(
+            _make_response(plan_text),
+            _make_response("Alpha result"),
+            _make_response("Beta result"),
+            _make_response("Final review: everything looks good"),
+        )
+        strategy = PlanExecuteStrategy(max_subtasks=10)
+        result = await strategy.reason(
+            [{"role": "user", "content": "do alpha and beta"}],
+            "test-model",
+            llm,
+        )
+        # The review call is the last one (index 3)
+        review_msgs = llm.calls[3]["messages"]
+        # Review messages should mention subtask results
+        review_text = " ".join(m.get("content", "") for m in review_msgs)
+        assert "Alpha result" in review_text
+        assert "Beta result" in review_text
+
+    async def test_final_response_is_review_output(self) -> None:
+        """The strategy result should be the review phase output."""
+        llm = FakeLLMClient()
+        plan_text = "1. Step one"
+        llm.set_responses(
+            _make_response(plan_text),
+            _make_response("Step one done"),
+            _make_response("Final summary: all completed."),
+        )
+        strategy = PlanExecuteStrategy(max_subtasks=10)
+        result = await strategy.reason(
+            [{"role": "user", "content": "do it"}],
+            "test-model",
+            llm,
+        )
+        assert result.response == "Final summary: all completed."
+
+
+class TestFallbackBehavior:
+    """When plan has no parseable subtasks, return plan text directly."""
+
+    async def test_no_parseable_subtasks_returns_plan_directly(self) -> None:
+        """If the plan response has no numbered/dashed items, return it as-is."""
+        llm = FakeLLMClient()
+        # A plan response with no numbered or dashed items
+        plan_text = "I can help you with that directly. The answer is 42."
+        llm.set_responses(_make_response(plan_text))
+        strategy = PlanExecuteStrategy(max_subtasks=10)
+        result = await strategy.reason(
+            [{"role": "user", "content": "what is the meaning of life?"}],
+            "test-model",
+            llm,
+        )
+        assert result.response == plan_text
+        assert result.done is True
+        # Only the plan call was made, no execute or review
+        assert len(llm.calls) == 1
+
+
+class TestToolCallsInExecute:
+    """Execute phase should handle tool calls when tools are provided."""
+
+    async def test_tool_calls_executed_during_subtask(self) -> None:
+        """When a subtask triggers a tool call, it should be executed."""
+        llm = FakeLLMClient()
+        plan_text = "1. Read the file"
+        tool_call_resp = _make_tool_call_response("read_file", {"path": "data.csv"})
+        llm.set_responses(
+            _make_response(plan_text),
+            # Execute subtask 1: LLM requests tool call, then gets result, then responds
+            tool_call_resp,
+            _make_response("File contents processed"),
+            # Review
+            _make_response("Review: file was read successfully"),
+        )
+
+        tool_calls_made: list[tuple[str, dict]] = []
+
+        async def tool_executor(name: str, args: dict) -> str:
+            tool_calls_made.append((name, args))
+            return "col1,col2\n1,2\n3,4"
+
+        tools = [
+            {
+                "type": "function",
+                "function": {
+                    "name": "read_file",
+                    "description": "Read a file",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {"path": {"type": "string"}},
+                    },
+                },
+            }
+        ]
+
+        strategy = PlanExecuteStrategy(max_subtasks=10)
+        result = await strategy.reason(
+            [{"role": "user", "content": "read and process data.csv"}],
+            "test-model",
+            llm,
+            tools=tools,
+            tool_executor=tool_executor,
+        )
+        assert result.done is True
+        assert len(tool_calls_made) == 1
+        assert tool_calls_made[0][0] == "read_file"
+        assert tool_calls_made[0][1] == {"path": "data.csv"}
+
+
+class TestEdgeCases:
+    """Edge cases and boundary conditions."""
+
+    async def test_empty_messages_returns_empty_result(self) -> None:
+        """Empty message list should produce an empty-ish result."""
+        llm = FakeLLMClient()
+        llm.set_responses(_make_response(""))
+        strategy = PlanExecuteStrategy()
+        result = await strategy.reason([], "test-model", llm)
+        assert result.done is True
+
+    async def test_reasoning_result_done_is_true_on_completion(self) -> None:
+        """ReasoningResult.done should be True when strategy completes."""
+        llm = FakeLLMClient()
+        plan_text = "1. One step"
+        llm.set_responses(
+            _make_response(plan_text),
+            _make_response("Step done"),
+            _make_response("Review done"),
+        )
+        strategy = PlanExecuteStrategy(max_subtasks=10)
+        result = await strategy.reason(
+            [{"role": "user", "content": "simple task"}],
+            "test-model",
+            llm,
+        )
+        assert result.done is True
+
+    async def test_token_tracking(self) -> None:
+        """Input/output tokens should be accumulated across all phases."""
+        llm = FakeLLMClient()
+        plan_text = "1. Step A"
+        llm.set_responses(
+            _make_response(plan_text),
+            _make_response("A done"),
+            _make_response("Review done"),
+        )
+        strategy = PlanExecuteStrategy(max_subtasks=10)
+        result = await strategy.reason(
+            [{"role": "user", "content": "count tokens"}],
+            "test-model",
+            llm,
+        )
+        # 3 calls x 10 prompt_tokens = 30, 3 calls x 20 completion_tokens = 60
+        assert result.input_tokens == 30
+        assert result.output_tokens == 60
+
+    async def test_default_max_subtasks_is_10(self) -> None:
+        """Default max_subtasks should be 10."""
+        strategy = PlanExecuteStrategy()
+        assert strategy.max_subtasks == 10
+
+    async def test_model_forwarded_to_all_llm_calls(self) -> None:
+        """The model parameter should be passed to every LLM call."""
+        llm = FakeLLMClient()
+        plan_text = "1. Single step"
+        llm.set_responses(
+            _make_response(plan_text),
+            _make_response("Done"),
+            _make_response("Review"),
+        )
+        strategy = PlanExecuteStrategy(max_subtasks=10)
+        await strategy.reason(
+            [{"role": "user", "content": "task"}],
+            "my-special-model",
+            llm,
+        )
+        for call in llm.calls:
+            assert call["model"] == "my-special-model"

--- a/tests/agents/test_strategies.py
+++ b/tests/agents/test_strategies.py
@@ -317,20 +317,53 @@ class TestDelegateStrategy:
 
 
 class TestPlanExecuteStrategy:
-    """PlanExecuteStrategy (Artificer): generates a plan."""
+    """PlanExecuteStrategy (Artificer): plan -> execute -> review."""
 
     @pytest.mark.asyncio
-    async def test_generates_plan(self) -> None:
+    async def test_generates_plan_and_executes(self) -> None:
         llm = FakeLLMClient()
-        llm.set_simple_response("1. Parse input\n2. Process\n3. Output")
+        # Plan returns 3 subtasks -> execute each -> review
+        plan_resp = {
+            "id": "fake",
+            "choices": [
+                {
+                    "message": {
+                        "role": "assistant",
+                        "content": "1. Parse input\n2. Process\n3. Output",
+                    },
+                    "finish_reason": "stop",
+                }
+            ],
+            "usage": {"prompt_tokens": 10, "completion_tokens": 20, "total_tokens": 30},
+        }
+        exec_resp = {
+            "id": "fake",
+            "choices": [
+                {"message": {"role": "assistant", "content": "Done"}, "finish_reason": "stop"}
+            ],
+            "usage": {"prompt_tokens": 10, "completion_tokens": 5, "total_tokens": 15},
+        }
+        review_resp = {
+            "id": "fake",
+            "choices": [
+                {
+                    "message": {"role": "assistant", "content": "All steps complete."},
+                    "finish_reason": "stop",
+                }
+            ],
+            "usage": {"prompt_tokens": 10, "completion_tokens": 5, "total_tokens": 15},
+        }
+        llm.set_responses(plan_resp, exec_resp, exec_resp, exec_resp, review_resp)
         strategy = PlanExecuteStrategy(max_subtasks=10)
         result = await strategy.reason(
             [{"role": "user", "content": "build a web scraper"}],
             "m",
             llm,
         )
-        assert result.response == "1. Parse input\n2. Process\n3. Output"
+        assert result.response == "All steps complete."
         assert result.done is True
+        # plan + 3 execute + review = 5 LLM calls
+        assert len(llm.calls) == 5
 
     @pytest.mark.asyncio
     async def test_plan_prompt_includes_max_subtasks(self) -> None:


### PR DESCRIPTION
Closes #47. Real 3-phase implementation: plan → execute subtasks → review. Handles tool calls, max_subtasks cap, fallback. 14 new tests.