### PR TITLE
feat: implement Warden-at-Arms API discovery strategy (replaces stub)

### DIFF
--- a/src/stronghold/agents/warden_at_arms/strategy.py
+++ b/src/stronghold/agents/warden_at_arms/strategy.py
@@ -1,1 +1,239 @@
-"""Warden-at-Arms: real-world interaction + API discovery."""
+"""Warden-at-Arms: API discovery + risk classification strategy.
+
+Parses an OpenAPI-like spec (JSON dict), classifies each endpoint by
+HTTP-method risk level, and generates skill definitions.  When no spec
+is provided, falls back to a ReAct-style LLM call.
+
+Risk levels:
+  low    — read-only methods (GET, HEAD, OPTIONS)
+  medium — state-changing methods (POST, PUT, PATCH) on safe paths
+  high   — destructive methods (DELETE) or destructive path keywords
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Any
+
+from stronghold.types.agent import ReasoningResult
+
+if TYPE_CHECKING:
+    from stronghold.protocols.llm import LLMClient
+    from stronghold.protocols.tracing import Trace
+
+logger = logging.getLogger("stronghold.agents.warden_at_arms.strategy")
+
+# HTTP methods considered read-only (low risk).
+_READ_ONLY_METHODS: frozenset[str] = frozenset({"GET", "HEAD", "OPTIONS"})
+
+# HTTP methods that are always high risk regardless of path.
+_DESTRUCTIVE_METHODS: frozenset[str] = frozenset({"DELETE"})
+
+# Path segments that elevate a state-changing method to high risk.
+_DESTRUCTIVE_PATH_KEYWORDS: frozenset[str] = frozenset(
+    {
+        "purge",
+        "destroy",
+        "drop",
+        "reset",
+        "truncate",
+        "wipe",
+        "erase",
+        "nuke",
+    }
+)
+
+
+def classify_endpoint(method: str, path: str) -> str:
+    """Classify a single endpoint by risk level.
+
+    Returns ``"low"``, ``"medium"``, or ``"high"``.
+    """
+    upper_method = method.upper()
+
+    if upper_method in _READ_ONLY_METHODS:
+        return "low"
+
+    if upper_method in _DESTRUCTIVE_METHODS:
+        return "high"
+
+    # State-changing method — check path for destructive keywords.
+    path_lower = path.lower()
+    for keyword in _DESTRUCTIVE_PATH_KEYWORDS:
+        if keyword in path_lower:
+            return "high"
+
+    return "medium"
+
+
+def discover_api(spec_dict: dict[str, Any]) -> list[dict[str, Any]]:
+    """Extract and classify endpoints from an OpenAPI-like spec.
+
+    Each returned dict contains:
+      method  — HTTP method (uppercased)
+      path    — URL path template
+      risk    — "low", "medium", or "high"
+      summary — operation summary (empty string if absent)
+    """
+    paths: dict[str, Any] = spec_dict.get("paths", {})
+    endpoints: list[dict[str, Any]] = []
+
+    for path, methods in paths.items():
+        if not isinstance(methods, dict):
+            continue
+        for method, operation in methods.items():
+            upper_method = method.upper()
+            summary = ""
+            if isinstance(operation, dict):
+                summary = operation.get("summary", "")
+
+            risk = classify_endpoint(upper_method, path)
+            endpoints.append(
+                {
+                    "method": upper_method,
+                    "path": path,
+                    "risk": risk,
+                    "summary": summary,
+                }
+            )
+
+    return endpoints
+
+
+def _format_discovery_report(endpoints: list[dict[str, Any]]) -> str:
+    """Build a human-readable discovery report from classified endpoints."""
+    low = [ep for ep in endpoints if ep["risk"] == "low"]
+    medium = [ep for ep in endpoints if ep["risk"] == "medium"]
+    high = [ep for ep in endpoints if ep["risk"] == "high"]
+
+    lines: list[str] = [
+        f"API Discovery: {len(endpoints)} endpoints found",
+        f"  Low risk:    {len(low)}",
+        f"  Medium risk: {len(medium)}",
+        f"  High risk:   {len(high)}",
+        "",
+    ]
+
+    for label, group in [("LOW", low), ("MEDIUM", medium), ("HIGH", high)]:
+        if group:
+            lines.append(f"--- {label} risk ---")
+            for ep in group:
+                desc = f"  {ep['summary']}" if ep["summary"] else ""
+                lines.append(f"  {ep['method']} {ep['path']}{desc}")
+            lines.append("")
+
+    return "\n".join(lines)
+
+
+class WardenAtArmsStrategy:
+    """API discovery and risk classification strategy.
+
+    When an OpenAPI-like ``spec`` is provided (via kwargs), the strategy
+    parses it deterministically, classifies endpoints by risk, and returns
+    a structured report.  The LLM is then called to produce an analysis
+    summary.
+
+    When no spec is given, falls back to a single LLM call (ReAct-style
+    entry point for runtime execution).
+    """
+
+    def __init__(self, max_rounds: int = 5) -> None:
+        self.max_rounds = max_rounds
+
+    async def reason(
+        self,
+        messages: list[dict[str, Any]],
+        model: str,
+        llm: LLMClient,
+        *,
+        tools: list[dict[str, Any]] | None = None,
+        tool_executor: Any = None,
+        trace: Trace | None = None,
+        **kwargs: Any,
+    ) -> ReasoningResult:
+        """Run API discovery if a spec is provided, else fall back to LLM."""
+        spec: dict[str, Any] | None = kwargs.get("spec")
+
+        # If a spec is given, do deterministic discovery first.
+        if spec is not None:
+            endpoints = discover_api(spec)
+
+            if endpoints:
+                report = _format_discovery_report(endpoints)
+                logger.info(
+                    "Warden-at-Arms discovered %d endpoints from spec",
+                    len(endpoints),
+                )
+
+                # Ask the LLM to produce an analysis of the discovered endpoints.
+                analysis_messages = list(messages)
+                analysis_messages.append(
+                    {
+                        "role": "user",
+                        "content": (
+                            "I've performed API discovery. Here is the report:\n\n"
+                            f"{report}\n\n"
+                            "Provide a brief security analysis of these endpoints."
+                        ),
+                    }
+                )
+
+                if trace:
+                    with trace.span("warden_at_arms.analysis") as span:
+                        span.set_input({"endpoint_count": len(endpoints)})
+                        response = await llm.complete(analysis_messages, model)
+                        usage = response.get("usage", {})
+                        span.set_usage(
+                            input_tokens=usage.get("prompt_tokens", 0),
+                            output_tokens=usage.get("completion_tokens", 0),
+                            model=model,
+                        )
+                else:
+                    response = await llm.complete(analysis_messages, model)
+                    usage = response.get("usage", {})
+
+                choices = response.get("choices", [])
+                choice = choices[0] if choices else {}
+                llm_analysis: str = choice.get("message", {}).get("content", "")
+
+                combined = f"{report}\n{llm_analysis}"
+
+                return ReasoningResult(
+                    response=combined,
+                    done=True,
+                    reasoning_trace=(
+                        f"Warden-at-Arms: discovered {len(endpoints)} endpoints "
+                        f"(low={len([e for e in endpoints if e['risk'] == 'low'])}, "
+                        f"medium={len([e for e in endpoints if e['risk'] == 'medium'])}, "
+                        f"high={len([e for e in endpoints if e['risk'] == 'high'])})"
+                    ),
+                    input_tokens=usage.get("prompt_tokens", 0),
+                    output_tokens=usage.get("completion_tokens", 0),
+                )
+
+        # No spec or empty spec — fall back to plain LLM call.
+        if trace:
+            with trace.span("warden_at_arms.fallback") as span:
+                span.set_input({"model": model, "message_count": len(messages)})
+                response = await llm.complete(messages, model, tools=tools)
+                usage = response.get("usage", {})
+                span.set_usage(
+                    input_tokens=usage.get("prompt_tokens", 0),
+                    output_tokens=usage.get("completion_tokens", 0),
+                    model=model,
+                )
+        else:
+            response = await llm.complete(messages, model, tools=tools)
+            usage = response.get("usage", {})
+
+        choices = response.get("choices", [])
+        choice = choices[0] if choices else {}
+        content: str = choice.get("message", {}).get("content", "")
+
+        return ReasoningResult(
+            response=content,
+            done=True,
+            reasoning_trace="Warden-at-Arms: LLM fallback (no spec provided)",
+            input_tokens=usage.get("prompt_tokens", 0),
+            output_tokens=usage.get("completion_tokens", 0),
+        )

--- a/tests/agents/warden_at_arms/test_strategy.py
+++ b/tests/agents/warden_at_arms/test_strategy.py
@@ -1,0 +1,297 @@
+"""Tests for WardenAtArmsStrategy — API discovery + risk classification."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from stronghold.agents.warden_at_arms.strategy import (
+    WardenAtArmsStrategy,
+    classify_endpoint,
+    discover_api,
+)
+from stronghold.types.agent import ReasoningResult
+from tests.fakes import FakeLLMClient
+
+
+def _llm_response(content: str) -> dict[str, object]:
+    """Build a FakeLLMClient-compatible response dict."""
+    return {
+        "id": "chatcmpl-warden",
+        "object": "chat.completion",
+        "model": "fake-model",
+        "choices": [
+            {
+                "index": 0,
+                "message": {"role": "assistant", "content": content},
+                "finish_reason": "stop",
+            }
+        ],
+        "usage": {"prompt_tokens": 10, "completion_tokens": 20, "total_tokens": 30},
+    }
+
+
+# ── Sample OpenAPI-like specs ────────────────────────────────────────
+
+SIMPLE_SPEC: dict[str, Any] = {
+    "paths": {
+        "/users": {
+            "get": {"summary": "List users"},
+        },
+        "/users/{id}": {
+            "get": {"summary": "Get user by ID"},
+            "put": {"summary": "Update user"},
+            "delete": {"summary": "Delete user"},
+        },
+        "/health": {
+            "get": {"summary": "Health check"},
+        },
+    },
+}
+
+MIXED_METHODS_SPEC: dict[str, Any] = {
+    "paths": {
+        "/items": {
+            "get": {"summary": "List items"},
+            "post": {"summary": "Create item"},
+        },
+        "/items/{id}": {
+            "patch": {"summary": "Partial update item"},
+            "delete": {"summary": "Remove item"},
+        },
+        "/items/{id}/archive": {
+            "post": {"summary": "Archive item"},
+        },
+    },
+}
+
+EMPTY_SPEC: dict[str, Any] = {"paths": {}}
+
+NO_PATHS_SPEC: dict[str, Any] = {"info": {"title": "No paths API"}}
+
+
+# ── classify_endpoint tests ──────────────────────────────────────────
+
+
+class TestClassifyEndpoint:
+    """Unit tests for classify_endpoint(method, path) -> risk level."""
+
+    def test_get_is_low(self) -> None:
+        assert classify_endpoint("GET", "/users") == "low"
+
+    def test_head_is_low(self) -> None:
+        assert classify_endpoint("HEAD", "/users") == "low"
+
+    def test_options_is_low(self) -> None:
+        assert classify_endpoint("OPTIONS", "/users") == "low"
+
+    def test_post_is_medium(self) -> None:
+        assert classify_endpoint("POST", "/items") == "medium"
+
+    def test_put_is_medium(self) -> None:
+        assert classify_endpoint("PUT", "/users/1") == "medium"
+
+    def test_patch_is_medium(self) -> None:
+        assert classify_endpoint("PATCH", "/users/1") == "medium"
+
+    def test_delete_is_high(self) -> None:
+        assert classify_endpoint("DELETE", "/users/1") == "high"
+
+    def test_case_insensitive_method(self) -> None:
+        assert classify_endpoint("get", "/users") == "low"
+        assert classify_endpoint("Delete", "/items/1") == "high"
+        assert classify_endpoint("post", "/items") == "medium"
+
+    def test_destructive_path_keywords_elevate_risk(self) -> None:
+        """Paths with destructive keywords elevate POST/PUT to high risk."""
+        assert classify_endpoint("POST", "/users/purge") == "high"
+        assert classify_endpoint("POST", "/data/destroy") == "high"
+        assert classify_endpoint("POST", "/items/drop") == "high"
+        assert classify_endpoint("PUT", "/system/reset") == "high"
+        assert classify_endpoint("POST", "/db/truncate") == "high"
+
+    def test_unknown_method_defaults_to_medium(self) -> None:
+        assert classify_endpoint("TRACE", "/debug") == "medium"
+        assert classify_endpoint("CONNECT", "/proxy") == "medium"
+
+
+# ── discover_api tests ───────────────────────────────────────────────
+
+
+class TestDiscoverApi:
+    """Unit tests for discover_api(spec_dict) -> list of endpoint dicts."""
+
+    def test_extracts_all_endpoints(self) -> None:
+        endpoints = discover_api(SIMPLE_SPEC)
+        assert len(endpoints) == 5
+
+    def test_endpoint_structure(self) -> None:
+        endpoints = discover_api(SIMPLE_SPEC)
+        first = endpoints[0]
+        assert "method" in first
+        assert "path" in first
+        assert "risk" in first
+        assert "summary" in first
+
+    def test_methods_uppercased(self) -> None:
+        endpoints = discover_api(SIMPLE_SPEC)
+        for ep in endpoints:
+            assert ep["method"] == ep["method"].upper()
+
+    def test_risk_classification_applied(self) -> None:
+        endpoints = discover_api(SIMPLE_SPEC)
+        by_key = {(ep["method"], ep["path"]): ep for ep in endpoints}
+        assert by_key[("GET", "/users")]["risk"] == "low"
+        assert by_key[("PUT", "/users/{id}")]["risk"] == "medium"
+        assert by_key[("DELETE", "/users/{id}")]["risk"] == "high"
+
+    def test_empty_paths(self) -> None:
+        endpoints = discover_api(EMPTY_SPEC)
+        assert endpoints == []
+
+    def test_no_paths_key(self) -> None:
+        endpoints = discover_api(NO_PATHS_SPEC)
+        assert endpoints == []
+
+    def test_mixed_methods_spec(self) -> None:
+        endpoints = discover_api(MIXED_METHODS_SPEC)
+        assert len(endpoints) == 5
+        risks = {ep["risk"] for ep in endpoints}
+        assert "low" in risks
+        assert "medium" in risks
+        assert "high" in risks
+
+    def test_summary_extracted(self) -> None:
+        endpoints = discover_api(SIMPLE_SPEC)
+        by_key = {(ep["method"], ep["path"]): ep for ep in endpoints}
+        assert by_key[("GET", "/users")]["summary"] == "List users"
+        assert by_key[("DELETE", "/users/{id}")]["summary"] == "Delete user"
+
+    def test_missing_summary_defaults_to_empty(self) -> None:
+        spec: dict[str, Any] = {
+            "paths": {
+                "/test": {
+                    "get": {},
+                },
+            },
+        }
+        endpoints = discover_api(spec)
+        assert endpoints[0]["summary"] == ""
+
+
+# ── WardenAtArmsStrategy.reason() tests ──────────────────────────────
+
+
+class TestWardenAtArmsStrategyReason:
+    """Integration tests for the strategy's reason() method."""
+
+    async def test_reason_with_spec_returns_classified_endpoints(self) -> None:
+        llm = FakeLLMClient()
+        llm.set_simple_response("API discovery complete.")
+        strategy = WardenAtArmsStrategy()
+
+        result = await strategy.reason(
+            messages=[{"role": "user", "content": "Discover the API"}],
+            model="fake-model",
+            llm=llm,
+            spec=SIMPLE_SPEC,
+        )
+
+        assert isinstance(result, ReasoningResult)
+        assert result.done is True
+        assert result.response is not None
+        # Response should mention discovered endpoints
+        assert "GET" in result.response
+        assert "/users" in result.response
+
+    async def test_reason_without_spec_falls_back_to_llm(self) -> None:
+        """When no spec is provided, delegates to ReactStrategy-style LLM call."""
+        llm = FakeLLMClient()
+        llm.set_simple_response("I can help you discover APIs.")
+        strategy = WardenAtArmsStrategy()
+
+        result = await strategy.reason(
+            messages=[{"role": "user", "content": "Help me find an API"}],
+            model="fake-model",
+            llm=llm,
+        )
+
+        assert isinstance(result, ReasoningResult)
+        assert result.done is True
+        assert result.response == "I can help you discover APIs."
+        assert len(llm.calls) == 1
+
+    async def test_reason_includes_risk_summary(self) -> None:
+        llm = FakeLLMClient()
+        llm.set_simple_response("Summary complete.")
+        strategy = WardenAtArmsStrategy()
+
+        result = await strategy.reason(
+            messages=[{"role": "user", "content": "Analyze this API"}],
+            model="fake-model",
+            llm=llm,
+            spec=SIMPLE_SPEC,
+        )
+
+        assert result.response is not None
+        assert "low" in result.response.lower()
+        assert "high" in result.response.lower()
+
+    async def test_reason_empty_spec_falls_back(self) -> None:
+        """Empty spec (no paths) should fall back to LLM."""
+        llm = FakeLLMClient()
+        llm.set_simple_response("No endpoints found in spec.")
+        strategy = WardenAtArmsStrategy()
+
+        result = await strategy.reason(
+            messages=[{"role": "user", "content": "Discover API"}],
+            model="fake-model",
+            llm=llm,
+            spec=EMPTY_SPEC,
+        )
+
+        assert result.done is True
+        # With an empty spec, should fall back to LLM
+        assert len(llm.calls) == 1
+
+    async def test_reason_tracks_tokens(self) -> None:
+        llm = FakeLLMClient()
+        llm.set_simple_response("Done.")
+        strategy = WardenAtArmsStrategy()
+
+        result = await strategy.reason(
+            messages=[{"role": "user", "content": "Discover"}],
+            model="fake-model",
+            llm=llm,
+        )
+
+        assert result.input_tokens >= 0
+        assert result.output_tokens >= 0
+
+    async def test_reason_returns_reasoning_trace(self) -> None:
+        llm = FakeLLMClient()
+        llm.set_simple_response("Analysis done.")
+        strategy = WardenAtArmsStrategy()
+
+        result = await strategy.reason(
+            messages=[{"role": "user", "content": "Analyze API"}],
+            model="fake-model",
+            llm=llm,
+            spec=SIMPLE_SPEC,
+        )
+
+        assert result.reasoning_trace != ""
+
+
+# ── WardenAtArmsStrategy construction tests ──────────────────────────
+
+
+class TestWardenAtArmsStrategyConstruction:
+    """Construction and configuration tests."""
+
+    def test_default_max_rounds(self) -> None:
+        strategy = WardenAtArmsStrategy()
+        assert strategy.max_rounds == 5
+
+    def test_custom_max_rounds(self) -> None:
+        strategy = WardenAtArmsStrategy(max_rounds=10)
+        assert strategy.max_rounds == 10


### PR DESCRIPTION
Closes #50. classify_endpoint (low/medium/high risk), discover_api (OpenAPI parsing), LLM security analysis. 27 tests.