### PR TITLE
feat: add OpenAI-compatible embeddings endpoint

### DIFF
--- a/src/stronghold/api/app.py
+++ b/src/stronghold/api/app.py
@@ -108,6 +108,7 @@ def create_app() -> FastAPI:
     from stronghold.api.routes.auth import router as auth_router
     from stronghold.api.routes.chat import router as chat_router
     from stronghold.api.routes.dashboard import router as dashboard_router
+    from stronghold.api.routes.embeddings import router as embeddings_router
     from stronghold.api.routes.gate_endpoint import router as gate_router
     from stronghold.api.routes.marketplace import router as marketplace_router
     from stronghold.api.routes.mcp import router as mcp_router
@@ -125,6 +126,7 @@ def create_app() -> FastAPI:
     app.include_router(auth_router)  # BFF auth (must be before dashboard for /auth/* routes)
     app.include_router(chat_router)
     app.include_router(models_router)
+    app.include_router(embeddings_router)
     app.include_router(status_router)
     app.include_router(agents_router)
     app.include_router(prompts_router)

--- a/src/stronghold/api/routes/embeddings.py
+++ b/src/stronghold/api/routes/embeddings.py
@@ -1,0 +1,82 @@
+"""OpenAI-compatible embeddings endpoint.
+
+POST /v1/embeddings — accepts {input, model}, returns OpenAI-format response.
+Auth required.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from fastapi import APIRouter, HTTPException, Request
+
+logger = logging.getLogger("stronghold.api.embeddings")
+
+router = APIRouter()
+
+
+@router.post("/v1/embeddings")
+async def create_embeddings(request: Request) -> dict[str, Any]:
+    """Create embeddings for the given input text(s).
+
+    OpenAI-compatible: accepts ``{input, model}`` where ``input`` is a string
+    or list of strings. Returns ``{object, data, model, usage}``.
+    """
+    container = request.app.state.container
+
+    # --- Auth ---
+    auth_header = request.headers.get("authorization")
+    try:
+        await container.auth_provider.authenticate(auth_header, headers=dict(request.headers))
+    except ValueError as e:
+        raise HTTPException(status_code=401, detail=str(e)) from e
+
+    # --- Parse body ---
+    body = await request.json()
+    raw_input = body.get("input")
+    model = body.get("model", "text-embedding-3-small")
+
+    if raw_input is None:
+        raise HTTPException(status_code=400, detail="Missing 'input' field")
+
+    # Normalize to list[str]
+    if isinstance(raw_input, str):
+        texts: list[str] = [raw_input]
+    elif isinstance(raw_input, list):
+        texts = [str(t) for t in raw_input]
+    else:
+        raise HTTPException(status_code=400, detail="'input' must be a string or list of strings")
+
+    if not texts:
+        raise HTTPException(status_code=400, detail="'input' must not be empty")
+
+    # --- Get embedding client ---
+    embedding_client = getattr(container, "embedding_client", None)
+    if embedding_client is None:
+        raise HTTPException(status_code=501, detail="Embedding client not configured")
+
+    # --- Compute embeddings ---
+    vectors = await embedding_client.embed_batch(texts)
+
+    # --- Build OpenAI-compatible response ---
+    data: list[dict[str, Any]] = [
+        {
+            "object": "embedding",
+            "embedding": vec,
+            "index": idx,
+        }
+        for idx, vec in enumerate(vectors)
+    ]
+
+    total_tokens = sum(len(t.split()) for t in texts)
+
+    return {
+        "object": "list",
+        "data": data,
+        "model": model,
+        "usage": {
+            "prompt_tokens": total_tokens,
+            "total_tokens": total_tokens,
+        },
+    }

--- a/src/stronghold/embeddings/__init__.py
+++ b/src/stronghold/embeddings/__init__.py
@@ -1,0 +1,1 @@
+"""Embedding clients: InMemory (deterministic, for testing) and LiteLLM (proxy)."""

--- a/src/stronghold/embeddings/client.py
+++ b/src/stronghold/embeddings/client.py
@@ -1,0 +1,115 @@
+"""Embedding client implementations.
+
+InMemoryEmbeddingClient — deterministic hash-based 384-dim vectors for testing.
+LiteLLMEmbeddingClient — proxies to LiteLLM /embeddings endpoint.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+import struct
+from typing import Any
+
+import httpx
+
+logger = logging.getLogger("stronghold.embeddings")
+
+_DIMENSION = 384
+
+
+class InMemoryEmbeddingClient:
+    """Deterministic fake embedding client for testing.
+
+    Generates 384-dim vectors from a SHA-256 hash of the input text.
+    Same input always produces the same vector. Implements EmbeddingClient protocol.
+    """
+
+    @property
+    def dimension(self) -> int:
+        return _DIMENSION
+
+    def _hash_to_vector(self, text: str) -> list[float]:
+        """Convert text to a deterministic 384-dim vector via SHA-256 cycling."""
+        # We need 384 floats. SHA-256 gives 32 bytes = 8 floats (4 bytes each).
+        # Cycle the hash with different seeds to fill 384 dimensions.
+        result: list[float] = []
+        idx = 0
+        while len(result) < _DIMENSION:
+            digest = hashlib.sha256(f"{idx}:{text}".encode()).digest()
+            # Each 4 bytes -> one float in [-1, 1]
+            for offset in range(0, 32, 4):
+                if len(result) >= _DIMENSION:
+                    break
+                raw = struct.unpack_from(">I", digest, offset)[0]
+                # Map uint32 to [-1, 1]
+                val = (raw / 0xFFFFFFFF) * 2.0 - 1.0
+                result.append(val)
+            idx += 1
+
+        return result
+
+    async def embed(self, text: str) -> list[float]:
+        """Embed a single text. Returns a 384-dim vector."""
+        return self._hash_to_vector(text)
+
+    async def embed_batch(self, texts: list[str]) -> list[list[float]]:
+        """Embed multiple texts. Returns list of 384-dim vectors."""
+        return [self._hash_to_vector(t) for t in texts]
+
+
+class LiteLLMEmbeddingClient:
+    """Embedding client that proxies to LiteLLM /embeddings endpoint.
+
+    Implements EmbeddingClient protocol. Sends OpenAI-compatible requests
+    to the LiteLLM proxy and returns the resulting vectors.
+    """
+
+    def __init__(
+        self,
+        base_url: str,
+        api_key: str,
+        model: str = "text-embedding-3-small",
+        dim: int = _DIMENSION,
+    ) -> None:
+        self._base_url = base_url.rstrip("/")
+        self._api_key = api_key
+        self._model = model
+        self._dim = dim
+
+    @property
+    def dimension(self) -> int:
+        return self._dim
+
+    async def _request(self, input_data: str | list[str]) -> dict[str, Any]:
+        """Send an embedding request to LiteLLM."""
+        headers = {
+            "Authorization": f"Bearer {self._api_key}",
+            "Content-Type": "application/json",
+        }
+        body: dict[str, Any] = {
+            "input": input_data,
+            "model": self._model,
+        }
+        async with httpx.AsyncClient(timeout=60.0) as client:
+            resp = await client.post(
+                f"{self._base_url}/v1/embeddings",
+                json=body,
+                headers=headers,
+            )
+            resp.raise_for_status()
+            return resp.json()  # type: ignore[no-any-return]
+
+    async def embed(self, text: str) -> list[float]:
+        """Embed a single text via LiteLLM."""
+        data = await self._request(text)
+        return data["data"][0]["embedding"]  # type: ignore[no-any-return]
+
+    async def embed_batch(self, texts: list[str]) -> list[list[float]]:
+        """Embed multiple texts via LiteLLM in one request."""
+        if not texts:
+            return []
+        data = await self._request(texts)
+        # Sort by index to guarantee order
+        items = sorted(data["data"], key=lambda x: x["index"])
+        return [item["embedding"] for item in items]

