### PR TITLE
feat: add tool usage tracker for adaptive discovery

### DIFF
--- a/src/stronghold/tools/usage_tracker.py
+++ b/src/stronghold/tools/usage_tracker.py
@@ -1,0 +1,145 @@
+"""Tool usage tracker: records tool invocations and provides usage-based ranking.
+
+Supports adaptive tool discovery by tracking which tools are used for which
+task types, which parameters are actually exercised, and which tool sequences
+occur frequently. This data feeds into context building for schema pruning
+(removing rarely-used parameters) and priority ordering (most-used tools first).
+"""
+
+from __future__ import annotations
+
+import logging
+from collections import defaultdict
+
+logger = logging.getLogger("stronghold.tools.usage_tracker")
+
+
+class ToolUsageTracker:
+    """Tracks tool usage patterns for adaptive discovery and schema pruning.
+
+    Thread-safety: This is an in-memory tracker intended for single-process use.
+    For multi-process deployments, back this with a shared store (e.g. Redis/PG).
+    """
+
+    def __init__(self) -> None:
+        # task_type -> tool_name -> invocation count
+        self._task_tool_counts: dict[str, dict[str, int]] = defaultdict(
+            lambda: defaultdict(int),
+        )
+        # tool_name -> parameter_name -> usage count
+        self._param_counts: dict[str, dict[str, int]] = defaultdict(
+            lambda: defaultdict(int),
+        )
+        # tool_name -> total invocation count (across all task types)
+        self._tool_total: dict[str, int] = defaultdict(int)
+        # Ordered history of (tool_name,) for chain detection
+        self._invocation_history: list[str] = []
+        # (tool_a, tool_b) -> sequential pair count
+        self._chain_counts: dict[tuple[str, str], int] = defaultdict(int)
+
+    def record_usage(
+        self,
+        tool_name: str,
+        task_type: str,
+        parameters_used: list[str],
+    ) -> None:
+        """Record a single tool invocation.
+
+        Args:
+            tool_name: Name of the tool that was invoked.
+            task_type: The classified task type for this request.
+            parameters_used: List of parameter names that were passed.
+        """
+        self._task_tool_counts[task_type][tool_name] += 1
+        self._tool_total[tool_name] += 1
+
+        for param in parameters_used:
+            self._param_counts[tool_name][param] += 1
+
+        # Track sequential chains
+        if self._invocation_history:
+            prev = self._invocation_history[-1]
+            self._chain_counts[(prev, tool_name)] += 1
+        self._invocation_history.append(tool_name)
+
+        logger.debug(
+            "Recorded usage: tool=%s task=%s params=%s",
+            tool_name,
+            task_type,
+            parameters_used,
+        )
+
+    def get_ranked_tools(self, task_type: str) -> list[str]:
+        """Return tools sorted by usage frequency for a given task type.
+
+        Args:
+            task_type: The task type to rank tools for.
+
+        Returns:
+            Tool names sorted descending by invocation count, with ties
+            broken alphabetically for deterministic ordering.
+        """
+        counts = self._task_tool_counts.get(task_type)
+        if not counts:
+            return []
+        return sorted(counts, key=lambda t: (-counts[t], t))
+
+    def get_parameter_usage(self, tool_name: str) -> dict[str, int]:
+        """Return parameter usage counts for a tool.
+
+        Args:
+            tool_name: The tool to get parameter stats for.
+
+        Returns:
+            Dict mapping parameter name to invocation count.
+        """
+        raw = self._param_counts.get(tool_name)
+        if raw is None:
+            return {}
+        return dict(raw)
+
+    def get_unused_parameters(
+        self,
+        tool_name: str,
+        min_usage_pct: float = 0.05,
+    ) -> list[str]:
+        """Return parameters used less than min_usage_pct of the time.
+
+        Args:
+            tool_name: The tool to check.
+            min_usage_pct: Threshold as a fraction (0.05 = 5%). Parameters
+                used in fewer than this fraction of total invocations are
+                considered unused.
+
+        Returns:
+            List of parameter names below the usage threshold.
+        """
+        total = self._tool_total.get(tool_name, 0)
+        if total == 0:
+            return []
+
+        raw = self._param_counts.get(tool_name)
+        if raw is None:
+            return []
+
+        threshold = total * min_usage_pct
+        return sorted(param for param, count in raw.items() if count < threshold)
+
+    def get_common_chains(
+        self,
+        min_count: int = 3,
+    ) -> list[tuple[str, str]]:
+        """Return frequently sequential tool pairs.
+
+        Args:
+            min_count: Minimum number of times a pair must appear
+                sequentially to be included.
+
+        Returns:
+            List of (tool_a, tool_b) pairs that appeared sequentially
+            at least min_count times, sorted by count descending.
+        """
+        return sorted(
+            (pair for pair, count in self._chain_counts.items() if count >= min_count),
+            key=lambda p: (-self._chain_counts[p], p),
+        )

