### PR TITLE
feat: batch API for async task submission and polling

### DIFF
--- a/src/stronghold/api/app.py
+++ b/src/stronghold/api/app.py
@@ -118,6 +118,7 @@ def create_app() -> FastAPI:
     from stronghold.api.routes.status import router as status_router
     from stronghold.api.routes.tasks import router as tasks_router
     from stronghold.api.routes.traces import router as traces_router
+    from stronghold.api.routes.batch import router as batch_router
     from stronghold.api.routes.webhooks import router as webhooks_router
     from stronghold.prompts.routes import router as prompts_router
 
@@ -139,6 +140,7 @@ def create_app() -> FastAPI:
     app.include_router(dashboard_router)
     app.include_router(webhooks_router)
     app.include_router(mcp_router)
+    app.include_router(batch_router)
 
     # Dashboard — try multiple paths (installed package vs source layout)
     _dashboard_candidates = [

--- a/src/stronghold/api/routes/batch.py
+++ b/src/stronghold/api/routes/batch.py
@@ -1,0 +1,141 @@
+"""Batch API endpoints — async task submission with polling.
+
+- POST   /v1/stronghold/batch/tasks — submit async task (auth)
+- GET    /v1/stronghold/batch/tasks — list user's tasks (auth)
+- GET    /v1/stronghold/batch/tasks/{task_id} — poll status (auth)
+- DELETE /v1/stronghold/batch/tasks/{task_id} — cancel (auth)
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi import APIRouter, HTTPException, Request
+from fastapi.responses import JSONResponse
+
+from stronghold.batch.manager import BatchTask
+
+router = APIRouter(prefix="/v1/stronghold/batch/tasks")
+
+
+def _check_csrf(request: Request) -> None:
+    """Verify CSRF defense header on cookie-authenticated mutations."""
+    if request.method not in ("POST", "PUT", "DELETE"):
+        return
+    if request.headers.get("authorization"):
+        return  # Bearer token — not CSRF-vulnerable
+    if not request.cookies:
+        return  # No cookies = not a browser session
+    if not request.headers.get("x-stronghold-request"):
+        raise HTTPException(
+            status_code=403,
+            detail="Missing X-Stronghold-Request header (CSRF protection)",
+        )
+
+
+async def _authenticate(request: Request) -> tuple[Any, Any]:
+    """Authenticate and return (auth, container). CSRF checked after auth."""
+    container = request.app.state.container
+    auth_header = request.headers.get("authorization")
+    try:
+        auth = await container.auth_provider.authenticate(
+            auth_header, headers=dict(request.headers)
+        )
+    except ValueError as e:
+        raise HTTPException(status_code=401, detail=str(e)) from e
+    _check_csrf(request)
+    return auth, container
+
+
+@router.post("")
+async def submit_batch_task(request: Request) -> JSONResponse:
+    """Submit a batch task for async processing."""
+    auth, container = await _authenticate(request)
+
+    body: dict[str, Any] = await request.json()
+    messages: list[dict[str, Any]] = body.get("messages", [])
+    execution_mode: str = body.get("execution_mode", "best_effort")
+    callback_url: str = body.get("callback_url", "")
+
+    if not messages:
+        raise HTTPException(status_code=400, detail="'messages' is required")
+
+    task = BatchTask(
+        user_id=auth.user_id,
+        org_id=auth.org_id,
+        messages=messages,
+        execution_mode=execution_mode,
+        callback_url=callback_url,
+    )
+    task = await container.batch_manager.submit(task)
+
+    return JSONResponse(
+        status_code=200,
+        content={"task_id": task.id, "status": task.status},
+    )
+
+
+@router.get("")
+async def list_batch_tasks(
+    request: Request,
+    limit: int = 20,
+) -> JSONResponse:
+    """List the caller's batch tasks."""
+    auth, container = await _authenticate(request)
+    limit = min(max(limit, 1), 100)
+
+    tasks = await container.batch_manager.list_for_user(
+        user_id=auth.user_id,
+        org_id=auth.org_id,
+        limit=limit,
+    )
+
+    return JSONResponse(
+        content={
+            "tasks": [
+                {
+                    "task_id": t.id,
+                    "status": t.status,
+                    "execution_mode": t.execution_mode,
+                    "progress": t.progress,
+                    "created_at": t.created_at,
+                }
+                for t in tasks
+            ],
+        },
+    )
+
+
+@router.get("/{task_id}")
+async def get_batch_task(task_id: str, request: Request) -> JSONResponse:
+    """Poll batch task status."""
+    auth, container = await _authenticate(request)
+
+    task = await container.batch_manager.get(task_id, org_id=auth.org_id)
+    if task is None:
+        raise HTTPException(status_code=404, detail="Task not found")
+
+    return JSONResponse(
+        content={
+            "task_id": task.id,
+            "status": task.status,
+            "progress": task.progress,
+            "result": task.result,
+            "error": task.error,
+            "created_at": task.created_at,
+            "started_at": task.started_at,
+            "completed_at": task.completed_at,
+        },
+    )
+
+
+@router.delete("/{task_id}")
+async def cancel_batch_task(task_id: str, request: Request) -> JSONResponse:
+    """Cancel a batch task."""
+    auth, container = await _authenticate(request)
+
+    cancelled = await container.batch_manager.cancel(task_id, org_id=auth.org_id)
+    if not cancelled:
+        raise HTTPException(status_code=404, detail="Task not found or not cancellable")
+
+    return JSONResponse(content={"task_id": task_id, "status": "cancelled"})

--- a/src/stronghold/batch/__init__.py
+++ b/src/stronghold/batch/__init__.py
@@ -1,0 +1,1 @@
+"""Batch task management — async submission, polling, callbacks."""

--- a/src/stronghold/batch/manager.py
+++ b/src/stronghold/batch/manager.py
@@ -1,0 +1,100 @@
+"""Batch task manager — async submission, polling, callbacks."""
+
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass, field
+from typing import Any
+from uuid import uuid4
+
+
+@dataclass
+class BatchTask:
+    """A batch task submitted for async processing."""
+
+    id: str = ""
+    user_id: str = ""
+    org_id: str = ""
+    messages: list[dict[str, Any]] = field(default_factory=list)
+    execution_mode: str = "best_effort"
+    callback_url: str = ""
+    status: str = "submitted"  # submitted, working, completed, failed, cancelled
+    progress: str = ""
+    result: dict[str, Any] | None = None
+    error: str = ""
+    created_at: float = 0.0
+    started_at: float = 0.0
+    completed_at: float = 0.0
+
+
+class InMemoryBatchManager:
+    """In-memory batch manager. PostgreSQL version for production."""
+
+    def __init__(self) -> None:
+        self._tasks: dict[str, BatchTask] = {}
+
+    async def submit(self, task: BatchTask) -> BatchTask:
+        """Submit a batch task. Assigns ID and timestamp if not set."""
+        if not task.id:
+            task.id = f"batch-{uuid4().hex[:12]}"
+        task.created_at = time.time()
+        task.status = "submitted"
+        self._tasks[task.id] = task
+        return task
+
+    async def get(self, task_id: str, *, org_id: str) -> BatchTask | None:
+        """Get a task by ID, scoped to org."""
+        task = self._tasks.get(task_id)
+        if task and task.org_id == org_id:
+            return task
+        return None
+
+    async def list_for_user(
+        self,
+        *,
+        user_id: str,
+        org_id: str,
+        limit: int = 20,
+    ) -> list[BatchTask]:
+        """List tasks for a user within their org."""
+        tasks = [t for t in self._tasks.values() if t.user_id == user_id and t.org_id == org_id]
+        # Sort by created_at descending (newest first)
+        tasks.sort(key=lambda t: t.created_at, reverse=True)
+        return tasks[:limit]
+
+    async def update_status(
+        self,
+        task_id: str,
+        *,
+        status: str,
+        progress: str = "",
+        result: dict[str, Any] | None = None,
+        error: str = "",
+    ) -> bool:
+        """Update the status of a task. Returns False if task not found."""
+        task = self._tasks.get(task_id)
+        if not task:
+            return False
+        task.status = status
+        if progress:
+            task.progress = progress
+        if result is not None:
+            task.result = result
+        if error:
+            task.error = error
+        if status == "working" and task.started_at == 0.0:
+            task.started_at = time.time()
+        if status in ("completed", "failed", "cancelled"):
+            task.completed_at = time.time()
+        return True
+
+    async def cancel(self, task_id: str, *, org_id: str) -> bool:
+        """Cancel a task. Returns False if not found, wrong org, or terminal status."""
+        task = self._tasks.get(task_id)
+        if not task or task.org_id != org_id:
+            return False
+        if task.status in ("completed", "failed", "cancelled"):
+            return False
+        task.status = "cancelled"
+        task.completed_at = time.time()
+        return True

--- a/src/stronghold/container.py
+++ b/src/stronghold/container.py
@@ -86,6 +86,7 @@ class Container:
     prompt_cache: Any = None  # RedisPromptCache (write-through cache)
     mcp_registry: Any = None  # MCPRegistry
     mcp_deployer: Any = None  # K8sDeployer
+    batch_manager: Any = None  # InMemoryBatchManager
     conduit: Any = None  # Conduit — wired in __post_init__ or create_container
 
     def __post_init__(self) -> None:
@@ -379,6 +380,11 @@ async def create_container(config: StrongholdConfig) -> Container:
         approval_gate=approval_gate,
     )
 
