### PR TITLE
feat: add outcome tracker for closed-loop model selection

### DIFF
--- a/src/stronghold/router/outcome_tracker.py
+++ b/src/stronghold/router/outcome_tracker.py
@@ -1,0 +1,139 @@
+"""Outcome tracker — closed-loop feedback for model selection.
+
+Tracks rolling-window statistics per model and provider so the router
+can incorporate real-world performance data into scoring decisions:
+
+- Latency P50/P99 per model
+- Tool success rate per model per task_type
+- Provider reliability (error rate)
+
+All windows default to the last 100 observations per metric.
+"""
+
+from __future__ import annotations
+
+import math
+from collections import deque
+from dataclasses import dataclass, field
+
+_DEFAULT_WINDOW_SIZE = 100
+
+
+@dataclass(frozen=True)
+class ModelStats:
+    """Aggregated outcome statistics for a single model."""
+
+    p50_latency_ms: float = 0.0
+    p99_latency_ms: float = 0.0
+    tool_success_rates: dict[str, float] = field(default_factory=dict)
+    request_count: int = 0
+
+
+class OutcomeTracker:
+    """Tracks rolling outcome metrics for models and providers.
+
+    Thread-safety note: this implementation is not thread-safe.
+    For concurrent access, wrap calls with an external lock or
+    use a thread-safe subclass.
+    """
+
+    def __init__(self, window_size: int = _DEFAULT_WINDOW_SIZE) -> None:
+        self._window_size = window_size
+        # model_id → deque of latencies
+        self._latencies: dict[str, deque[float]] = {}
+        # model_id → task_type → deque of bools (True = success)
+        self._tool_outcomes: dict[str, dict[str, deque[bool]]] = {}
+        # provider → deque of bools (True = success)
+        self._provider_outcomes: dict[str, deque[bool]] = {}
+
+    def record_latency(self, model_id: str, latency_ms: float) -> None:
+        """Record a request latency observation for a model."""
+        if model_id not in self._latencies:
+            self._latencies[model_id] = deque(maxlen=self._window_size)
+        self._latencies[model_id].append(latency_ms)
+
+    def record_tool_outcome(
+        self,
+        model_id: str,
+        task_type: str,
+        *,
+        success: bool,
+    ) -> None:
+        """Record a tool call outcome for a model and task type."""
+        if model_id not in self._tool_outcomes:
+            self._tool_outcomes[model_id] = {}
+        by_task = self._tool_outcomes[model_id]
+        if task_type not in by_task:
+            by_task[task_type] = deque(maxlen=self._window_size)
+        by_task[task_type].append(success)
+
+    def record_error(
+        self,
+        provider: str,
+        *,
+        is_error: bool = True,
+    ) -> None:
+        """Record a provider request outcome (success or error).
+
+        Args:
+            provider: Provider identifier (e.g. "openai", "anthropic").
+            is_error: True if the request failed, False if it succeeded.
+        """
+        if provider not in self._provider_outcomes:
+            self._provider_outcomes[provider] = deque(maxlen=self._window_size)
+        self._provider_outcomes[provider].append(not is_error)
+
+    def get_model_stats(self, model_id: str) -> ModelStats:
+        """Return aggregated stats for a model. Returns defaults for unknown models."""
+        latencies = self._latencies.get(model_id)
+        if not latencies:
+            # Cold start — no data
+            tool_rates = self._compute_tool_rates(model_id)
+            return ModelStats(
+                p50_latency_ms=0.0,
+                p99_latency_ms=0.0,
+                tool_success_rates=tool_rates,
+                request_count=0,
+            )
+
+        sorted_lats = sorted(latencies)
+        n = len(sorted_lats)
+        p50 = self._percentile(sorted_lats, n, 50)
+        p99 = self._percentile(sorted_lats, n, 99)
+        tool_rates = self._compute_tool_rates(model_id)
+
+        return ModelStats(
+            p50_latency_ms=p50,
+            p99_latency_ms=p99,
+            tool_success_rates=tool_rates,
+            request_count=n,
+        )
+
+    def get_provider_reliability(self, provider: str) -> float:
+        """Return success rate for a provider. Returns 1.0 for unknown providers."""
+        outcomes = self._provider_outcomes.get(provider)
+        if not outcomes:
+            return 1.0
+        return sum(1 for ok in outcomes if ok) / len(outcomes)
+
+    def _compute_tool_rates(self, model_id: str) -> dict[str, float]:
+        """Compute success rates for each task_type a model has outcomes for."""
+        by_task = self._tool_outcomes.get(model_id)
+        if not by_task:
+            return {}
+        rates: dict[str, float] = {}
+        for task_type, outcomes in by_task.items():
+            if outcomes:
+                rates[task_type] = sum(1 for ok in outcomes if ok) / len(outcomes)
+        return rates
+
+    @staticmethod
+    def _percentile(sorted_values: list[float], n: int, pct: int) -> float:
+        """Compute a percentile using nearest-rank method."""
+        if n == 1:
+            return sorted_values[0]
+        rank = (pct / 100.0) * (n - 1)
+        lower = int(math.floor(rank))
+        upper = min(lower + 1, n - 1)
+        frac = rank - lower
+        return sorted_values[lower] + frac * (sorted_values[upper] - sorted_values[lower])