--- a/tests/api/test_embeddings_route.py
+++ b/tests/api/test_embeddings_route.py
@@ -1,0 +1,374 @@
+"""Tests for POST /v1/embeddings — OpenAI-compatible embeddings endpoint.
+
+Uses real InMemoryEmbeddingClient (deterministic, no external calls).
+Auth via StaticKeyAuthProvider. No unittest.mock.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from stronghold.agents.base import Agent
+from stronghold.agents.context_builder import ContextBuilder
+from stronghold.agents.intents import IntentRegistry
+from stronghold.agents.strategies.direct import DirectStrategy
+from stronghold.api.routes.embeddings import router as embeddings_router
+from stronghold.classifier.engine import ClassifierEngine
+from stronghold.container import Container
+from stronghold.embeddings.client import InMemoryEmbeddingClient
+from stronghold.memory.learnings.extractor import ToolCorrectionExtractor
+from stronghold.memory.learnings.store import InMemoryLearningStore
+from stronghold.memory.outcomes import InMemoryOutcomeStore
+from stronghold.prompts.store import InMemoryPromptManager
+from stronghold.quota.tracker import InMemoryQuotaTracker
+from stronghold.router.selector import RouterEngine
+from stronghold.security.auth_static import StaticKeyAuthProvider
+from stronghold.security.gate import Gate
+from stronghold.security.sentinel.audit import InMemoryAuditLog
+from stronghold.security.sentinel.policy import Sentinel
+from stronghold.security.warden.detector import Warden
+from stronghold.sessions.store import InMemorySessionStore
+from stronghold.tools.executor import ToolDispatcher
+from stronghold.tools.registry import InMemoryToolRegistry
+from stronghold.tracing.noop import NoopTracingBackend
+from stronghold.types.agent import AgentIdentity
+from stronghold.types.auth import PermissionTable
+from stronghold.types.config import StrongholdConfig, TaskTypeConfig
+from tests.fakes import FakeLLMClient
+
+AUTH_HEADER = {"Authorization": "Bearer sk-test"}
+
+
+@pytest.fixture
+def embeddings_app() -> FastAPI:
+    """FastAPI app with /v1/embeddings route and InMemoryEmbeddingClient."""
+    app = FastAPI()
+    app.include_router(embeddings_router)
+
+    fake_llm = FakeLLMClient()
+    fake_llm.set_simple_response("OK")
+
+    config = StrongholdConfig(
+        providers={
+            "test": {"status": "active", "billing_cycle": "monthly", "free_tokens": 1_000_000},
+        },
+        models={
+            "test-model": {
+                "provider": "test",
+                "litellm_id": "test/model",
+                "tier": "medium",
+                "quality": 0.7,
+                "speed": 500,
+                "strengths": ["chat"],
+            },
+        },
+        task_types={
+            "chat": TaskTypeConfig(keywords=["hello"], preferred_strengths=["chat"]),
+        },
+        permissions={"admin": ["*"]},
+        router_api_key="sk-test",
+    )
+
+    prompts = InMemoryPromptManager()
+    warden = Warden()
+
+    async def setup() -> Container:
+        await prompts.upsert("agent.arbiter.soul", "You are helpful.", label="production")
+        default_agent = Agent(
+            identity=AgentIdentity(
+                name="arbiter",
+                soul_prompt_name="agent.arbiter.soul",
+                model="test/model",
+                memory_config={"learnings": True},
+            ),
+            strategy=DirectStrategy(),
+            llm=fake_llm,
+            context_builder=ContextBuilder(),
+            prompt_manager=prompts,
+            warden=warden,
+            learning_store=InMemoryLearningStore(),
+        )
+        return Container(
+            config=config,
+            auth_provider=StaticKeyAuthProvider(api_key="sk-test"),
+            permission_table=PermissionTable.from_config({"admin": ["*"]}),
+            router=RouterEngine(InMemoryQuotaTracker()),
+            classifier=ClassifierEngine(),
+            quota_tracker=InMemoryQuotaTracker(),
+            prompt_manager=prompts,
+            learning_store=InMemoryLearningStore(),
+            learning_extractor=ToolCorrectionExtractor(),
+            outcome_store=InMemoryOutcomeStore(),
+            session_store=InMemorySessionStore(),
+            audit_log=InMemoryAuditLog(),
+            warden=warden,
+            gate=Gate(warden=warden),
+            sentinel=Sentinel(
+                warden=warden,
+                permission_table=PermissionTable.from_config(config.permissions),
+                audit_log=InMemoryAuditLog(),
+            ),
+            tracer=NoopTracingBackend(),
+            context_builder=ContextBuilder(),
+            intent_registry=IntentRegistry(),
+            llm=fake_llm,
+            tool_registry=InMemoryToolRegistry(),
+            tool_dispatcher=ToolDispatcher(InMemoryToolRegistry()),
+            agents={"arbiter": default_agent},
+        )
+
+    container = asyncio.get_event_loop().run_until_complete(setup())
+    # Attach the embedding client
+    container.embedding_client = InMemoryEmbeddingClient()  # type: ignore[attr-defined]
+    app.state.container = container
+    return app
+
+
+@pytest.fixture
+def no_embed_app() -> FastAPI:
+    """FastAPI app without an embedding client configured."""
+    app = FastAPI()
+    app.include_router(embeddings_router)
+
+    fake_llm = FakeLLMClient()
+    config = StrongholdConfig(
+        providers={
+            "test": {"status": "active", "billing_cycle": "monthly", "free_tokens": 1_000_000},
+        },
+        models={
+            "test-model": {
+                "provider": "test",
+                "litellm_id": "test/model",
+                "tier": "medium",
+                "quality": 0.7,
+                "speed": 500,
+                "strengths": ["chat"],
+            },
+        },
+        task_types={
+            "chat": TaskTypeConfig(keywords=["hello"], preferred_strengths=["chat"]),
+        },
+        permissions={"admin": ["*"]},
+        router_api_key="sk-test",
+    )
+    prompts = InMemoryPromptManager()
+    warden = Warden()
+
+    async def setup() -> Container:
+        await prompts.upsert("agent.arbiter.soul", "You are helpful.", label="production")
+        default_agent = Agent(
+            identity=AgentIdentity(
+                name="arbiter",
+                soul_prompt_name="agent.arbiter.soul",
+                model="test/model",
+                memory_config={"learnings": True},
+            ),
+            strategy=DirectStrategy(),
+            llm=fake_llm,
+            context_builder=ContextBuilder(),
+            prompt_manager=prompts,
+            warden=warden,
+            learning_store=InMemoryLearningStore(),
+        )
+        return Container(
+            config=config,
+            auth_provider=StaticKeyAuthProvider(api_key="sk-test"),
+            permission_table=PermissionTable.from_config({"admin": ["*"]}),
+            router=RouterEngine(InMemoryQuotaTracker()),
+            classifier=ClassifierEngine(),
+            quota_tracker=InMemoryQuotaTracker(),
+            prompt_manager=prompts,
+            learning_store=InMemoryLearningStore(),
+            learning_extractor=ToolCorrectionExtractor(),
+            outcome_store=InMemoryOutcomeStore(),
+            session_store=InMemorySessionStore(),
+            audit_log=InMemoryAuditLog(),
+            warden=warden,
+            gate=Gate(warden=warden),
+            sentinel=Sentinel(
+                warden=warden,
+                permission_table=PermissionTable.from_config(config.permissions),
+                audit_log=InMemoryAuditLog(),
+            ),
+            tracer=NoopTracingBackend(),
+            context_builder=ContextBuilder(),
+            intent_registry=IntentRegistry(),
+            llm=fake_llm,
+            tool_registry=InMemoryToolRegistry(),
+            tool_dispatcher=ToolDispatcher(InMemoryToolRegistry()),
+            agents={"arbiter": default_agent},
+        )
+
+    container = asyncio.get_event_loop().run_until_complete(setup())
+    # Do NOT set container.embedding_client — leave it absent
+    app.state.container = container
+    return app
+
+
+# ── Auth Tests ──────────────────────────────────────────────────────
+
+
+class TestEmbeddingsAuth:
+    def test_no_auth_returns_401(self, embeddings_app: FastAPI) -> None:
+        with TestClient(embeddings_app) as client:
+            resp = client.post("/v1/embeddings", json={"input": "hello", "model": "m"})
+            assert resp.status_code == 401
+
+    def test_wrong_key_returns_401(self, embeddings_app: FastAPI) -> None:
+        with TestClient(embeddings_app) as client:
+            resp = client.post(
+                "/v1/embeddings",
+                json={"input": "hello", "model": "m"},
+                headers={"Authorization": "Bearer wrong-key"},
+            )
+            assert resp.status_code == 401
+
+
+# ── Validation Tests ────────────────────────────────────────────────
+
+
+class TestEmbeddingsValidation:
+    def test_missing_input_returns_400(self, embeddings_app: FastAPI) -> None:
+        with TestClient(embeddings_app) as client:
+            resp = client.post(
+                "/v1/embeddings",
+                json={"model": "text-embedding-3-small"},
+                headers=AUTH_HEADER,
+            )
+            assert resp.status_code == 400
+            assert "input" in resp.json()["detail"].lower()
+
+    def test_invalid_input_type_returns_400(self, embeddings_app: FastAPI) -> None:
+        with TestClient(embeddings_app) as client:
+            resp = client.post(
+                "/v1/embeddings",
+                json={"input": 42, "model": "m"},
+                headers=AUTH_HEADER,
+            )
+            assert resp.status_code == 400
+
+    def test_empty_list_returns_400(self, embeddings_app: FastAPI) -> None:
+        with TestClient(embeddings_app) as client:
+            resp = client.post(
+                "/v1/embeddings",
+                json={"input": [], "model": "m"},
+                headers=AUTH_HEADER,
+            )
+            assert resp.status_code == 400
+
+
+# ── Single Input ────────────────────────────────────────────────────
+
+
+class TestEmbeddingsSingleInput:
+    def test_string_input_returns_one_embedding(self, embeddings_app: FastAPI) -> None:
+        with TestClient(embeddings_app) as client:
+            resp = client.post(
+                "/v1/embeddings",
+                json={"input": "hello world", "model": "text-embedding-3-small"},
+                headers=AUTH_HEADER,
+            )
+            assert resp.status_code == 200
+            data = resp.json()
+            assert data["object"] == "list"
+            assert data["model"] == "text-embedding-3-small"
+            assert len(data["data"]) == 1
+            item = data["data"][0]
+            assert item["object"] == "embedding"
+            assert item["index"] == 0
+            assert len(item["embedding"]) == 384
+
+    def test_response_has_usage(self, embeddings_app: FastAPI) -> None:
+        with TestClient(embeddings_app) as client:
+            resp = client.post(
+                "/v1/embeddings",
+                json={"input": "some text", "model": "m"},
+                headers=AUTH_HEADER,
+            )
+            assert resp.status_code == 200
+            usage = resp.json()["usage"]
+            assert "prompt_tokens" in usage
+            assert "total_tokens" in usage
+            assert usage["prompt_tokens"] > 0
+
+
+# ── Batch Input ─────────────────────────────────────────────────────
+
+
+class TestEmbeddingsBatchInput:
+    def test_list_input_returns_multiple_embeddings(self, embeddings_app: FastAPI) -> None:
+        with TestClient(embeddings_app) as client:
+            resp = client.post(
+                "/v1/embeddings",
+                json={"input": ["alpha", "bravo", "charlie"], "model": "m"},
+                headers=AUTH_HEADER,
+            )
+            assert resp.status_code == 200
+            data = resp.json()
+            assert len(data["data"]) == 3
+            indices = [d["index"] for d in data["data"]]
+            assert indices == [0, 1, 2]
+
+    def test_each_embedding_is_384_dim(self, embeddings_app: FastAPI) -> None:
+        with TestClient(embeddings_app) as client:
+            resp = client.post(
+                "/v1/embeddings",
+                json={"input": ["one", "two"], "model": "m"},
+                headers=AUTH_HEADER,
+            )
+            for item in resp.json()["data"]:
+                assert len(item["embedding"]) == 384
+
+
+# ── Determinism ─────────────────────────────────────────────────────
+
+
+class TestEmbeddingsDeterminism:
+    def test_same_input_same_output(self, embeddings_app: FastAPI) -> None:
+        with TestClient(embeddings_app) as client:
+            resp1 = client.post(
+                "/v1/embeddings",
+                json={"input": "deterministic", "model": "m"},
+                headers=AUTH_HEADER,
+            )
+            resp2 = client.post(
+                "/v1/embeddings",
+                json={"input": "deterministic", "model": "m"},
+                headers=AUTH_HEADER,
+            )
+            assert resp1.json()["data"][0]["embedding"] == resp2.json()["data"][0]["embedding"]
+
+
+# ── No Embedding Client Configured ──────────────────────────────────
+
+
+class TestEmbeddingsNotConfigured:
+    def test_returns_501_when_no_client(self, no_embed_app: FastAPI) -> None:
+        with TestClient(no_embed_app) as client:
+            resp = client.post(
+                "/v1/embeddings",
+                json={"input": "hello", "model": "m"},
+                headers=AUTH_HEADER,
+            )
+            assert resp.status_code == 501
+            assert "not configured" in resp.json()["detail"].lower()
+
+
+# ── Default Model ───────────────────────────────────────────────────
+
+
+class TestEmbeddingsDefaultModel:
+    def test_default_model_when_omitted(self, embeddings_app: FastAPI) -> None:
+        with TestClient(embeddings_app) as client:
+            resp = client.post(
+                "/v1/embeddings",
+                json={"input": "hello"},
+                headers=AUTH_HEADER,
+            )
+            assert resp.status_code == 200
+            assert resp.json()["model"] == "text-embedding-3-small"

--- a/tests/embeddings/test_client.py
+++ b/tests/embeddings/test_client.py
@@ -1,0 +1,224 @@
+"""Tests for InMemoryEmbeddingClient and LiteLLMEmbeddingClient.
+
+InMemoryEmbeddingClient: deterministic hash-based 384-dim vectors.
+LiteLLMEmbeddingClient: proxies to LiteLLM /embeddings endpoint (uses respx for HTTP).
+"""
+
+from __future__ import annotations
+
+import pytest
+import respx
+from httpx import Response as HttpxResponse
+
+from stronghold.embeddings.client import InMemoryEmbeddingClient, LiteLLMEmbeddingClient
+from stronghold.protocols.embeddings import EmbeddingClient
+
+
+# ── InMemoryEmbeddingClient ─────────────────────────────────────────
+
+
+class TestInMemoryProtocolConformance:
+    """InMemoryEmbeddingClient implements EmbeddingClient protocol."""
+
+    def test_is_embedding_client(self) -> None:
+        client = InMemoryEmbeddingClient()
+        assert isinstance(client, EmbeddingClient)
+
+    def test_dimension_is_384(self) -> None:
+        client = InMemoryEmbeddingClient()
+        assert client.dimension == 384
+
+
+class TestInMemoryEmbed:
+    """embed() returns deterministic 384-dim vectors."""
+
+    async def test_returns_384_floats(self) -> None:
+        client = InMemoryEmbeddingClient()
+        vec = await client.embed("hello world")
+        assert len(vec) == 384
+        assert all(isinstance(v, float) for v in vec)
+
+    async def test_values_in_range(self) -> None:
+        client = InMemoryEmbeddingClient()
+        vec = await client.embed("test input")
+        assert all(-1.0 <= v <= 1.0 for v in vec)
+
+    async def test_deterministic(self) -> None:
+        client = InMemoryEmbeddingClient()
+        v1 = await client.embed("same text")
+        v2 = await client.embed("same text")
+        assert v1 == v2
+
+    async def test_different_inputs_different_vectors(self) -> None:
+        client = InMemoryEmbeddingClient()
+        v1 = await client.embed("hello")
+        v2 = await client.embed("goodbye")
+        assert v1 != v2
+
+
+class TestInMemoryEmbedBatch:
+    """embed_batch() returns a list of vectors, one per input."""
+
+    async def test_batch_returns_correct_count(self) -> None:
+        client = InMemoryEmbeddingClient()
+        texts = ["alpha", "bravo", "charlie"]
+        result = await client.embed_batch(texts)
+        assert len(result) == 3
+        assert all(len(v) == 384 for v in result)
+
+    async def test_batch_matches_individual(self) -> None:
+        client = InMemoryEmbeddingClient()
+        texts = ["one", "two"]
+        batch = await client.embed_batch(texts)
+        individual = [await client.embed(t) for t in texts]
+        assert batch == individual
+
+    async def test_empty_batch(self) -> None:
+        client = InMemoryEmbeddingClient()
+        result = await client.embed_batch([])
+        assert result == []
+
+
+# ── LiteLLMEmbeddingClient ──────────────────────────────────────────
+
+
+class TestLiteLLMProtocolConformance:
+    """LiteLLMEmbeddingClient implements EmbeddingClient protocol."""
+
+    def test_is_embedding_client(self) -> None:
+        client = LiteLLMEmbeddingClient(
+            base_url="http://fake:4000",
+            api_key="sk-test",
+        )
+        assert isinstance(client, EmbeddingClient)
+
+    def test_dimension_default(self) -> None:
+        client = LiteLLMEmbeddingClient(
+            base_url="http://fake:4000",
+            api_key="sk-test",
+        )
+        assert client.dimension == 384
+
+    def test_dimension_custom(self) -> None:
+        client = LiteLLMEmbeddingClient(
+            base_url="http://fake:4000",
+            api_key="sk-test",
+            dim=1536,
+        )
+        assert client.dimension == 1536
+
+
+class TestLiteLLMEmbed:
+    """embed() calls LiteLLM and returns the vector."""
+
+    @respx.mock
+    async def test_embed_single(self) -> None:
+        respx.post("http://fake:4000/v1/embeddings").mock(
+            return_value=HttpxResponse(
+                200,
+                json={
+                    "object": "list",
+                    "data": [{"object": "embedding", "embedding": [0.1, 0.2, 0.3], "index": 0}],
+                    "model": "text-embedding-3-small",
+                    "usage": {"prompt_tokens": 2, "total_tokens": 2},
+                },
+            )
+        )
+        client = LiteLLMEmbeddingClient(
+            base_url="http://fake:4000",
+            api_key="sk-test",
+        )
+        vec = await client.embed("hello")
+        assert vec == [0.1, 0.2, 0.3]
+
+    @respx.mock
+    async def test_embed_sends_auth_header(self) -> None:
+        route = respx.post("http://fake:4000/v1/embeddings").mock(
+            return_value=HttpxResponse(
+                200,
+                json={
+                    "object": "list",
+                    "data": [{"object": "embedding", "embedding": [0.5], "index": 0}],
+                    "model": "m",
+                    "usage": {"prompt_tokens": 1, "total_tokens": 1},
+                },
+            )
+        )
+        client = LiteLLMEmbeddingClient(
+            base_url="http://fake:4000",
+            api_key="sk-secret-key",
+        )
+        await client.embed("test")
+        assert route.called
+        req = route.calls[0].request
+        assert req.headers["authorization"] == "Bearer sk-secret-key"
+
+
+class TestLiteLLMEmbedBatch:
+    """embed_batch() sends a list and returns vectors in order."""
+
+    @respx.mock
+    async def test_batch_returns_ordered(self) -> None:
+        # Return out-of-order to verify sorting
+        respx.post("http://fake:4000/v1/embeddings").mock(
+            return_value=HttpxResponse(
+                200,
+                json={
+                    "object": "list",
+                    "data": [
+                        {"object": "embedding", "embedding": [0.2], "index": 1},
+                        {"object": "embedding", "embedding": [0.1], "index": 0},
+                    ],
+                    "model": "text-embedding-3-small",
+                    "usage": {"prompt_tokens": 4, "total_tokens": 4},
+                },
+            )
+        )
+        client = LiteLLMEmbeddingClient(
+            base_url="http://fake:4000",
+            api_key="sk-test",
+        )
+        result = await client.embed_batch(["first", "second"])
+        assert result == [[0.1], [0.2]]
+
+    @respx.mock
+    async def test_batch_empty_returns_empty(self) -> None:
+        # Should not even make an HTTP call
+        route = respx.post("http://fake:4000/v1/embeddings").mock(
+            return_value=HttpxResponse(200, json={"data": []}),
+        )
+        client = LiteLLMEmbeddingClient(
+            base_url="http://fake:4000",
+            api_key="sk-test",
+        )
+        result = await client.embed_batch([])
+        assert result == []
+        assert not route.called
+
+
+class TestLiteLLMErrorHandling:
+    """LiteLLMEmbeddingClient raises on HTTP errors."""
+
+    @respx.mock
+    async def test_401_raises(self) -> None:
+        respx.post("http://fake:4000/v1/embeddings").mock(
+            return_value=HttpxResponse(401, json={"error": "unauthorized"}),
+        )
+        client = LiteLLMEmbeddingClient(
+            base_url="http://fake:4000",
+            api_key="bad-key",
+        )
+        with pytest.raises(Exception):  # noqa: B017
+            await client.embed("test")
+
+    @respx.mock
+    async def test_500_raises(self) -> None:
+        respx.post("http://fake:4000/v1/embeddings").mock(
+            return_value=HttpxResponse(500, json={"error": "internal"}),
+        )
+        client = LiteLLMEmbeddingClient(
+            base_url="http://fake:4000",
+            api_key="sk-test",
+        )
+        with pytest.raises(Exception):  # noqa: B017
+            await client.embed("test")


### PR DESCRIPTION
Closes #157. InMemoryEmbeddingClient (deterministic 384-dim) + LiteLLMEmbeddingClient (HTTP proxy). POST /v1/embeddings with auth. 30 tests.