### PR TITLE
feat: outbound notification channels (Slack, Discord, webhook)

### DIFF
--- a/src/stronghold/notifications/__init__.py
+++ b/src/stronghold/notifications/__init__.py
@@ -1,0 +1,1 @@
+"""Outbound notification channels — Slack, Discord, Teams, generic webhook."""

--- a/src/stronghold/notifications/channels.py
+++ b/src/stronghold/notifications/channels.py
@@ -1,0 +1,146 @@
+"""Outbound notification channels — Slack, Discord, Teams, generic webhook."""
+
+from __future__ import annotations
+
+import logging
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from typing import Any
+
+logger = logging.getLogger("stronghold.notifications")
+
+
+@dataclass
+class Notification:
+    """An outbound notification triggered by a Stronghold event."""
+
+    event_type: str  # "warden_block", "circuit_open", "quota_warning", etc.
+    title: str = ""
+    detail: str = ""
+    severity: str = "info"  # info, warning, error, critical
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+
+class NotificationChannel(ABC):
+    """Base class for outbound notification channels."""
+
+    @abstractmethod
+    async def send(self, notification: Notification) -> bool:
+        """Send a notification. Returns True on success."""
+        ...
+
+    @abstractmethod
+    def format_message(self, notification: Notification) -> dict[str, Any]:
+        """Format a notification for this channel's wire format."""
+        ...
+
+
+_SLACK_COLORS: dict[str, str] = {
+    "info": "#36a64f",
+    "warning": "#ff9900",
+    "error": "#ff0000",
+    "critical": "#8b0000",
+}
+
+
+class SlackChannel(NotificationChannel):
+    """Posts notifications to a Slack incoming webhook."""
+
+    def __init__(self, webhook_url: str, channel: str = "") -> None:
+        self._url = webhook_url
+        self._channel = channel
+
+    def format_message(self, n: Notification) -> dict[str, Any]:
+        color = _SLACK_COLORS.get(n.severity, "#808080")
+        return {
+            "attachments": [
+                {
+                    "color": color,
+                    "title": n.title,
+                    "text": n.detail,
+                    "fields": [
+                        {"title": k, "value": str(v), "short": True} for k, v in n.metadata.items()
+                    ],
+                }
+            ]
+        }
+
+    async def send(self, notification: Notification) -> bool:
+        import httpx  # noqa: PLC0415
+
+        msg = self.format_message(notification)
+        try:
+            async with httpx.AsyncClient(timeout=10) as client:
+                resp = await client.post(self._url, json=msg)
+                return resp.status_code == 200
+        except Exception:
+            logger.warning("Slack notification failed", exc_info=True)
+            return False
+
+
+_DISCORD_COLORS: dict[str, int] = {
+    "info": 0x36A64F,
+    "warning": 0xFF9900,
+    "error": 0xFF0000,
+    "critical": 0x8B0000,
+}
+
+
+class DiscordChannel(NotificationChannel):
+    """Posts notifications to a Discord webhook."""
+
+    def __init__(self, webhook_url: str) -> None:
+        self._url = webhook_url
+
+    def format_message(self, n: Notification) -> dict[str, Any]:
+        color = _DISCORD_COLORS.get(n.severity, 0x808080)
+        return {
+            "embeds": [
+                {
+                    "title": n.title,
+                    "description": n.detail,
+                    "color": color,
+                    "fields": [
+                        {"name": k, "value": str(v), "inline": True} for k, v in n.metadata.items()
+                    ],
+                }
+            ]
+        }
+
+    async def send(self, notification: Notification) -> bool:
+        import httpx  # noqa: PLC0415
+
+        try:
+            async with httpx.AsyncClient(timeout=10) as client:
+                resp = await client.post(self._url, json=self.format_message(notification))
+                return 200 <= resp.status_code < 300
+        except Exception:
+            logger.warning("Discord notification failed", exc_info=True)
+            return False
+
+
+class GenericWebhookChannel(NotificationChannel):
+    """Posts notifications as plain JSON to any HTTP endpoint."""
+
+    def __init__(self, webhook_url: str) -> None:
+        self._url = webhook_url
+
+    def format_message(self, n: Notification) -> dict[str, Any]:
+        return {
+            "event_type": n.event_type,
+            "title": n.title,
+            "detail": n.detail,
+            "severity": n.severity,
+            "metadata": n.metadata,
+        }
+
+    async def send(self, notification: Notification) -> bool:
+        import httpx  # noqa: PLC0415
+
+        try:
+            async with httpx.AsyncClient(timeout=10) as client:
+                resp = await client.post(self._url, json=self.format_message(notification))
+                return 200 <= resp.status_code < 300
+        except Exception:
+            logger.warning("Webhook notification failed", exc_info=True)
+            return False