+    # Batch manager
+    from stronghold.batch.manager import InMemoryBatchManager  # noqa: PLC0415
+
+    batch_manager = InMemoryBatchManager()
+
     # MCP server registry + K8s deployer
     from stronghold.mcp.registry import MCPRegistry  # noqa: PLC0415
 
@@ -430,6 +436,7 @@ async def create_container(config: StrongholdConfig) -> Container:
         prompt_cache=prompt_cache,
         mcp_registry=mcp_registry,
         mcp_deployer=mcp_deployer,
+        batch_manager=batch_manager,
     )
 
     # Conduit pipeline is auto-wired via __post_init__

--- a/tests/batch/test_manager.py
+++ b/tests/batch/test_manager.py
@@ -1,0 +1,179 @@
+"""Tests for batch task manager: submit, get, list, update, cancel."""
+
+from __future__ import annotations
+
+import pytest
+
+from stronghold.batch.manager import BatchTask, InMemoryBatchManager
+
+
+@pytest.fixture
+def manager() -> InMemoryBatchManager:
+    return InMemoryBatchManager()
+
+
+class TestSubmit:
+    async def test_submit_assigns_id(self, manager: InMemoryBatchManager) -> None:
+        task = BatchTask(user_id="u1", org_id="org1", messages=[{"role": "user", "content": "hi"}])
+        result = await manager.submit(task)
+        assert result.id.startswith("batch-")
+        assert len(result.id) > 6
+
+    async def test_submit_sets_status_to_submitted(self, manager: InMemoryBatchManager) -> None:
+        task = BatchTask(user_id="u1", org_id="org1", messages=[{"role": "user", "content": "hi"}])
+        result = await manager.submit(task)
+        assert result.status == "submitted"
+
+    async def test_submit_sets_created_at(self, manager: InMemoryBatchManager) -> None:
+        task = BatchTask(user_id="u1", org_id="org1", messages=[{"role": "user", "content": "hi"}])
+        result = await manager.submit(task)
+        assert result.created_at > 0
+
+    async def test_submit_preserves_custom_id(self, manager: InMemoryBatchManager) -> None:
+        task = BatchTask(
+            id="custom-id", user_id="u1", org_id="org1", messages=[{"role": "user", "content": "x"}]
+        )
+        result = await manager.submit(task)
+        assert result.id == "custom-id"
+
+
+class TestGet:
+    async def test_get_returns_task_for_correct_org(self, manager: InMemoryBatchManager) -> None:
+        task = BatchTask(user_id="u1", org_id="org1", messages=[{"role": "user", "content": "hi"}])
+        submitted = await manager.submit(task)
+        result = await manager.get(submitted.id, org_id="org1")
+        assert result is not None
+        assert result.id == submitted.id
+
+    async def test_get_returns_none_for_wrong_org(self, manager: InMemoryBatchManager) -> None:
+        task = BatchTask(user_id="u1", org_id="org1", messages=[{"role": "user", "content": "hi"}])
+        submitted = await manager.submit(task)
+        result = await manager.get(submitted.id, org_id="org2")
+        assert result is None
+
+    async def test_get_returns_none_for_nonexistent(self, manager: InMemoryBatchManager) -> None:
+        result = await manager.get("nonexistent", org_id="org1")
+        assert result is None
+
+
+class TestListForUser:
+    async def test_filters_by_user_and_org(self, manager: InMemoryBatchManager) -> None:
+        await manager.submit(
+            BatchTask(user_id="u1", org_id="org1", messages=[{"role": "user", "content": "a"}])
+        )
+        await manager.submit(
+            BatchTask(user_id="u2", org_id="org1", messages=[{"role": "user", "content": "b"}])
+        )
+        await manager.submit(
+            BatchTask(user_id="u1", org_id="org2", messages=[{"role": "user", "content": "c"}])
+        )
+
+        tasks = await manager.list_for_user(user_id="u1", org_id="org1")
+        assert len(tasks) == 1
+        assert tasks[0].user_id == "u1"
+        assert tasks[0].org_id == "org1"
+
+    async def test_respects_limit(self, manager: InMemoryBatchManager) -> None:
+        for i in range(5):
+            await manager.submit(
+                BatchTask(
+                    user_id="u1",
+                    org_id="org1",
+                    messages=[{"role": "user", "content": f"task {i}"}],
+                )
+            )
+        tasks = await manager.list_for_user(user_id="u1", org_id="org1", limit=3)
+        assert len(tasks) == 3
+
+    async def test_returns_empty_for_no_match(self, manager: InMemoryBatchManager) -> None:
+        tasks = await manager.list_for_user(user_id="nobody", org_id="org1")
+        assert tasks == []
+
+
+class TestUpdateStatus:
+    async def test_updates_status_and_progress(self, manager: InMemoryBatchManager) -> None:
+        task = BatchTask(user_id="u1", org_id="org1", messages=[{"role": "user", "content": "hi"}])
+        submitted = await manager.submit(task)
+
+        ok = await manager.update_status(submitted.id, status="working", progress="50%")
+        assert ok is True
+
+        updated = await manager.get(submitted.id, org_id="org1")
+        assert updated is not None
+        assert updated.status == "working"
+        assert updated.progress == "50%"
+        assert updated.started_at > 0
+
+    async def test_updates_with_result(self, manager: InMemoryBatchManager) -> None:
+        task = BatchTask(user_id="u1", org_id="org1", messages=[{"role": "user", "content": "hi"}])
+        submitted = await manager.submit(task)
+
+        result_data = {"answer": "done"}
+        ok = await manager.update_status(
+            submitted.id, status="completed", result=result_data
+        )
+        assert ok is True
+
+        updated = await manager.get(submitted.id, org_id="org1")
+        assert updated is not None
+        assert updated.status == "completed"
+        assert updated.result == {"answer": "done"}
+        assert updated.completed_at > 0
+
+    async def test_updates_with_error(self, manager: InMemoryBatchManager) -> None:
+        task = BatchTask(user_id="u1", org_id="org1", messages=[{"role": "user", "content": "hi"}])
+        submitted = await manager.submit(task)
+
+        ok = await manager.update_status(
+            submitted.id, status="failed", error="something broke"
+        )
+        assert ok is True
+
+        updated = await manager.get(submitted.id, org_id="org1")
+        assert updated is not None
+        assert updated.status == "failed"
+        assert updated.error == "something broke"
+
+    async def test_returns_false_for_nonexistent(self, manager: InMemoryBatchManager) -> None:
+        ok = await manager.update_status("nope", status="working")
+        assert ok is False
+
+
+class TestCancel:
+    async def test_cancel_submitted_task(self, manager: InMemoryBatchManager) -> None:
+        task = BatchTask(user_id="u1", org_id="org1", messages=[{"role": "user", "content": "hi"}])
+        submitted = await manager.submit(task)
+
+        ok = await manager.cancel(submitted.id, org_id="org1")
+        assert ok is True
+
+        updated = await manager.get(submitted.id, org_id="org1")
+        assert updated is not None
+        assert updated.status == "cancelled"
+
+    async def test_cancel_working_task(self, manager: InMemoryBatchManager) -> None:
+        task = BatchTask(user_id="u1", org_id="org1", messages=[{"role": "user", "content": "hi"}])
+        submitted = await manager.submit(task)
+        await manager.update_status(submitted.id, status="working")
+
+        ok = await manager.cancel(submitted.id, org_id="org1")
+        assert ok is True
+
+    async def test_cancel_fails_for_completed_task(self, manager: InMemoryBatchManager) -> None:
+        task = BatchTask(user_id="u1", org_id="org1", messages=[{"role": "user", "content": "hi"}])
+        submitted = await manager.submit(task)
+        await manager.update_status(submitted.id, status="completed")
+
+        ok = await manager.cancel(submitted.id, org_id="org1")
+        assert ok is False
+
+    async def test_cancel_fails_for_wrong_org(self, manager: InMemoryBatchManager) -> None:
+        task = BatchTask(user_id="u1", org_id="org1", messages=[{"role": "user", "content": "hi"}])
+        submitted = await manager.submit(task)
+
+        ok = await manager.cancel(submitted.id, org_id="wrong-org")
+        assert ok is False
+
+    async def test_cancel_fails_for_nonexistent(self, manager: InMemoryBatchManager) -> None:
+        ok = await manager.cancel("nope", org_id="org1")
+        assert ok is False

