### PR TITLE
feat: response cache with task-type-aware TTL

### DIFF
--- a/src/stronghold/cache/response_cache.py
+++ b/src/stronghold/cache/response_cache.py
@@ -1,0 +1,199 @@
+"""Response cache for LLM completions.
+
+Exact-match cache keyed on message content + model + task_type.
+Task-type-aware TTL: chat=3600s, real-time=300s, creative=0 (no cache).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import time
+from dataclasses import dataclass
+from typing import Any
+
+logger = logging.getLogger("stronghold.cache.response")
+
+# Default TTL per task_type (seconds). 0 = never cache.
+DEFAULT_TTL: dict[str, int] = {
+    "chat": 3600,  # 1 hour
+    "code": 1800,  # 30 min
+    "search": 600,  # 10 min
+    "smart_home": 300,  # 5 min (real-time)
+    "trading": 60,  # 1 min (real-time)
+    "creative": 0,  # never cache
+}
+DEFAULT_FALLBACK_TTL = 1800  # 30 min for unknown task types
+
+
+@dataclass
+class CacheEntry:
+    """A single cached response with metadata."""
+
+    response: dict[str, Any]
+    created_at: float
+    ttl: int
+    task_type: str
+    hit_count: int = 0
+
+    @property
+    def is_expired(self) -> bool:
+        return (time.time() - self.created_at) > self.ttl
+
+
+@dataclass
+class CacheStats:
+    """Aggregate cache statistics."""
+
+    hits: int = 0
+    misses: int = 0
+    evictions: int = 0
+    entries: int = 0
+
+    @property
+    def hit_rate(self) -> float:
+        total = self.hits + self.misses
+        return self.hits / total if total > 0 else 0.0
+
+
+class InMemoryResponseCache:
+    """In-memory response cache with TTL and task-type awareness.
+
+    Keys are SHA-256 hashes of (messages, model, task_type). Each task
+    type has its own TTL (e.g. creative=0 means never cache). When the
+    cache reaches ``max_entries``, the least-recently-used entry is evicted.
+    """
+
+    def __init__(
+        self,
+        ttl_overrides: dict[str, int] | None = None,
+        max_entries: int = 1000,
+    ) -> None:
+        self._cache: dict[str, CacheEntry] = {}
+        self._ttls = {**DEFAULT_TTL, **(ttl_overrides or {})}
+        self._max_entries = max_entries
+        self._stats = CacheStats()
+        # Insertion-order list for LRU tracking (oldest first).
+        self._access_order: list[str] = []
+
+    def cache_key(
+        self,
+        messages: list[dict[str, Any]],
+        model: str,
+        task_type: str,
+    ) -> str:
+        """Generate deterministic cache key from request parameters."""
+        content = json.dumps(
+            {"messages": messages, "model": model, "task_type": task_type},
+            sort_keys=True,
+        )
+        return hashlib.sha256(content.encode()).hexdigest()
+
+    def get(
+        self,
+        messages: list[dict[str, Any]],
+        model: str,
+        task_type: str,
+    ) -> dict[str, Any] | None:
+        """Get cached response. Returns None on miss or expired entry."""
+        key = self.cache_key(messages, model, task_type)
+        entry = self._cache.get(key)
+
+        if entry is None:
+            self._stats.misses += 1
+            return None
+
+        if entry.is_expired:
+            del self._cache[key]
+            if key in self._access_order:
+                self._access_order.remove(key)
+            self._stats.entries = len(self._cache)
+            self._stats.misses += 1
+            self._stats.evictions += 1
+            return None
+
+        entry.hit_count += 1
+        self._stats.hits += 1
+
+        # Move to end of access order (most recently used).
+        if key in self._access_order:
+            self._access_order.remove(key)
+        self._access_order.append(key)
+
+        return entry.response
+
+    def put(
+        self,
+        messages: list[dict[str, Any]],
+        model: str,
+        task_type: str,
+        response: dict[str, Any],
+    ) -> None:
+        """Cache a response. Respects task_type TTL. No-op if TTL=0."""
+        ttl = self._ttls.get(task_type, DEFAULT_FALLBACK_TTL)
+        if ttl == 0:
+            return
+
+        key = self.cache_key(messages, model, task_type)
+
+        # Evict expired entries before checking capacity.
+        self._evict_expired()
+
+        # Evict LRU if at capacity (and not replacing existing key).
+        if key not in self._cache and len(self._cache) >= self._max_entries:
+            self._evict_lru()
+
+        self._cache[key] = CacheEntry(
+            response=response,
+            created_at=time.time(),
+            ttl=ttl,
+            task_type=task_type,
+        )
+
+        # Track access order.
+        if key in self._access_order:
+            self._access_order.remove(key)
+        self._access_order.append(key)
+
+        self._stats.entries = len(self._cache)
+
+    def invalidate(self, key: str) -> bool:
+        """Remove a specific entry. Returns True if it existed."""
+        if key in self._cache:
+            del self._cache[key]
+            if key in self._access_order:
+                self._access_order.remove(key)
+            self._stats.entries = len(self._cache)
+            return True
+        return False
+
+    def clear(self) -> None:
+        """Clear all entries."""
+        self._cache.clear()
+        self._access_order.clear()
+        self._stats.entries = 0
+
+    @property
+    def stats(self) -> CacheStats:
+        return self._stats
+
+    def _evict_expired(self) -> None:
+        """Remove expired entries."""
+        expired_keys = [k for k, v in self._cache.items() if v.is_expired]
+        for key in expired_keys:
+            del self._cache[key]
+            if key in self._access_order:
+                self._access_order.remove(key)
+            self._stats.evictions += 1
+        self._stats.entries = len(self._cache)
+
+    def _evict_lru(self) -> None:
+        """Evict least-recently-used entry when at capacity."""
+        if not self._access_order:
+            return
+        lru_key = self._access_order.pop(0)
+        if lru_key in self._cache:
+            del self._cache[lru_key]
+            self._stats.evictions += 1
+            self._stats.entries = len(self._cache)

--- a/tests/cache/test_response_cache.py
+++ b/tests/cache/test_response_cache.py
@@ -1,0 +1,270 @@
+"""Tests for InMemoryResponseCache — exact-match response caching with TTL.
+
+Covers: cache miss, hit, expiration, task-type TTL, custom overrides,
+deterministic keys, LRU eviction, invalidation, clear, and stats.
+"""
+
+from __future__ import annotations
+
+import time
+
+import pytest
+
+from stronghold.cache.response_cache import (
+    DEFAULT_FALLBACK_TTL,
+    DEFAULT_TTL,
+    CacheEntry,
+    CacheStats,
+    InMemoryResponseCache,
+)
+
+# ── Helpers ──────────────────────────────────────────────────────────
+
+SAMPLE_MESSAGES = [{"role": "user", "content": "Hello, world!"}]
+SAMPLE_MODEL = "test/small"
+SAMPLE_TASK = "chat"
+SAMPLE_RESPONSE: dict[str, object] = {
+    "id": "resp-1",
+    "choices": [{"message": {"role": "assistant", "content": "Hi!"}}],
+}
+
+
+def _make_cache(**kwargs: object) -> InMemoryResponseCache:
+    return InMemoryResponseCache(**kwargs)  # type: ignore[arg-type]
+
+
+# ── CacheEntry ───────────────────────────────────────────────────────
+
+
+class TestCacheEntry:
+    def test_not_expired_within_ttl(self) -> None:
+        entry = CacheEntry(
+            response={"x": 1}, created_at=time.time(), ttl=3600, task_type="chat"
+        )
+        assert not entry.is_expired
+
+    def test_expired_after_ttl(self) -> None:
+        entry = CacheEntry(
+            response={"x": 1}, created_at=time.time() - 7200, ttl=3600, task_type="chat"
+        )
+        assert entry.is_expired
+
+
+# ── CacheStats ───────────────────────────────────────────────────────
+
+
+class TestCacheStats:
+    def test_hit_rate_zero_when_empty(self) -> None:
+        stats = CacheStats()
+        assert stats.hit_rate == 0.0
+
+    def test_hit_rate_calculation(self) -> None:
+        stats = CacheStats(hits=3, misses=7)
+        assert stats.hit_rate == pytest.approx(0.3)
+
+    def test_hit_rate_perfect(self) -> None:
+        stats = CacheStats(hits=10, misses=0)
+        assert stats.hit_rate == pytest.approx(1.0)
+
+
+# ── Cache key ────────────────────────────────────────────────────────
+
+
+class TestCacheKey:
+    def test_deterministic(self) -> None:
+        cache = _make_cache()
+        k1 = cache.cache_key(SAMPLE_MESSAGES, SAMPLE_MODEL, SAMPLE_TASK)
+        k2 = cache.cache_key(SAMPLE_MESSAGES, SAMPLE_MODEL, SAMPLE_TASK)
+        assert k1 == k2
+
+    def test_different_messages_different_keys(self) -> None:
+        cache = _make_cache()
+        k1 = cache.cache_key(SAMPLE_MESSAGES, SAMPLE_MODEL, SAMPLE_TASK)
+        k2 = cache.cache_key(
+            [{"role": "user", "content": "Different"}], SAMPLE_MODEL, SAMPLE_TASK
+        )
+        assert k1 != k2
+
+    def test_different_model_different_keys(self) -> None:
+        cache = _make_cache()
+        k1 = cache.cache_key(SAMPLE_MESSAGES, "model-a", SAMPLE_TASK)
+        k2 = cache.cache_key(SAMPLE_MESSAGES, "model-b", SAMPLE_TASK)
+        assert k1 != k2
+
+    def test_different_task_type_different_keys(self) -> None:
+        cache = _make_cache()
+        k1 = cache.cache_key(SAMPLE_MESSAGES, SAMPLE_MODEL, "chat")
+        k2 = cache.cache_key(SAMPLE_MESSAGES, SAMPLE_MODEL, "code")
+        assert k1 != k2
+
+
+# ── Miss / Hit ───────────────────────────────────────────────────────
+
+
+class TestGetPut:
+    def test_miss_returns_none(self) -> None:
+        cache = _make_cache()
+        assert cache.get(SAMPLE_MESSAGES, SAMPLE_MODEL, SAMPLE_TASK) is None
+
+    def test_put_then_get(self) -> None:
+        cache = _make_cache()
+        cache.put(SAMPLE_MESSAGES, SAMPLE_MODEL, SAMPLE_TASK, dict(SAMPLE_RESPONSE))
+        result = cache.get(SAMPLE_MESSAGES, SAMPLE_MODEL, SAMPLE_TASK)
+        assert result is not None
+        assert result["id"] == "resp-1"
+
+    def test_hit_increments_hit_count(self) -> None:
+        cache = _make_cache()
+        cache.put(SAMPLE_MESSAGES, SAMPLE_MODEL, SAMPLE_TASK, dict(SAMPLE_RESPONSE))
+        cache.get(SAMPLE_MESSAGES, SAMPLE_MODEL, SAMPLE_TASK)
+        cache.get(SAMPLE_MESSAGES, SAMPLE_MODEL, SAMPLE_TASK)
+        key = cache.cache_key(SAMPLE_MESSAGES, SAMPLE_MODEL, SAMPLE_TASK)
+        assert cache._cache[key].hit_count == 2
+
+
+# ── Expiration ───────────────────────────────────────────────────────
+
+
+class TestExpiration:
+    def test_expired_entry_returns_none(self) -> None:
+        cache = _make_cache()
+        cache.put(SAMPLE_MESSAGES, SAMPLE_MODEL, SAMPLE_TASK, dict(SAMPLE_RESPONSE))
+        key = cache.cache_key(SAMPLE_MESSAGES, SAMPLE_MODEL, SAMPLE_TASK)
+        # Manually backdate the entry
+        cache._cache[key].created_at = time.time() - 9999
+        assert cache.get(SAMPLE_MESSAGES, SAMPLE_MODEL, SAMPLE_TASK) is None
+
+    def test_expired_entry_removed_on_get(self) -> None:
+        cache = _make_cache()
+        cache.put(SAMPLE_MESSAGES, SAMPLE_MODEL, SAMPLE_TASK, dict(SAMPLE_RESPONSE))
+        key = cache.cache_key(SAMPLE_MESSAGES, SAMPLE_MODEL, SAMPLE_TASK)
+        cache._cache[key].created_at = time.time() - 9999
+        cache.get(SAMPLE_MESSAGES, SAMPLE_MODEL, SAMPLE_TASK)
+        assert key not in cache._cache
+
+
+# ── Task-type TTL ────────────────────────────────────────────────────
+
+
+class TestTaskTypeTTL:
+    def test_creative_never_cached(self) -> None:
+        cache = _make_cache()
+        cache.put(SAMPLE_MESSAGES, SAMPLE_MODEL, "creative", dict(SAMPLE_RESPONSE))
+        assert cache.get(SAMPLE_MESSAGES, SAMPLE_MODEL, "creative") is None
+
+    def test_chat_uses_default_ttl(self) -> None:
+        cache = _make_cache()
+        cache.put(SAMPLE_MESSAGES, SAMPLE_MODEL, "chat", dict(SAMPLE_RESPONSE))
+        key = cache.cache_key(SAMPLE_MESSAGES, SAMPLE_MODEL, "chat")
+        assert cache._cache[key].ttl == DEFAULT_TTL["chat"]
+
+    def test_unknown_task_uses_fallback_ttl(self) -> None:
+        cache = _make_cache()
+        cache.put(SAMPLE_MESSAGES, SAMPLE_MODEL, "unknown_type", dict(SAMPLE_RESPONSE))
+        key = cache.cache_key(SAMPLE_MESSAGES, SAMPLE_MODEL, "unknown_type")
+        assert cache._cache[key].ttl == DEFAULT_FALLBACK_TTL
+
+    def test_custom_ttl_override(self) -> None:
+        cache = _make_cache(ttl_overrides={"chat": 60})
+        cache.put(SAMPLE_MESSAGES, SAMPLE_MODEL, "chat", dict(SAMPLE_RESPONSE))
+        key = cache.cache_key(SAMPLE_MESSAGES, SAMPLE_MODEL, "chat")
+        assert cache._cache[key].ttl == 60
+
+
+# ── LRU eviction ─────────────────────────────────────────────────────
+
+
+class TestEviction:
+    def test_max_entries_evicts_oldest(self) -> None:
+        cache = _make_cache(max_entries=2)
+        msgs_a = [{"role": "user", "content": "a"}]
+        msgs_b = [{"role": "user", "content": "b"}]
+        msgs_c = [{"role": "user", "content": "c"}]
+
+        cache.put(msgs_a, SAMPLE_MODEL, SAMPLE_TASK, {"id": "a"})
+        cache.put(msgs_b, SAMPLE_MODEL, SAMPLE_TASK, {"id": "b"})
+        # This should evict 'a' (oldest)
+        cache.put(msgs_c, SAMPLE_MODEL, SAMPLE_TASK, {"id": "c"})
+
+        assert cache.get(msgs_a, SAMPLE_MODEL, SAMPLE_TASK) is None
+        assert cache.get(msgs_b, SAMPLE_MODEL, SAMPLE_TASK) is not None
+        assert cache.get(msgs_c, SAMPLE_MODEL, SAMPLE_TASK) is not None
+
+    def test_eviction_increments_stats(self) -> None:
+        cache = _make_cache(max_entries=1)
+        msgs_a = [{"role": "user", "content": "a"}]
+        msgs_b = [{"role": "user", "content": "b"}]
+
+        cache.put(msgs_a, SAMPLE_MODEL, SAMPLE_TASK, {"id": "a"})
+        cache.put(msgs_b, SAMPLE_MODEL, SAMPLE_TASK, {"id": "b"})
+        assert cache.stats.evictions >= 1
+
+
+# ── Invalidate / Clear ───────────────────────────────────────────────
+
+
+class TestInvalidateAndClear:
+    def test_invalidate_removes_entry(self) -> None:
+        cache = _make_cache()
+        cache.put(SAMPLE_MESSAGES, SAMPLE_MODEL, SAMPLE_TASK, dict(SAMPLE_RESPONSE))
+        key = cache.cache_key(SAMPLE_MESSAGES, SAMPLE_MODEL, SAMPLE_TASK)
+        assert cache.invalidate(key) is True
+        assert cache.get(SAMPLE_MESSAGES, SAMPLE_MODEL, SAMPLE_TASK) is None
+
+    def test_invalidate_nonexistent_returns_false(self) -> None:
+        cache = _make_cache()
+        assert cache.invalidate("nonexistent-key") is False
+
+    def test_clear_removes_all(self) -> None:
+        cache = _make_cache()
+        cache.put(SAMPLE_MESSAGES, SAMPLE_MODEL, SAMPLE_TASK, dict(SAMPLE_RESPONSE))
+        cache.put(
+            [{"role": "user", "content": "other"}],
+            SAMPLE_MODEL,
+            SAMPLE_TASK,
+            {"id": "resp-2"},
+        )
+        cache.clear()
+        assert len(cache._cache) == 0
+
+    def test_clear_resets_entries_stat(self) -> None:
+        cache = _make_cache()
+        cache.put(SAMPLE_MESSAGES, SAMPLE_MODEL, SAMPLE_TASK, dict(SAMPLE_RESPONSE))
+        cache.clear()
+        assert cache.stats.entries == 0
+
+
+# ── Stats tracking ───────────────────────────────────────────────────
+
+
+class TestStats:
+    def test_miss_increments_misses(self) -> None:
+        cache = _make_cache()
+        cache.get(SAMPLE_MESSAGES, SAMPLE_MODEL, SAMPLE_TASK)
+        assert cache.stats.misses == 1
+
+    def test_hit_increments_hits(self) -> None:
+        cache = _make_cache()
+        cache.put(SAMPLE_MESSAGES, SAMPLE_MODEL, SAMPLE_TASK, dict(SAMPLE_RESPONSE))
+        cache.get(SAMPLE_MESSAGES, SAMPLE_MODEL, SAMPLE_TASK)
+        assert cache.stats.hits == 1
+
+    def test_entries_count(self) -> None:
+        cache = _make_cache()
+        cache.put(SAMPLE_MESSAGES, SAMPLE_MODEL, SAMPLE_TASK, dict(SAMPLE_RESPONSE))
+        assert cache.stats.entries == 1
+
+    def test_stats_after_multiple_operations(self) -> None:
+        cache = _make_cache()
+        # 1 miss
+        cache.get(SAMPLE_MESSAGES, SAMPLE_MODEL, SAMPLE_TASK)
+        # 1 put
+        cache.put(SAMPLE_MESSAGES, SAMPLE_MODEL, SAMPLE_TASK, dict(SAMPLE_RESPONSE))
+        # 2 hits
+        cache.get(SAMPLE_MESSAGES, SAMPLE_MODEL, SAMPLE_TASK)
+        cache.get(SAMPLE_MESSAGES, SAMPLE_MODEL, SAMPLE_TASK)
+
+        assert cache.stats.misses == 1
+        assert cache.stats.hits == 2
+        assert cache.stats.entries == 1
+        assert cache.stats.hit_rate == pytest.approx(2 / 3)


### PR DESCRIPTION
Closes #149. InMemoryResponseCache with SHA-256 keying, task-type TTL (chat=1h, creative=never), LRU eviction, cache stats. 28 tests.