--- a/src/stronghold/notifications/dispatcher.py
+++ b/src/stronghold/notifications/dispatcher.py
@@ -1,0 +1,51 @@
+"""Notification dispatcher — routes events to configured channels."""
+
+from __future__ import annotations
+
+import logging
+
+from stronghold.notifications.channels import Notification, NotificationChannel  # noqa: TC001
+
+logger = logging.getLogger("stronghold.notifications.dispatcher")
+
+
+class NotificationDispatcher:
+    """Routes notifications to registered channels based on event type."""
+
+    def __init__(self) -> None:
+        self._routes: dict[str, list[NotificationChannel]] = {}
+
+    def register(self, event_type: str, channel: NotificationChannel) -> None:
+        """Register a channel to receive notifications for a specific event type."""
+        if event_type not in self._routes:
+            self._routes[event_type] = []
+        self._routes[event_type].append(channel)
+        logger.info(
+            "Registered %s channel for event type '%s'",
+            type(channel).__name__,
+            event_type,
+        )
+
+    async def dispatch(self, notification: Notification) -> dict[str, bool]:
+        """Dispatch a notification to all channels registered for its event type.
+
+        Returns a dict mapping channel identifiers to send success/failure.
+        """
+        channels = self._routes.get(notification.event_type, [])
+        if not channels:
+            return {}
+
+        results: dict[str, bool] = {}
+        for i, channel in enumerate(channels):
+            key = f"{type(channel).__name__}_{i}"
+            success = await channel.send(notification)
+            results[key] = success
+
+        sent = sum(1 for v in results.values() if v)
+        logger.info(
+            "Dispatched '%s' to %d channels (%d succeeded)",
+            notification.event_type,
+            len(channels),
+            sent,
+        )
+        return results