--- a/tests/routing/test_outcome_tracker.py
+++ b/tests/routing/test_outcome_tracker.py
@@ -1,0 +1,188 @@
+"""Tests for outcome tracker — closed-loop model selection feedback.
+
+Covers: latency tracking (P50/P99), tool success rate per model per task_type,
+provider reliability (error rate), cold start defaults, and rolling window eviction.
+"""
+
+from __future__ import annotations
+
+from stronghold.router.outcome_tracker import OutcomeTracker
+
+
+class TestLatencyRecording:
+    def test_record_single_latency(self) -> None:
+        tracker = OutcomeTracker()
+        tracker.record_latency("gpt-4o", 150.0)
+        stats = tracker.get_model_stats("gpt-4o")
+        assert stats.p50_latency_ms == 150.0
+        assert stats.p99_latency_ms == 150.0
+
+    def test_record_multiple_latencies(self) -> None:
+        tracker = OutcomeTracker()
+        for ms in [100.0, 200.0, 300.0]:
+            tracker.record_latency("gpt-4o", ms)
+        stats = tracker.get_model_stats("gpt-4o")
+        assert stats.p50_latency_ms == 200.0
+
+    def test_latencies_per_model_are_independent(self) -> None:
+        tracker = OutcomeTracker()
+        tracker.record_latency("gpt-4o", 100.0)
+        tracker.record_latency("claude-sonnet", 500.0)
+        gpt_stats = tracker.get_model_stats("gpt-4o")
+        claude_stats = tracker.get_model_stats("claude-sonnet")
+        assert gpt_stats.p50_latency_ms == 100.0
+        assert claude_stats.p50_latency_ms == 500.0
+
+
+class TestP50P99Calculation:
+    def test_p50_is_median(self) -> None:
+        tracker = OutcomeTracker()
+        # 10 values: 10, 20, ... 100
+        for i in range(1, 11):
+            tracker.record_latency("m", float(i * 10))
+        stats = tracker.get_model_stats("m")
+        # Median of [10..100] with 10 values: between 50 and 60
+        assert 50.0 <= stats.p50_latency_ms <= 60.0
+
+    def test_p99_captures_tail(self) -> None:
+        tracker = OutcomeTracker()
+        # 99 fast requests + 1 slow outlier
+        for _ in range(99):
+            tracker.record_latency("m", 50.0)
+        tracker.record_latency("m", 5000.0)
+        stats = tracker.get_model_stats("m")
+        # P99 should be at or near the outlier
+        assert stats.p99_latency_ms >= 50.0
+        # P50 should be the fast value
+        assert stats.p50_latency_ms == 50.0
+
+    def test_p99_with_two_values(self) -> None:
+        tracker = OutcomeTracker()
+        tracker.record_latency("m", 10.0)
+        tracker.record_latency("m", 1000.0)
+        stats = tracker.get_model_stats("m")
+        # With 2 values and linear interpolation, P99 is near the max
+        assert stats.p99_latency_ms >= 980.0
+
+
+class TestToolSuccessRate:
+    def test_success_rate_all_successes(self) -> None:
+        tracker = OutcomeTracker()
+        for _ in range(10):
+            tracker.record_tool_outcome("gpt-4o", "code", success=True)
+        stats = tracker.get_model_stats("gpt-4o")
+        assert stats.tool_success_rates["code"] == 1.0
+
+    def test_success_rate_all_failures(self) -> None:
+        tracker = OutcomeTracker()
+        for _ in range(5):
+            tracker.record_tool_outcome("gpt-4o", "code", success=False)
+        stats = tracker.get_model_stats("gpt-4o")
+        assert stats.tool_success_rates["code"] == 0.0
+
+    def test_success_rate_mixed(self) -> None:
+        tracker = OutcomeTracker()
+        for _ in range(7):
+            tracker.record_tool_outcome("gpt-4o", "code", success=True)
+        for _ in range(3):
+            tracker.record_tool_outcome("gpt-4o", "code", success=False)
+        stats = tracker.get_model_stats("gpt-4o")
+        assert abs(stats.tool_success_rates["code"] - 0.7) < 0.01
+
+    def test_success_rate_per_task_type(self) -> None:
+        tracker = OutcomeTracker()
+        tracker.record_tool_outcome("gpt-4o", "code", success=True)
+        tracker.record_tool_outcome("gpt-4o", "chat", success=False)
+        stats = tracker.get_model_stats("gpt-4o")
+        assert stats.tool_success_rates["code"] == 1.0
+        assert stats.tool_success_rates["chat"] == 0.0
+
+
+class TestProviderReliability:
+    def test_no_errors_full_reliability(self) -> None:
+        tracker = OutcomeTracker()
+        # Record some latency so the provider has data
+        tracker.record_latency("gpt-4o", 100.0)
+        reliability = tracker.get_provider_reliability("openai")
+        # No errors recorded — default 1.0
+        assert reliability == 1.0
+
+    def test_errors_reduce_reliability(self) -> None:
+        tracker = OutcomeTracker()
+        for _ in range(10):
+            tracker.record_error("openai")
+        # 10 errors, 0 successes → 0.0 reliability
+        reliability = tracker.get_provider_reliability("openai")
+        assert reliability == 0.0
+
+    def test_mixed_errors_and_successes(self) -> None:
+        tracker = OutcomeTracker()
+        for _ in range(8):
+            tracker.record_error("openai", is_error=False)  # success
+        for _ in range(2):
+            tracker.record_error("openai", is_error=True)
+        reliability = tracker.get_provider_reliability("openai")
+        assert abs(reliability - 0.8) < 0.01
+
+
+class TestColdStart:
+    def test_unknown_model_returns_defaults(self) -> None:
+        tracker = OutcomeTracker()
+        stats = tracker.get_model_stats("never-seen-model")
+        assert stats.p50_latency_ms == 0.0
+        assert stats.p99_latency_ms == 0.0
+        assert stats.tool_success_rates == {}
+        assert stats.request_count == 0
+
+    def test_unknown_provider_returns_full_reliability(self) -> None:
+        tracker = OutcomeTracker()
+        reliability = tracker.get_provider_reliability("unknown-provider")
+        assert reliability == 1.0
+
+
+class TestRollingWindowEviction:
+    def test_latency_window_caps_at_max(self) -> None:
+        tracker = OutcomeTracker(window_size=10)
+        # Record 15 values — first 5 should be evicted
+        for i in range(15):
+            tracker.record_latency("m", float(i * 10))
+        stats = tracker.get_model_stats("m")
+        # Only last 10 values (50..140) should remain
+        # P50 of [50, 60, 70, 80, 90, 100, 110, 120, 130, 140]
+        assert 90.0 <= stats.p50_latency_ms <= 100.0
+
+    def test_tool_outcome_window_caps_at_max(self) -> None:
+        tracker = OutcomeTracker(window_size=10)
+        # Record 10 successes, then 10 failures — only failures should remain
+        for _ in range(10):
+            tracker.record_tool_outcome("m", "code", success=True)
+        for _ in range(10):
+            tracker.record_tool_outcome("m", "code", success=False)
+        stats = tracker.get_model_stats("m")
+        assert stats.tool_success_rates["code"] == 0.0
+
+    def test_provider_reliability_window_caps_at_max(self) -> None:
+        tracker = OutcomeTracker(window_size=10)
+        # 10 successes, then 10 errors — only errors remain
+        for _ in range(10):
+            tracker.record_error("prov", is_error=False)
+        for _ in range(10):
+            tracker.record_error("prov", is_error=True)
+        reliability = tracker.get_provider_reliability("prov")
+        assert reliability == 0.0
+
+
+class TestRequestCount:
+    def test_request_count_tracks_latencies(self) -> None:
+        tracker = OutcomeTracker()
+        for _ in range(5):
+            tracker.record_latency("m", 100.0)
+        stats = tracker.get_model_stats("m")
+        assert stats.request_count == 5
+
+    def test_request_count_respects_window(self) -> None:
+        tracker = OutcomeTracker(window_size=10)
+        for _ in range(25):
+            tracker.record_latency("m", 100.0)
+        stats = tracker.get_model_stats("m")
+        assert stats.request_count == 10


### PR DESCRIPTION
Closes #81. OutcomeTracker with rolling P50/P99 latency, per-model tool success rates, provider reliability. Deque-based window eviction. 20 tests.