--- a/tests/tools/test_usage_tracker.py
+++ b/tests/tools/test_usage_tracker.py
@@ -1,0 +1,152 @@
+"""Tests for tool usage tracker: usage-based ranking and schema pruning."""
+
+from stronghold.tools.usage_tracker import ToolUsageTracker
+
+
+class TestRecordUsage:
+    def test_record_single_usage(self) -> None:
+        tracker = ToolUsageTracker()
+        tracker.record_usage("web_search", "search", ["query"])
+        stats = tracker.get_parameter_usage("web_search")
+        assert stats == {"query": 1}
+
+    def test_record_multiple_usages_same_tool(self) -> None:
+        tracker = ToolUsageTracker()
+        tracker.record_usage("web_search", "search", ["query"])
+        tracker.record_usage("web_search", "search", ["query", "max_results"])
+        stats = tracker.get_parameter_usage("web_search")
+        assert stats == {"query": 2, "max_results": 1}
+
+    def test_record_usage_different_task_types(self) -> None:
+        tracker = ToolUsageTracker()
+        tracker.record_usage("shell", "code", ["command"])
+        tracker.record_usage("shell", "automation", ["command"])
+        # Tool should appear in rankings for both task types
+        assert "shell" in tracker.get_ranked_tools("code")
+        assert "shell" in tracker.get_ranked_tools("automation")
+
+
+class TestGetRankedTools:
+    def test_ranked_by_frequency(self) -> None:
+        tracker = ToolUsageTracker()
+        tracker.record_usage("web_search", "search", ["query"])
+        tracker.record_usage("file_read", "search", ["path"])
+        tracker.record_usage("web_search", "search", ["query"])
+        tracker.record_usage("web_search", "search", ["query"])
+        ranked = tracker.get_ranked_tools("search")
+        assert ranked == ["web_search", "file_read"]
+
+    def test_empty_task_type_returns_empty(self) -> None:
+        tracker = ToolUsageTracker()
+        assert tracker.get_ranked_tools("nonexistent") == []
+
+    def test_ranked_tools_only_returns_tools_for_task_type(self) -> None:
+        tracker = ToolUsageTracker()
+        tracker.record_usage("web_search", "search", ["query"])
+        tracker.record_usage("shell", "code", ["command"])
+        ranked = tracker.get_ranked_tools("search")
+        assert ranked == ["web_search"]
+        assert "shell" not in ranked
+
+    def test_tie_breaking_is_stable(self) -> None:
+        tracker = ToolUsageTracker()
+        tracker.record_usage("alpha", "code", ["x"])
+        tracker.record_usage("beta", "code", ["y"])
+        ranked = tracker.get_ranked_tools("code")
+        assert len(ranked) == 2
+        # Both have count 1, order should be deterministic (alphabetical)
+        assert ranked == ["alpha", "beta"]
+
+
+class TestGetParameterUsage:
+    def test_unknown_tool_returns_empty(self) -> None:
+        tracker = ToolUsageTracker()
+        assert tracker.get_parameter_usage("nonexistent") == {}
+
+    def test_accumulates_across_task_types(self) -> None:
+        tracker = ToolUsageTracker()
+        tracker.record_usage("shell", "code", ["command", "timeout"])
+        tracker.record_usage("shell", "automation", ["command"])
+        stats = tracker.get_parameter_usage("shell")
+        assert stats == {"command": 2, "timeout": 1}
+
+
+class TestGetUnusedParameters:
+    def test_identifies_rarely_used_params(self) -> None:
+        tracker = ToolUsageTracker()
+        # Use "query" 20 times, "max_results" once — 1/21 ≈ 4.8% < 5%
+        for _ in range(20):
+            tracker.record_usage("web_search", "search", ["query"])
+        tracker.record_usage("web_search", "search", ["query", "max_results"])
+        unused = tracker.get_unused_parameters("web_search")
+        assert "max_results" in unused
+        assert "query" not in unused
+
+    def test_no_unused_when_all_frequent(self) -> None:
+        tracker = ToolUsageTracker()
+        for _ in range(10):
+            tracker.record_usage("shell", "code", ["command", "timeout"])
+        unused = tracker.get_unused_parameters("shell")
+        assert unused == []
+
+    def test_unknown_tool_returns_empty(self) -> None:
+        tracker = ToolUsageTracker()
+        assert tracker.get_unused_parameters("nonexistent") == []
+
+    def test_custom_min_usage_pct(self) -> None:
+        tracker = ToolUsageTracker()
+        # 10 usages of "query", 1 usage of "filter" — 1/11 ≈ 9.1%
+        for _ in range(10):
+            tracker.record_usage("search", "code", ["query"])
+        tracker.record_usage("search", "code", ["query", "filter"])
+        # Default 5% threshold: filter is NOT unused (9.1% > 5%)
+        assert "filter" not in tracker.get_unused_parameters("search")
+        # Raise threshold to 10%: filter IS unused (9.1% < 10%)
+        assert "filter" in tracker.get_unused_parameters("search", min_usage_pct=0.10)
+
+
+class TestGetCommonChains:
+    def test_detects_sequential_pairs(self) -> None:
+        tracker = ToolUsageTracker()
+        # Record a chain: web_search -> file_write, 3 times
+        for _ in range(3):
+            tracker.record_usage("web_search", "search", ["query"])
+            tracker.record_usage("file_write", "search", ["path", "content"])
+        chains = tracker.get_common_chains(min_count=3)
+        assert ("web_search", "file_write") in chains
+
+    def test_below_threshold_excluded(self) -> None:
+        tracker = ToolUsageTracker()
+        # Only 2 occurrences — below default threshold of 3
+        for _ in range(2):
+            tracker.record_usage("web_search", "search", ["query"])
+            tracker.record_usage("file_write", "search", ["path"])
+        chains = tracker.get_common_chains(min_count=3)
+        assert ("web_search", "file_write") not in chains
+
+    def test_chains_across_task_types(self) -> None:
+        tracker = ToolUsageTracker()
+        # Same sequential pair across different task types should still count
+        for _ in range(2):
+            tracker.record_usage("shell", "code", ["command"])
+            tracker.record_usage("file_read", "code", ["path"])
+        tracker.record_usage("shell", "automation", ["command"])
+        tracker.record_usage("file_read", "automation", ["path"])
+        chains = tracker.get_common_chains(min_count=3)
+        assert ("shell", "file_read") in chains
+
+    def test_no_chains_returns_empty(self) -> None:
+        tracker = ToolUsageTracker()
+        tracker.record_usage("solo_tool", "code", ["x"])
+        assert tracker.get_common_chains() == []
+
+    def test_interleaved_tools_dont_false_chain(self) -> None:
+        tracker = ToolUsageTracker()
+        # A -> B -> A -> B only produces (A, B) and (B, A), each twice
+        tracker.record_usage("alpha", "code", ["x"])
+        tracker.record_usage("beta", "code", ["y"])
+        tracker.record_usage("alpha", "code", ["x"])
+        tracker.record_usage("beta", "code", ["y"])
+        # Neither pair reaches 3
+        chains = tracker.get_common_chains(min_count=3)
+        assert chains == []


### PR DESCRIPTION
Closes #123. ToolUsageTracker with ranked tools per task_type, parameter usage, unused param detection, common chains. 18 tests.