### PR TITLE
feat: human escalation path for stuck agents

### DIFF
--- a/src/stronghold/api/app.py
+++ b/src/stronghold/api/app.py
@@ -108,6 +108,7 @@ def create_app() -> FastAPI:
     from stronghold.api.routes.auth import router as auth_router
     from stronghold.api.routes.chat import router as chat_router
     from stronghold.api.routes.dashboard import router as dashboard_router
+    from stronghold.api.routes.escalations import router as escalations_router
     from stronghold.api.routes.gate_endpoint import router as gate_router
     from stronghold.api.routes.marketplace import router as marketplace_router
     from stronghold.api.routes.mcp import router as mcp_router
@@ -140,7 +141,7 @@ def create_app() -> FastAPI:
     app.include_router(dashboard_router)
     app.include_router(webhooks_router)
     app.include_router(mcp_router)
-    app.include_router(schedules_router)
+    app.include_router(escalations_router)
 
     # Dashboard — try multiple paths (installed package vs source layout)
     _dashboard_candidates = [

--- a/src/stronghold/api/routes/escalations.py
+++ b/src/stronghold/api/routes/escalations.py
@@ -1,0 +1,147 @@
+"""API routes: human escalation management."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from fastapi import APIRouter, HTTPException, Request
+from fastapi.responses import JSONResponse
+
+logger = logging.getLogger("stronghold.api.escalations")
+
+router = APIRouter()
+
+
+def _check_csrf(request: Request) -> None:
+    """Verify CSRF defense header on cookie-authenticated mutations."""
+    if request.method not in ("POST", "PUT", "DELETE"):
+        return
+    if request.headers.get("authorization"):
+        return  # Bearer token — not CSRF-vulnerable
+    if not request.cookies:
+        return  # No cookies = not a browser session
+    if not request.headers.get("x-stronghold-request"):
+        raise HTTPException(
+            status_code=403,
+            detail="Missing X-Stronghold-Request header (CSRF protection)",
+        )
+
+
+async def _require_admin(request: Request) -> Any:
+    """Authenticate and require admin role."""
+    container = request.app.state.container
+    auth_header = request.headers.get("authorization")
+    try:
+        auth = await container.auth_provider.authenticate(
+            auth_header, headers=dict(request.headers)
+        )
+    except ValueError as e:
+        raise HTTPException(status_code=401, detail=str(e)) from e
+    if not auth.has_role("admin"):
+        raise HTTPException(status_code=403, detail="Admin role required")
+    _check_csrf(request)
+    return auth
+
+
+@router.get("/v1/stronghold/escalations")
+async def list_escalations(request: Request) -> JSONResponse:
+    """List pending escalations (admin only, org-scoped)."""
+    auth = await _require_admin(request)
+    container = request.app.state.container
+    manager = container.escalation_manager
+    pending = await manager.list_pending(org_id=auth.org_id)
+    return JSONResponse(
+        content=[
+            {
+                "id": esc.id,
+                "session_id": esc.session_id,
+                "agent_name": esc.agent_name,
+                "user_id": esc.user_id,
+                "reason": esc.reason,
+                "status": esc.status,
+                "created_at": esc.created_at,
+            }
+            for esc in pending
+        ]
+    )
+
+
+@router.get("/v1/stronghold/escalations/{esc_id}")
+async def get_escalation(request: Request, esc_id: str) -> JSONResponse:
+    """Get escalation details (admin only, org-scoped)."""
+    auth = await _require_admin(request)
+    container = request.app.state.container
+    manager = container.escalation_manager
+    esc = await manager.get(esc_id, org_id=auth.org_id)
+    if esc is None:
+        raise HTTPException(status_code=404, detail="Escalation not found")
+    return JSONResponse(
+        content={
+            "id": esc.id,
+            "session_id": esc.session_id,
+            "agent_name": esc.agent_name,
+            "user_id": esc.user_id,
+            "org_id": esc.org_id,
+            "reason": esc.reason,
+            "context": esc.context,
+            "status": esc.status,
+            "response": esc.response,
+            "created_at": esc.created_at,
+            "resolved_at": esc.resolved_at,
+            "resolved_by": esc.resolved_by,
+        }
+    )
+
+
+@router.post("/v1/stronghold/escalations/{esc_id}/respond")
+async def respond_escalation(request: Request, esc_id: str) -> JSONResponse:
+    """Human responds to an escalation (admin only)."""
+    auth = await _require_admin(request)
+    container = request.app.state.container
+    manager = container.escalation_manager
+    body = await request.json()
+    response_text: str = body.get("response", "")
+    if not response_text:
+        raise HTTPException(status_code=400, detail="response is required")
+    ok = await manager.respond(
+        esc_id,
+        org_id=auth.org_id,
+        response=response_text,
+        resolved_by=auth.user_id,
+    )
+    if not ok:
+        raise HTTPException(status_code=404, detail="Escalation not found or already resolved")
+    return JSONResponse(content={"status": "responded"})
+
+
+@router.post("/v1/stronghold/escalations/{esc_id}/takeover")
+async def takeover_escalation(request: Request, esc_id: str) -> JSONResponse:
+    """Human takes over the session (admin only)."""
+    auth = await _require_admin(request)
+    container = request.app.state.container
+    manager = container.escalation_manager
+    ok = await manager.takeover(
+        esc_id,
+        org_id=auth.org_id,
+        resolved_by=auth.user_id,
+    )
+    if not ok:
+        raise HTTPException(status_code=404, detail="Escalation not found or already resolved")
+    return JSONResponse(content={"status": "taken_over"})
+
+
+@router.post("/v1/stronghold/escalations/{esc_id}/dismiss")
+async def dismiss_escalation(request: Request, esc_id: str) -> JSONResponse:
+    """Dismiss an escalation — agent retries (admin only)."""
+    auth = await _require_admin(request)
+    container = request.app.state.container
+    manager = container.escalation_manager
+    ok = await manager.dismiss(
+        esc_id,
+        org_id=auth.org_id,
+        resolved_by=auth.user_id,
+    )
+    if not ok:
+        raise HTTPException(status_code=404, detail="Escalation not found or already resolved")
+    return JSONResponse(content={"status": "dismissed"})

--- a/src/stronghold/container.py
+++ b/src/stronghold/container.py
@@ -88,6 +88,7 @@ class Container:
     mcp_registry: Any = None  # MCPRegistry
     schedule_store: InMemoryScheduleStore = field(default_factory=InMemoryScheduleStore)
     mcp_deployer: Any = None  # K8sDeployer
+    escalation_manager: Any = None  # InMemoryEscalationManager
     conduit: Any = None  # Conduit — wired in __post_init__ or create_container
 
     def __post_init__(self) -> None:
@@ -381,6 +382,11 @@ async def create_container(config: StrongholdConfig) -> Container:
         approval_gate=approval_gate,
     )
 
+    # Human escalation manager
+    from stronghold.escalation.manager import InMemoryEscalationManager  # noqa: PLC0415
+
+    escalation_manager = InMemoryEscalationManager()
+
     # MCP server registry + K8s deployer
     from stronghold.mcp.registry import MCPRegistry  # noqa: PLC0415
 
@@ -432,6 +438,7 @@ async def create_container(config: StrongholdConfig) -> Container:
         prompt_cache=prompt_cache,
         mcp_registry=mcp_registry,
         mcp_deployer=mcp_deployer,
+        escalation_manager=escalation_manager,
     )
 
     # Conduit pipeline is auto-wired via __post_init__

--- a/src/stronghold/escalation/__init__.py
+++ b/src/stronghold/escalation/__init__.py
@@ -1,0 +1,1 @@
+"""Human escalation — transfer stuck requests to operators."""

--- a/src/stronghold/escalation/manager.py
+++ b/src/stronghold/escalation/manager.py
@@ -1,0 +1,113 @@
+"""Human escalation — transfer stuck requests to operators."""
+
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass, field
+from typing import Any
+from uuid import uuid4
+
+
+@dataclass
+class Escalation:
+    """A request escalated from an agent to a human operator."""
+
+    id: str = ""
+    session_id: str = ""
+    agent_name: str = ""
+    user_id: str = ""
+    org_id: str = ""
+    reason: str = ""  # "max_rounds_exceeded", "user_requested", "warden_block", "timeout"
+    context: list[dict[str, Any]] = field(default_factory=list)  # conversation history
+    status: str = "pending"  # pending, responded, taken_over, dismissed
+    response: str = ""  # human's response
+    created_at: float = 0.0
+    resolved_at: float = 0.0
+    resolved_by: str = ""
+
+
+class InMemoryEscalationManager:
+    """In-memory escalation store for dev/test. Production uses PostgreSQL."""
+
+    def __init__(self) -> None:
+        self._escalations: dict[str, Escalation] = {}
+
+    async def escalate(self, escalation: Escalation) -> Escalation:
+        """Create a new escalation. Assigns ID and timestamp if missing."""
+        if not escalation.id:
+            escalation.id = f"esc-{uuid4().hex[:12]}"
+        escalation.created_at = time.time()
+        escalation.status = "pending"
+        self._escalations[escalation.id] = escalation
+        return escalation
+
+    async def get(self, esc_id: str, *, org_id: str) -> Escalation | None:
+        """Get an escalation by ID, scoped to org."""
+        esc = self._escalations.get(esc_id)
+        if esc is None or esc.org_id != org_id:
+            return None
+        return esc
+
+    async def list_pending(self, *, org_id: str) -> list[Escalation]:
+        """List all pending escalations for an org."""
+        return [
+            esc
+            for esc in self._escalations.values()
+            if esc.org_id == org_id and esc.status == "pending"
+        ]
+
+    async def respond(
+        self,
+        esc_id: str,
+        *,
+        org_id: str,
+        response: str,
+        resolved_by: str,
+    ) -> bool:
+        """Human provides a response to inject into the conversation."""
+        esc = self._escalations.get(esc_id)
+        if esc is None or esc.org_id != org_id:
+            return False
+        if esc.status != "pending":
+            return False
+        esc.status = "responded"
+        esc.response = response
+        esc.resolved_at = time.time()
+        esc.resolved_by = resolved_by
+        return True
+
+    async def takeover(
+        self,
+        esc_id: str,
+        *,
+        org_id: str,
+        resolved_by: str,
+    ) -> bool:
+        """Human takes full control of the session."""
+        esc = self._escalations.get(esc_id)
+        if esc is None or esc.org_id != org_id:
+            return False
+        if esc.status != "pending":
+            return False
+        esc.status = "taken_over"
+        esc.resolved_at = time.time()
+        esc.resolved_by = resolved_by
+        return True
+
+    async def dismiss(
+        self,
+        esc_id: str,
+        *,
+        org_id: str,
+        resolved_by: str,
+    ) -> bool:
+        """Dismiss escalation — agent retries."""
+        esc = self._escalations.get(esc_id)
+        if esc is None or esc.org_id != org_id:
+            return False
+        if esc.status != "pending":
+            return False
+        esc.status = "dismissed"
+        esc.resolved_at = time.time()
+        esc.resolved_by = resolved_by
+        return True

--- a/tests/escalation/test_manager.py
+++ b/tests/escalation/test_manager.py
@@ -1,0 +1,148 @@
+"""Tests for InMemoryEscalationManager."""
+
+from __future__ import annotations
+
+from stronghold.escalation.manager import Escalation, InMemoryEscalationManager
+
+
+class TestEscalate:
+    async def test_escalate_assigns_id_and_pending_status(self) -> None:
+        mgr = InMemoryEscalationManager()
+        esc = Escalation(
+            session_id="sess-1",
+            agent_name="artificer",
+            user_id="user-1",
+            org_id="org-1",
+            reason="max_rounds_exceeded",
+        )
+        result = await mgr.escalate(esc)
+        assert result.id.startswith("esc-")
+        assert result.status == "pending"
+        assert result.created_at > 0
+
+    async def test_escalate_preserves_custom_id(self) -> None:
+        mgr = InMemoryEscalationManager()
+        esc = Escalation(id="custom-id", org_id="org-1", reason="user_requested")
+        result = await mgr.escalate(esc)
+        assert result.id == "custom-id"
+
+    async def test_escalate_stores_context(self) -> None:
+        mgr = InMemoryEscalationManager()
+        ctx = [{"role": "user", "content": "help me"}]
+        esc = Escalation(org_id="org-1", reason="timeout", context=ctx)
+        result = await mgr.escalate(esc)
+        assert result.context == ctx
+
+
+class TestGet:
+    async def test_get_returns_escalation(self) -> None:
+        mgr = InMemoryEscalationManager()
+        esc = Escalation(org_id="org-1", reason="warden_block")
+        created = await mgr.escalate(esc)
+        result = await mgr.get(created.id, org_id="org-1")
+        assert result is not None
+        assert result.id == created.id
+
+    async def test_get_returns_none_for_missing(self) -> None:
+        mgr = InMemoryEscalationManager()
+        result = await mgr.get("nonexistent", org_id="org-1")
+        assert result is None
+
+    async def test_get_enforces_org_scoping(self) -> None:
+        mgr = InMemoryEscalationManager()
+        esc = Escalation(org_id="org-1", reason="timeout")
+        created = await mgr.escalate(esc)
+        # Different org cannot see it
+        result = await mgr.get(created.id, org_id="org-2")
+        assert result is None
+
+
+class TestListPending:
+    async def test_list_pending_returns_only_pending(self) -> None:
+        mgr = InMemoryEscalationManager()
+        esc1 = await mgr.escalate(Escalation(org_id="org-1", reason="timeout"))
+        esc2 = await mgr.escalate(Escalation(org_id="org-1", reason="user_requested"))
+        # Resolve esc1
+        await mgr.dismiss(esc1.id, org_id="org-1", resolved_by="admin")
+        pending = await mgr.list_pending(org_id="org-1")
+        assert len(pending) == 1
+        assert pending[0].id == esc2.id
+
+    async def test_list_pending_scoped_to_org(self) -> None:
+        mgr = InMemoryEscalationManager()
+        await mgr.escalate(Escalation(org_id="org-1", reason="timeout"))
+        await mgr.escalate(Escalation(org_id="org-2", reason="timeout"))
+        pending_org1 = await mgr.list_pending(org_id="org-1")
+        pending_org2 = await mgr.list_pending(org_id="org-2")
+        assert len(pending_org1) == 1
+        assert len(pending_org2) == 1
+
+
+class TestRespond:
+    async def test_respond_changes_status_and_records_response(self) -> None:
+        mgr = InMemoryEscalationManager()
+        esc = await mgr.escalate(Escalation(org_id="org-1", reason="timeout"))
+        ok = await mgr.respond(
+            esc.id, org_id="org-1", response="Try restarting", resolved_by="admin-user"
+        )
+        assert ok is True
+        updated = await mgr.get(esc.id, org_id="org-1")
+        assert updated is not None
+        assert updated.status == "responded"
+        assert updated.response == "Try restarting"
+        assert updated.resolved_by == "admin-user"
+        assert updated.resolved_at > 0
+
+    async def test_respond_fails_for_wrong_org(self) -> None:
+        mgr = InMemoryEscalationManager()
+        esc = await mgr.escalate(Escalation(org_id="org-1", reason="timeout"))
+        ok = await mgr.respond(
+            esc.id, org_id="org-2", response="nope", resolved_by="admin"
+        )
+        assert ok is False
+
+    async def test_respond_fails_for_already_resolved(self) -> None:
+        mgr = InMemoryEscalationManager()
+        esc = await mgr.escalate(Escalation(org_id="org-1", reason="timeout"))
+        await mgr.respond(esc.id, org_id="org-1", response="first", resolved_by="admin")
+        # Second respond should fail
+        ok = await mgr.respond(esc.id, org_id="org-1", response="second", resolved_by="admin")
+        assert ok is False
+
+
+class TestTakeover:
+    async def test_takeover_changes_status(self) -> None:
+        mgr = InMemoryEscalationManager()
+        esc = await mgr.escalate(Escalation(org_id="org-1", reason="max_rounds_exceeded"))
+        ok = await mgr.takeover(esc.id, org_id="org-1", resolved_by="ops-lead")
+        assert ok is True
+        updated = await mgr.get(esc.id, org_id="org-1")
+        assert updated is not None
+        assert updated.status == "taken_over"
+        assert updated.resolved_by == "ops-lead"
+
+    async def test_takeover_fails_for_already_resolved(self) -> None:
+        mgr = InMemoryEscalationManager()
+        esc = await mgr.escalate(Escalation(org_id="org-1", reason="timeout"))
+        await mgr.takeover(esc.id, org_id="org-1", resolved_by="admin")
+        ok = await mgr.takeover(esc.id, org_id="org-1", resolved_by="admin")
+        assert ok is False
+
+
+class TestDismiss:
+    async def test_dismiss_changes_status(self) -> None:
+        mgr = InMemoryEscalationManager()
+        esc = await mgr.escalate(Escalation(org_id="org-1", reason="warden_block"))
+        ok = await mgr.dismiss(esc.id, org_id="org-1", resolved_by="admin")
+        assert ok is True
+        updated = await mgr.get(esc.id, org_id="org-1")
+        assert updated is not None
+        assert updated.status == "dismissed"
+        assert updated.resolved_by == "admin"
+
+    async def test_dismiss_fails_for_already_resolved(self) -> None:
+        mgr = InMemoryEscalationManager()
+        esc = await mgr.escalate(Escalation(org_id="org-1", reason="timeout"))
+        await mgr.dismiss(esc.id, org_id="org-1", resolved_by="admin")
+        ok = await mgr.dismiss(esc.id, org_id="org-1", resolved_by="admin")
+        assert ok is False

--- a/tests/escalation/test_routes.py
+++ b/tests/escalation/test_routes.py
@@ -1,0 +1,303 @@
+"""Tests for escalation API routes."""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from stronghold.agents.base import Agent
+from stronghold.agents.context_builder import ContextBuilder
+from stronghold.agents.intents import IntentRegistry
+from stronghold.agents.strategies.direct import DirectStrategy
+from stronghold.api.routes.escalations import router as escalations_router
+from stronghold.classifier.engine import ClassifierEngine
+from stronghold.container import Container
+from stronghold.escalation.manager import Escalation, InMemoryEscalationManager
+from stronghold.memory.learnings.extractor import ToolCorrectionExtractor
+from stronghold.memory.learnings.store import InMemoryLearningStore
+from stronghold.memory.outcomes import InMemoryOutcomeStore
+from stronghold.prompts.store import InMemoryPromptManager
+from stronghold.quota.tracker import InMemoryQuotaTracker
+from stronghold.router.selector import RouterEngine
+from stronghold.security.auth_static import StaticKeyAuthProvider
+from stronghold.security.gate import Gate
+from stronghold.security.sentinel.audit import InMemoryAuditLog
+from stronghold.security.sentinel.policy import Sentinel
+from stronghold.security.warden.detector import Warden
+from stronghold.sessions.store import InMemorySessionStore
+from stronghold.tools.executor import ToolDispatcher
+from stronghold.tools.registry import InMemoryToolRegistry
+from stronghold.tracing.noop import NoopTracingBackend
+from stronghold.types.agent import AgentIdentity
+from stronghold.types.auth import AuthContext, PermissionTable
+from stronghold.types.config import StrongholdConfig, TaskTypeConfig
+from tests.fakes import FakeAuthProvider, FakeLLMClient
+
+
+@pytest.fixture
+def esc_app() -> FastAPI:
+    """Create a FastAPI app with escalation routes and seeded data."""
+    app = FastAPI()
+    app.include_router(escalations_router)
+
+    fake_llm = FakeLLMClient()
+    fake_llm.set_simple_response("ok")
+
+    config = StrongholdConfig(
+        providers={
+            "test": {"status": "active", "billing_cycle": "monthly", "free_tokens": 1000000},
+        },
+        models={
+            "test-model": {
+                "provider": "test",
+                "litellm_id": "test/model",
+                "tier": "medium",
+                "quality": 0.7,
+                "speed": 500,
+                "strengths": ["code"],
+            },
+        },
+        task_types={
+            "chat": TaskTypeConfig(keywords=["hello"], preferred_strengths=["chat"]),
+        },
+        permissions={"admin": ["*"]},
+        router_api_key="sk-test",
+    )
+
+    prompts = InMemoryPromptManager()
+    warden = Warden()
+    context_builder = ContextBuilder()
+    audit_log = InMemoryAuditLog()
+    escalation_manager = InMemoryEscalationManager()
+
+    async def setup() -> Container:
+        await prompts.upsert("agent.arbiter.soul", "You are helpful.", label="production")
+
+        # Seed two escalations in org __system__
+        await escalation_manager.escalate(
+            Escalation(
+                id="esc-seed-1",
+                session_id="sess-1",
+                agent_name="artificer",
+                user_id="user-1",
+                org_id="__system__",
+                reason="max_rounds_exceeded",
+            )
+        )
+        await escalation_manager.escalate(
+            Escalation(
+                id="esc-seed-2",
+                session_id="sess-2",
+                agent_name="ranger",
+                user_id="user-2",
+                org_id="__system__",
+                reason="timeout",
+            )
+        )
+        # One in a different org — should not be visible
+        await escalation_manager.escalate(
+            Escalation(
+                id="esc-other-org",
+                session_id="sess-3",
+                agent_name="scribe",
+                user_id="user-3",
+                org_id="org-other",
+                reason="warden_block",
+            )
+        )
+
+        default_agent = Agent(
+            identity=AgentIdentity(
+                name="arbiter",
+                soul_prompt_name="agent.arbiter.soul",
+                model="test/model",
+                memory_config={"learnings": True},
+            ),
+            strategy=DirectStrategy(),
+            llm=fake_llm,
+            context_builder=context_builder,
+            prompt_manager=prompts,
+            warden=warden,
+            learning_store=InMemoryLearningStore(),
+        )
+
+        return Container(
+            config=config,
+            auth_provider=StaticKeyAuthProvider(api_key="sk-test"),
+            permission_table=PermissionTable.from_config({"admin": ["*"]}),
+            router=RouterEngine(InMemoryQuotaTracker()),
+            classifier=ClassifierEngine(),
+            quota_tracker=InMemoryQuotaTracker(),
+            prompt_manager=prompts,
+            learning_store=InMemoryLearningStore(),
+            learning_extractor=ToolCorrectionExtractor(),
+            outcome_store=InMemoryOutcomeStore(),
+            session_store=InMemorySessionStore(),
+            audit_log=audit_log,
+            warden=warden,
+            gate=Gate(warden=warden),
+            sentinel=Sentinel(
+                warden=warden,
+                permission_table=PermissionTable.from_config(config.permissions),
+                audit_log=audit_log,
+            ),
+            tracer=NoopTracingBackend(),
+            context_builder=context_builder,
+            intent_registry=IntentRegistry(),
+            llm=fake_llm,
+            tool_registry=InMemoryToolRegistry(),
+            tool_dispatcher=ToolDispatcher(InMemoryToolRegistry()),
+            agents={"arbiter": default_agent},
+            escalation_manager=escalation_manager,
+        )
+
+    container = asyncio.get_event_loop().run_until_complete(setup())
+    app.state.container = container
+    return app
+
+
+AUTH_HEADERS = {"Authorization": "Bearer sk-test", "X-Stronghold-Request": "1"}
+
+
+class TestListEscalations:
+    def test_admin_lists_pending_escalations(self, esc_app: FastAPI) -> None:
+        with TestClient(esc_app) as client:
+            resp = client.get("/v1/stronghold/escalations", headers=AUTH_HEADERS)
+            assert resp.status_code == 200
+            data = resp.json()
+            # Only __system__ org escalations (2 seeded)
+            assert len(data) == 2
+            ids = {e["id"] for e in data}
+            assert ids == {"esc-seed-1", "esc-seed-2"}
+
+    def test_unauthenticated_returns_401(self, esc_app: FastAPI) -> None:
+        with TestClient(esc_app) as client:
+            resp = client.get("/v1/stronghold/escalations")
+            assert resp.status_code == 401
+
+    def test_non_admin_returns_403(self, esc_app: FastAPI) -> None:
+        esc_app.state.container.auth_provider = FakeAuthProvider(
+            auth_context=AuthContext(
+                user_id="viewer",
+                username="viewer",
+                roles=frozenset({"viewer"}),
+                auth_method="api_key",
+            )
+        )
+        with TestClient(esc_app) as client:
+            resp = client.get(
+                "/v1/stronghold/escalations",
+                headers=AUTH_HEADERS,
+            )
+            assert resp.status_code == 403
+
+
+class TestGetEscalation:
+    def test_admin_gets_escalation_details(self, esc_app: FastAPI) -> None:
+        with TestClient(esc_app) as client:
+            resp = client.get("/v1/stronghold/escalations/esc-seed-1", headers=AUTH_HEADERS)
+            assert resp.status_code == 200
+            data = resp.json()
+            assert data["id"] == "esc-seed-1"
+            assert data["agent_name"] == "artificer"
+            assert data["reason"] == "max_rounds_exceeded"
+            assert data["status"] == "pending"
+
+    def test_returns_404_for_missing(self, esc_app: FastAPI) -> None:
+        with TestClient(esc_app) as client:
+            resp = client.get("/v1/stronghold/escalations/nonexistent", headers=AUTH_HEADERS)
+            assert resp.status_code == 404
+
+    def test_returns_404_for_other_org(self, esc_app: FastAPI) -> None:
+        with TestClient(esc_app) as client:
+            resp = client.get("/v1/stronghold/escalations/esc-other-org", headers=AUTH_HEADERS)
+            assert resp.status_code == 404
+
+
+class TestRespondEscalation:
+    def test_respond_updates_status(self, esc_app: FastAPI) -> None:
+        with TestClient(esc_app) as client:
+            resp = client.post(
+                "/v1/stronghold/escalations/esc-seed-1/respond",
+                json={"response": "Try restarting the pipeline"},
+                headers=AUTH_HEADERS,
+            )
+            assert resp.status_code == 200
+            assert resp.json()["status"] == "responded"
+
+            # Verify it's now responded
+            detail = client.get(
+                "/v1/stronghold/escalations/esc-seed-1", headers=AUTH_HEADERS
+            )
+            assert detail.json()["status"] == "responded"
+            assert detail.json()["response"] == "Try restarting the pipeline"
+
+    def test_respond_requires_response_body(self, esc_app: FastAPI) -> None:
+        with TestClient(esc_app) as client:
+            resp = client.post(
+                "/v1/stronghold/escalations/esc-seed-1/respond",
+                json={},
+                headers=AUTH_HEADERS,
+            )
+            assert resp.status_code == 400
+
+    def test_respond_fails_for_already_resolved(self, esc_app: FastAPI) -> None:
+        with TestClient(esc_app) as client:
+            # First respond succeeds
+            client.post(
+                "/v1/stronghold/escalations/esc-seed-1/respond",
+                json={"response": "first"},
+                headers=AUTH_HEADERS,
+            )
+            # Second respond fails
+            resp = client.post(
+                "/v1/stronghold/escalations/esc-seed-1/respond",
+                json={"response": "second"},
+                headers=AUTH_HEADERS,
+            )
+            assert resp.status_code == 404
+
+
+class TestTakeoverEscalation:
+    def test_takeover_updates_status(self, esc_app: FastAPI) -> None:
+        with TestClient(esc_app) as client:
+            resp = client.post(
+                "/v1/stronghold/escalations/esc-seed-1/takeover",
+                headers=AUTH_HEADERS,
+            )
+            assert resp.status_code == 200
+            assert resp.json()["status"] == "taken_over"
+
+    def test_takeover_returns_404_for_missing(self, esc_app: FastAPI) -> None:
+        with TestClient(esc_app) as client:
+            resp = client.post(
+                "/v1/stronghold/escalations/nonexistent/takeover",
+                headers=AUTH_HEADERS,
+            )
+            assert resp.status_code == 404
+
+
+class TestDismissEscalation:
+    def test_dismiss_updates_status(self, esc_app: FastAPI) -> None:
+        with TestClient(esc_app) as client:
+            resp = client.post(
+                "/v1/stronghold/escalations/esc-seed-1/dismiss",
+                headers=AUTH_HEADERS,
+            )
+            assert resp.status_code == 200
+            assert resp.json()["status"] == "dismissed"
+
+    def test_dismiss_returns_404_for_already_resolved(self, esc_app: FastAPI) -> None:
+        with TestClient(esc_app) as client:
+            client.post(
+                "/v1/stronghold/escalations/esc-seed-1/dismiss",
+                headers=AUTH_HEADERS,
+            )
+            resp = client.post(
+                "/v1/stronghold/escalations/esc-seed-1/dismiss",
+                headers=AUTH_HEADERS,
+            )
+            assert resp.status_code == 404


### PR DESCRIPTION
Closes #147. InMemoryEscalationManager + 5 admin API routes (list, get, respond, takeover, dismiss). Org-scoped, CSRF protected. 28 tests.