--- a/tests/batch/test_routes.py
+++ b/tests/batch/test_routes.py
@@ -1,0 +1,271 @@
+"""Tests for batch API routes: submit, poll, list, cancel."""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from stronghold.agents.base import Agent
+from stronghold.agents.context_builder import ContextBuilder
+from stronghold.agents.intents import IntentRegistry
+from stronghold.agents.strategies.direct import DirectStrategy
+from stronghold.agents.task_queue import InMemoryTaskQueue
+from stronghold.api.routes.batch import router as batch_router
+from stronghold.batch.manager import InMemoryBatchManager
+from stronghold.classifier.engine import ClassifierEngine
+from stronghold.container import Container
+from stronghold.memory.learnings.extractor import ToolCorrectionExtractor
+from stronghold.memory.learnings.store import InMemoryLearningStore
+from stronghold.memory.outcomes import InMemoryOutcomeStore
+from stronghold.prompts.store import InMemoryPromptManager
+from stronghold.quota.tracker import InMemoryQuotaTracker
+from stronghold.router.selector import RouterEngine
+from stronghold.security.auth_static import StaticKeyAuthProvider
+from stronghold.security.gate import Gate
+from stronghold.security.sentinel.audit import InMemoryAuditLog
+from stronghold.security.sentinel.policy import Sentinel
+from stronghold.security.warden.detector import Warden
+from stronghold.sessions.store import InMemorySessionStore
+from stronghold.tools.executor import ToolDispatcher
+from stronghold.tools.registry import InMemoryToolRegistry
+from stronghold.tracing.noop import NoopTracingBackend
+from stronghold.types.agent import AgentIdentity
+from stronghold.types.auth import PermissionTable
+from stronghold.types.config import StrongholdConfig, TaskTypeConfig
+from tests.fakes import FakeLLMClient
+
+
+@pytest.fixture
+def batch_app() -> FastAPI:
+    """Create a FastAPI app with batch routes and real components."""
+    app = FastAPI()
+    app.include_router(batch_router)
+
+    fake_llm = FakeLLMClient()
+    fake_llm.set_simple_response("ok")
+
+    config = StrongholdConfig(
+        providers={
+            "test": {"status": "active", "billing_cycle": "monthly", "free_tokens": 1000000},
+        },
+        models={
+            "test-model": {
+                "provider": "test",
+                "litellm_id": "test/model",
+                "tier": "medium",
+                "quality": 0.7,
+                "speed": 500,
+                "strengths": ["code"],
+            },
+        },
+        task_types={
+            "chat": TaskTypeConfig(keywords=["hello"], preferred_strengths=["chat"]),
+        },
+        permissions={"admin": ["*"]},
+        router_api_key="sk-test",
+    )
+
+    prompts = InMemoryPromptManager()
+    learning_store = InMemoryLearningStore()
+    warden = Warden()
+    context_builder = ContextBuilder()
+    batch_manager = InMemoryBatchManager()
+
+    async def setup() -> Container:
+        await prompts.upsert("agent.arbiter.soul", "You are helpful.", label="production")
+
+        default_agent = Agent(
+            identity=AgentIdentity(
+                name="arbiter",
+                soul_prompt_name="agent.arbiter.soul",
+                model="test/model",
+                memory_config={"learnings": True},
+            ),
+            strategy=DirectStrategy(),
+            llm=fake_llm,
+            context_builder=context_builder,
+            prompt_manager=prompts,
+            warden=warden,
+            learning_store=learning_store,
+        )
+
+        return Container(
+            config=config,
+            auth_provider=StaticKeyAuthProvider(api_key="sk-test"),
+            permission_table=PermissionTable.from_config({"admin": ["*"]}),
+            router=RouterEngine(InMemoryQuotaTracker()),
+            classifier=ClassifierEngine(),
+            quota_tracker=InMemoryQuotaTracker(),
+            prompt_manager=prompts,
+            learning_store=learning_store,
+            learning_extractor=ToolCorrectionExtractor(),
+            outcome_store=InMemoryOutcomeStore(),
+            session_store=InMemorySessionStore(),
+            audit_log=InMemoryAuditLog(),
+            warden=warden,
+            gate=Gate(warden=warden),
+            sentinel=Sentinel(
+                warden=warden,
+                permission_table=PermissionTable.from_config(config.permissions),
+                audit_log=InMemoryAuditLog(),
+            ),
+            tracer=NoopTracingBackend(),
+            context_builder=context_builder,
+            intent_registry=IntentRegistry(),
+            llm=fake_llm,
+            tool_registry=InMemoryToolRegistry(),
+            tool_dispatcher=ToolDispatcher(InMemoryToolRegistry()),
+            task_queue=InMemoryTaskQueue(),
+            batch_manager=batch_manager,
+            agents={"arbiter": default_agent},
+        )
+
+    container = asyncio.get_event_loop().run_until_complete(setup())
+    app.state.container = container
+    return app
+
+
+class TestSubmitBatchTask:
+    def test_submit_returns_200_with_task_id(self, batch_app: FastAPI) -> None:
+        with TestClient(batch_app) as client:
+            resp = client.post(
+                "/v1/stronghold/batch/tasks",
+                json={"messages": [{"role": "user", "content": "hello"}]},
+                headers={"Authorization": "Bearer sk-test"},
+            )
+            assert resp.status_code == 200
+            data = resp.json()
+            assert "task_id" in data
+            assert data["status"] == "submitted"
+
+    def test_submit_empty_messages_returns_400(self, batch_app: FastAPI) -> None:
+        with TestClient(batch_app) as client:
+            resp = client.post(
+                "/v1/stronghold/batch/tasks",
+                json={"messages": []},
+                headers={"Authorization": "Bearer sk-test"},
+            )
+            assert resp.status_code == 400
+
+    def test_submit_requires_auth(self, batch_app: FastAPI) -> None:
+        with TestClient(batch_app) as client:
+            resp = client.post(
+                "/v1/stronghold/batch/tasks",
+                json={"messages": [{"role": "user", "content": "hello"}]},
+            )
+            assert resp.status_code == 401
+
+    def test_submit_with_callback_url(self, batch_app: FastAPI) -> None:
+        with TestClient(batch_app) as client:
+            resp = client.post(
+                "/v1/stronghold/batch/tasks",
+                json={
+                    "messages": [{"role": "user", "content": "hello"}],
+                    "callback_url": "https://example.com/webhook",
+                },
+                headers={"Authorization": "Bearer sk-test"},
+            )
+            assert resp.status_code == 200
+            assert "task_id" in resp.json()
+
+
+class TestPollBatchTask:
+    def test_poll_returns_task_status(self, batch_app: FastAPI) -> None:
+        with TestClient(batch_app) as client:
+            # Submit first
+            submit_resp = client.post(
+                "/v1/stronghold/batch/tasks",
+                json={"messages": [{"role": "user", "content": "hello"}]},
+                headers={"Authorization": "Bearer sk-test"},
+            )
+            task_id = submit_resp.json()["task_id"]
+
+            # Poll
+            resp = client.get(
+                f"/v1/stronghold/batch/tasks/{task_id}",
+                headers={"Authorization": "Bearer sk-test"},
+            )
+            assert resp.status_code == 200
+            data = resp.json()
+            assert data["task_id"] == task_id
+            assert data["status"] == "submitted"
+            assert "created_at" in data
+
+    def test_poll_nonexistent_returns_404(self, batch_app: FastAPI) -> None:
+        with TestClient(batch_app) as client:
+            resp = client.get(
+                "/v1/stronghold/batch/tasks/nonexistent",
+                headers={"Authorization": "Bearer sk-test"},
+            )
+            assert resp.status_code == 404
+
+    def test_poll_requires_auth(self, batch_app: FastAPI) -> None:
+        with TestClient(batch_app) as client:
+            resp = client.get("/v1/stronghold/batch/tasks/some-id")
+            assert resp.status_code == 401
+
+
+class TestListBatchTasks:
+    def test_list_returns_user_tasks(self, batch_app: FastAPI) -> None:
+        with TestClient(batch_app) as client:
+            # Submit two tasks
+            client.post(
+                "/v1/stronghold/batch/tasks",
+                json={"messages": [{"role": "user", "content": "task 1"}]},
+                headers={"Authorization": "Bearer sk-test"},
+            )
+            client.post(
+                "/v1/stronghold/batch/tasks",
+                json={"messages": [{"role": "user", "content": "task 2"}]},
+                headers={"Authorization": "Bearer sk-test"},
+            )
+
+            resp = client.get(
+                "/v1/stronghold/batch/tasks",
+                headers={"Authorization": "Bearer sk-test"},
+            )
+            assert resp.status_code == 200
+            data = resp.json()
+            assert "tasks" in data
+            assert len(data["tasks"]) >= 2
+
+    def test_list_requires_auth(self, batch_app: FastAPI) -> None:
+        with TestClient(batch_app) as client:
+            resp = client.get("/v1/stronghold/batch/tasks")
+            assert resp.status_code == 401
+
+
+class TestCancelBatchTask:
+    def test_cancel_returns_200(self, batch_app: FastAPI) -> None:
+        with TestClient(batch_app) as client:
+            # Submit
+            submit_resp = client.post(
+                "/v1/stronghold/batch/tasks",
+                json={"messages": [{"role": "user", "content": "hello"}]},
+                headers={"Authorization": "Bearer sk-test"},
+            )
+            task_id = submit_resp.json()["task_id"]
+
+            # Cancel
+            resp = client.delete(
+                f"/v1/stronghold/batch/tasks/{task_id}",
+                headers={"Authorization": "Bearer sk-test"},
+            )
+            assert resp.status_code == 200
+            assert resp.json()["status"] == "cancelled"
+
+    def test_cancel_nonexistent_returns_404(self, batch_app: FastAPI) -> None:
+        with TestClient(batch_app) as client:
+            resp = client.delete(
+                "/v1/stronghold/batch/tasks/nonexistent",
+                headers={"Authorization": "Bearer sk-test"},
+            )
+            assert resp.status_code == 404
+
+    def test_cancel_requires_auth(self, batch_app: FastAPI) -> None:
+        with TestClient(batch_app) as client:
+            resp = client.delete("/v1/stronghold/batch/tasks/some-id")
+            assert resp.status_code == 401


### PR DESCRIPTION
Closes #143. InMemoryBatchManager + 4 API routes (submit, list, poll, cancel). Org-scoped, auth required. 31 tests.