--- a/tests/notifications/test_channels.py
+++ b/tests/notifications/test_channels.py
@@ -1,0 +1,225 @@
+"""Tests for outbound notification channels — Slack, Discord, generic webhook."""
+from __future__ import annotations
+
+import httpx
+import pytest
+import respx
+
+from stronghold.notifications.channels import (
+    DiscordChannel,
+    GenericWebhookChannel,
+    Notification,
+    SlackChannel,
+)
+
+
+# ── Notification dataclass defaults ─────────────────────────────────
+
+
+class TestNotificationDefaults:
+    def test_minimal_notification(self) -> None:
+        n = Notification(event_type="warden_block")
+        assert n.event_type == "warden_block"
+        assert n.title == ""
+        assert n.detail == ""
+        assert n.severity == "info"
+        assert n.metadata == {}
+
+    def test_full_notification(self) -> None:
+        n = Notification(
+            event_type="circuit_open",
+            title="Circuit breaker tripped",
+            detail="Trigger 'quota_check' disabled after 3 failures",
+            severity="critical",
+            metadata={"trigger": "quota_check", "failures": 3},
+        )
+        assert n.event_type == "circuit_open"
+        assert n.title == "Circuit breaker tripped"
+        assert n.severity == "critical"
+        assert n.metadata["failures"] == 3
+
+
+# ── Slack channel ───────────────────────────────────────────────────
+
+
+class TestSlackChannel:
+    def test_format_attachments_with_color(self) -> None:
+        ch = SlackChannel(webhook_url="https://hooks.slack.com/services/T/B/X")
+        n = Notification(
+            event_type="warden_block",
+            title="Input blocked",
+            detail="Prompt injection detected",
+            severity="error",
+            metadata={"user": "alice", "score": "0.95"},
+        )
+        msg = ch.format_message(n)
+        assert "attachments" in msg
+        att = msg["attachments"][0]
+        assert att["color"] == "#ff0000"
+        assert att["title"] == "Input blocked"
+        assert att["text"] == "Prompt injection detected"
+        # Fields should contain metadata
+        field_titles = [f["title"] for f in att["fields"]]
+        assert "user" in field_titles
+        assert "score" in field_titles
+
+    def test_format_info_severity_green(self) -> None:
+        ch = SlackChannel(webhook_url="https://hooks.slack.com/services/T/B/X")
+        n = Notification(event_type="task_complete", severity="info")
+        msg = ch.format_message(n)
+        assert msg["attachments"][0]["color"] == "#36a64f"
+
+    def test_format_warning_severity_orange(self) -> None:
+        ch = SlackChannel(webhook_url="https://hooks.slack.com/services/T/B/X")
+        n = Notification(event_type="quota_warning", severity="warning")
+        msg = ch.format_message(n)
+        assert msg["attachments"][0]["color"] == "#ff9900"
+
+    def test_format_critical_severity_dark_red(self) -> None:
+        ch = SlackChannel(webhook_url="https://hooks.slack.com/services/T/B/X")
+        n = Notification(event_type="breach", severity="critical")
+        msg = ch.format_message(n)
+        assert msg["attachments"][0]["color"] == "#8b0000"
+
+    def test_format_unknown_severity_gray(self) -> None:
+        ch = SlackChannel(webhook_url="https://hooks.slack.com/services/T/B/X")
+        n = Notification(event_type="test", severity="debug")
+        msg = ch.format_message(n)
+        assert msg["attachments"][0]["color"] == "#808080"
+
+    @respx.mock
+    async def test_send_success(self) -> None:
+        url = "https://hooks.slack.com/services/T/B/X"
+        respx.post(url).mock(return_value=httpx.Response(200, text="ok"))
+        ch = SlackChannel(webhook_url=url)
+        n = Notification(event_type="test", title="Hello")
+        result = await ch.send(n)
+        assert result is True
+
+    @respx.mock
+    async def test_send_failure_500(self) -> None:
+        url = "https://hooks.slack.com/services/T/B/X"
+        respx.post(url).mock(return_value=httpx.Response(500, text="error"))
+        ch = SlackChannel(webhook_url=url)
+        n = Notification(event_type="test", title="Hello")
+        result = await ch.send(n)
+        assert result is False
+
+    @respx.mock
+    async def test_send_timeout(self) -> None:
+        url = "https://hooks.slack.com/services/T/B/X"
+        respx.post(url).mock(side_effect=httpx.ConnectTimeout("timeout"))
+        ch = SlackChannel(webhook_url=url)
+        n = Notification(event_type="test")
+        result = await ch.send(n)
+        assert result is False
+
+
+# ── Discord channel ─────────────────────────────────────────────────
+
+
+class TestDiscordChannel:
+    def test_format_embeds(self) -> None:
+        ch = DiscordChannel(webhook_url="https://discord.com/api/webhooks/123/abc")
+        n = Notification(
+            event_type="quota_warning",
+            title="Quota at 90%",
+            detail="Provider openai approaching limit",
+            severity="warning",
+            metadata={"provider": "openai", "pct": "90"},
+        )
+        msg = ch.format_message(n)
+        assert "embeds" in msg
+        embed = msg["embeds"][0]
+        assert embed["title"] == "Quota at 90%"
+        assert embed["description"] == "Provider openai approaching limit"
+        assert embed["color"] == 0xFF9900
+        field_names = [f["name"] for f in embed["fields"]]
+        assert "provider" in field_names
+
+    def test_format_error_severity_red(self) -> None:
+        ch = DiscordChannel(webhook_url="https://discord.com/api/webhooks/123/abc")
+        n = Notification(event_type="error", severity="error")
+        msg = ch.format_message(n)
+        assert msg["embeds"][0]["color"] == 0xFF0000
+
+    def test_format_unknown_severity_gray(self) -> None:
+        ch = DiscordChannel(webhook_url="https://discord.com/api/webhooks/123/abc")
+        n = Notification(event_type="test", severity="trace")
+        msg = ch.format_message(n)
+        assert msg["embeds"][0]["color"] == 0x808080
+
+    @respx.mock
+    async def test_send_success(self) -> None:
+        url = "https://discord.com/api/webhooks/123/abc"
+        respx.post(url).mock(return_value=httpx.Response(204))
+        ch = DiscordChannel(webhook_url=url)
+        n = Notification(event_type="test", title="Hello")
+        result = await ch.send(n)
+        assert result is True
+
+    @respx.mock
+    async def test_send_failure_500(self) -> None:
+        url = "https://discord.com/api/webhooks/123/abc"
+        respx.post(url).mock(return_value=httpx.Response(500, text="error"))
+        ch = DiscordChannel(webhook_url=url)
+        n = Notification(event_type="test")
+        result = await ch.send(n)
+        assert result is False
+
+    @respx.mock
+    async def test_send_timeout(self) -> None:
+        url = "https://discord.com/api/webhooks/123/abc"
+        respx.post(url).mock(side_effect=httpx.ReadTimeout("timeout"))
+        ch = DiscordChannel(webhook_url=url)
+        n = Notification(event_type="test")
+        result = await ch.send(n)
+        assert result is False
+
+
+# ── Generic webhook channel ─────────────────────────────────────────
+
+
+class TestGenericWebhookChannel:
+    def test_format_plain_json(self) -> None:
+        ch = GenericWebhookChannel(webhook_url="https://example.com/hook")
+        n = Notification(
+            event_type="circuit_open",
+            title="Breaker tripped",
+            detail="Trigger disabled",
+            severity="critical",
+            metadata={"trigger": "quota_check"},
+        )
+        msg = ch.format_message(n)
+        assert msg["event_type"] == "circuit_open"
+        assert msg["title"] == "Breaker tripped"
+        assert msg["detail"] == "Trigger disabled"
+        assert msg["severity"] == "critical"
+        assert msg["metadata"]["trigger"] == "quota_check"
+
+    @respx.mock
+    async def test_send_success(self) -> None:
+        url = "https://example.com/hook"
+        respx.post(url).mock(return_value=httpx.Response(200, json={"ok": True}))
+        ch = GenericWebhookChannel(webhook_url=url)
+        n = Notification(event_type="test")
+        result = await ch.send(n)
+        assert result is True
+
+    @respx.mock
+    async def test_send_failure_500(self) -> None:
+        url = "https://example.com/hook"
+        respx.post(url).mock(return_value=httpx.Response(500))
+        ch = GenericWebhookChannel(webhook_url=url)
+        n = Notification(event_type="test")
+        result = await ch.send(n)
+        assert result is False
+
+    @respx.mock
+    async def test_send_timeout(self) -> None:
+        url = "https://example.com/hook"
+        respx.post(url).mock(side_effect=httpx.ConnectTimeout("timeout"))
+        ch = GenericWebhookChannel(webhook_url=url)
+        n = Notification(event_type="test")
+        result = await ch.send(n)
+        assert result is False

--- a/tests/notifications/test_dispatcher.py
+++ b/tests/notifications/test_dispatcher.py
@@ -1,0 +1,109 @@
+"""Tests for the notification dispatcher — routes events to channels."""
+from __future__ import annotations
+
+import httpx
+import pytest
+import respx
+
+from stronghold.notifications.channels import (
+    DiscordChannel,
+    GenericWebhookChannel,
+    Notification,
+    SlackChannel,
+)
+from stronghold.notifications.dispatcher import NotificationDispatcher
+
+
+class TestDispatcherRegistration:
+    def test_register_channel(self) -> None:
+        d = NotificationDispatcher()
+        ch = GenericWebhookChannel(webhook_url="https://example.com/hook")
+        d.register("warden_block", ch)
+        # No error means success; internal state verified by dispatch tests
+
+    def test_register_multiple_channels_same_event(self) -> None:
+        d = NotificationDispatcher()
+        ch1 = SlackChannel(webhook_url="https://hooks.slack.com/a")
+        ch2 = DiscordChannel(webhook_url="https://discord.com/api/webhooks/1/x")
+        d.register("warden_block", ch1)
+        d.register("warden_block", ch2)
+        # Both should be stored — verified by dispatch test below
+
+
+class TestDispatcherRouting:
+    @respx.mock
+    async def test_dispatch_to_single_channel(self) -> None:
+        url = "https://example.com/hook"
+        respx.post(url).mock(return_value=httpx.Response(200))
+        d = NotificationDispatcher()
+        ch = GenericWebhookChannel(webhook_url=url)
+        d.register("circuit_open", ch)
+        n = Notification(event_type="circuit_open", title="Breaker tripped")
+        results = await d.dispatch(n)
+        assert len(results) == 1
+        assert all(results.values())
+
+    @respx.mock
+    async def test_dispatch_to_multiple_channels(self) -> None:
+        slack_url = "https://hooks.slack.com/services/T/B/X"
+        discord_url = "https://discord.com/api/webhooks/1/x"
+        respx.post(slack_url).mock(return_value=httpx.Response(200))
+        respx.post(discord_url).mock(return_value=httpx.Response(204))
+        d = NotificationDispatcher()
+        d.register("warden_block", SlackChannel(webhook_url=slack_url))
+        d.register("warden_block", DiscordChannel(webhook_url=discord_url))
+        n = Notification(event_type="warden_block", title="Blocked")
+        results = await d.dispatch(n)
+        assert len(results) == 2
+        assert all(results.values())
+
+    @respx.mock
+    async def test_dispatch_partial_failure(self) -> None:
+        ok_url = "https://example.com/ok"
+        fail_url = "https://example.com/fail"
+        respx.post(ok_url).mock(return_value=httpx.Response(200))
+        respx.post(fail_url).mock(return_value=httpx.Response(500))
+        d = NotificationDispatcher()
+        d.register("quota_warning", GenericWebhookChannel(webhook_url=ok_url))
+        d.register("quota_warning", GenericWebhookChannel(webhook_url=fail_url))
+        n = Notification(event_type="quota_warning")
+        results = await d.dispatch(n)
+        assert len(results) == 2
+        successes = [v for v in results.values()]
+        assert True in successes
+        assert False in successes
+
+    async def test_dispatch_unregistered_event(self) -> None:
+        d = NotificationDispatcher()
+        n = Notification(event_type="unknown_event")
+        results = await d.dispatch(n)
+        assert results == {}
+
+    @respx.mock
+    async def test_dispatch_does_not_send_to_wrong_event(self) -> None:
+        url = "https://example.com/hook"
+        route = respx.post(url).mock(return_value=httpx.Response(200))
+        d = NotificationDispatcher()
+        d.register("warden_block", GenericWebhookChannel(webhook_url=url))
+        n = Notification(event_type="quota_warning")
+        results = await d.dispatch(n)
+        assert results == {}
+        assert route.call_count == 0
+
+    @respx.mock
+    async def test_dispatch_multiple_event_types(self) -> None:
+        url1 = "https://example.com/hook1"
+        url2 = "https://example.com/hook2"
+        respx.post(url1).mock(return_value=httpx.Response(200))
+        respx.post(url2).mock(return_value=httpx.Response(200))
+        d = NotificationDispatcher()
+        d.register("warden_block", GenericWebhookChannel(webhook_url=url1))
+        d.register("quota_warning", GenericWebhookChannel(webhook_url=url2))
+
+        n1 = Notification(event_type="warden_block")
+        r1 = await d.dispatch(n1)
+        assert len(r1) == 1
+
+        n2 = Notification(event_type="quota_warning")
+        r2 = await d.dispatch(n2)
+        assert len(r2) == 1


### PR DESCRIPTION
Closes #140. NotificationChannel ABC + Slack/Discord/Generic implementations + NotificationDispatcher. 28 tests.