### PR TITLE
feat: add agent marketplace for browsing, rating, and installing agents

### DIFF
--- a/src/stronghold/marketplace/__init__.py
+++ b/src/stronghold/marketplace/__init__.py
@@ -1,0 +1,1 @@
+"""Agent marketplace — browse, rate, and install community agents."""

--- a/src/stronghold/marketplace/agents.py
+++ b/src/stronghold/marketplace/agents.py
@@ -1,0 +1,145 @@
+"""Agent marketplace: publish, search, rate, and retrieve community agents.
+
+Provides an in-memory implementation for browsing and rating agent listings.
+The marketplace enforces rating bounds (1-5), prevents duplicate publishes,
+and maintains running average ratings on each listing.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field, replace
+from datetime import UTC, datetime
+
+logger = logging.getLogger("stronghold.marketplace.agents")
+
+
+@dataclass(frozen=True)
+class AgentListing:
+    """A published agent in the marketplace."""
+
+    name: str
+    description: str = ""
+    author: str = ""
+    version: str = "1.0.0"
+    trust_tier: str = "t2"
+    install_count: int = 0
+    avg_rating: float = 0.0
+    tags: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
+class AgentRating:
+    """A user rating for a marketplace agent."""
+
+    agent_name: str
+    user_id: str
+    org_id: str
+    rating: int
+    comment: str = ""
+    timestamp: datetime = field(default_factory=lambda: datetime.now(UTC))
+
+
+class InMemoryAgentMarketplace:
+    """In-memory agent marketplace.
+
+    Stores published listings and user ratings. Supports search by
+    name, description, and tags with configurable result limits.
+    """
+
+    def __init__(self) -> None:
+        self._listings: dict[str, AgentListing] = {}
+        self._ratings: dict[str, list[AgentRating]] = {}
+
+    async def publish(self, listing: AgentListing) -> AgentListing:
+        """Publish an agent listing to the marketplace.
+
+        Raises ValueError if the name is empty or already published.
+        """
+        if not listing.name:
+            msg = "Agent name is required"
+            raise ValueError(msg)
+        if listing.name in self._listings:
+            msg = f"Agent '{listing.name}' is already published"
+            raise ValueError(msg)
+        self._listings[listing.name] = listing
+        logger.info(
+            "Agent '%s' published by %s (v%s)", listing.name, listing.author, listing.version
+        )
+        return listing
+
+    async def search(
+        self,
+        query: str,
+        tags: list[str] | None = None,
+        limit: int = 20,
+    ) -> list[AgentListing]:
+        """Search listings by name, description, and tags.
+
+        An empty query with no tag filter returns all listings (up to limit).
+        """
+        query_lower = query.lower().strip()
+        tag_set = {t.lower() for t in tags} if tags else set()
+
+        results: list[AgentListing] = []
+        for listing in self._listings.values():
+            # Tag filter: if tags specified, listing must have at least one matching tag
+            if tag_set:
+                listing_tags = {t.lower() for t in listing.tags}
+                if not tag_set & listing_tags:
+                    continue
+
+            # Text filter: match against name or description
+            if query_lower:
+                name_match = query_lower in listing.name.lower()
+                desc_match = query_lower in listing.description.lower()
+                if not (name_match or desc_match):
+                    continue
+
+            results.append(listing)
+            if len(results) >= limit:
+                break
+
+        return results
+
+    async def rate(self, rating: AgentRating) -> AgentRating:
+        """Rate a marketplace agent (1-5).
+
+        Updates the listing's avg_rating. Raises ValueError for invalid
+        ratings or unknown agents.
+        """
+        if rating.rating < 1 or rating.rating > 5:
+            msg = "Rating must be between 1 and 5"
+            raise ValueError(msg)
+        if rating.agent_name not in self._listings:
+            msg = f"Agent '{rating.agent_name}' not found in marketplace"
+            raise ValueError(msg)
+
+        # Store the rating
+        if rating.agent_name not in self._ratings:
+            self._ratings[rating.agent_name] = []
+        self._ratings[rating.agent_name].append(rating)
+
+        # Recalculate average
+        agent_ratings = self._ratings[rating.agent_name]
+        avg = sum(r.rating for r in agent_ratings) / len(agent_ratings)
+        self._listings[rating.agent_name] = replace(
+            self._listings[rating.agent_name], avg_rating=avg
+        )
+
+        logger.info(
+            "Agent '%s' rated %d/5 by %s (new avg: %.1f)",
+            rating.agent_name,
+            rating.rating,
+            rating.user_id,
+            avg,
+        )
+        return rating
+
+    async def get_ratings(self, agent_name: str) -> list[AgentRating]:
+        """Get all ratings for an agent."""
+        return list(self._ratings.get(agent_name, []))
+
+    async def get_listing(self, agent_name: str) -> AgentListing | None:
+        """Get a single agent listing by name, or None if not found."""
+        return self._listings.get(agent_name)

--- a/tests/marketplace/test_agents.py
+++ b/tests/marketplace/test_agents.py
@@ -1,0 +1,228 @@
+"""Tests for agent marketplace — browse, rate, install community agents."""
+
+from __future__ import annotations
+
+import pytest
+
+from stronghold.marketplace.agents import (
+    AgentListing,
+    AgentRating,
+    InMemoryAgentMarketplace,
+)
+
+
+@pytest.fixture
+def marketplace() -> InMemoryAgentMarketplace:
+    """Fresh marketplace instance for each test."""
+    return InMemoryAgentMarketplace()
+
+
+def _sample_listing(**overrides: object) -> AgentListing:
+    """Build a sample AgentListing with sensible defaults."""
+    defaults: dict[str, object] = {
+        "name": "code-reviewer",
+        "description": "Reviews code for quality and security issues",
+        "author": "stronghold-team",
+        "version": "1.0.0",
+        "trust_tier": "t2",
+        "install_count": 0,
+        "avg_rating": 0.0,
+        "tags": ("code", "review", "security"),
+    }
+    defaults.update(overrides)
+    return AgentListing(**defaults)  # type: ignore[arg-type]
+
+
+def _sample_rating(**overrides: object) -> AgentRating:
+    """Build a sample AgentRating with sensible defaults."""
+    defaults: dict[str, object] = {
+        "agent_name": "code-reviewer",
+        "user_id": "user-1",
+        "org_id": "org-1",
+        "rating": 4,
+        "comment": "Works great!",
+    }
+    defaults.update(overrides)
+    return AgentRating(**defaults)  # type: ignore[arg-type]
+
+
+# ── Publish ──────────────────────────────────────────────────────────
+
+
+class TestPublish:
+    """Tests for publishing agent listings."""
+
+    async def test_publish_returns_listing(
+        self, marketplace: InMemoryAgentMarketplace
+    ) -> None:
+        listing = _sample_listing()
+        result = await marketplace.publish(listing)
+        assert result.name == "code-reviewer"
+        assert result.author == "stronghold-team"
+        assert result.version == "1.0.0"
+
+    async def test_publish_duplicate_raises(
+        self, marketplace: InMemoryAgentMarketplace
+    ) -> None:
+        listing = _sample_listing()
+        await marketplace.publish(listing)
+        with pytest.raises(ValueError, match="already published"):
+            await marketplace.publish(listing)
+
+    async def test_publish_empty_name_raises(
+        self, marketplace: InMemoryAgentMarketplace
+    ) -> None:
+        listing = _sample_listing(name="")
+        with pytest.raises(ValueError, match="name.*required"):
+            await marketplace.publish(listing)
+
+
+# ── Search ───────────────────────────────────────────────────────────
+
+
+class TestSearch:
+    """Tests for searching the marketplace."""
+
+    async def test_search_by_name(
+        self, marketplace: InMemoryAgentMarketplace
+    ) -> None:
+        await marketplace.publish(_sample_listing(name="code-reviewer"))
+        await marketplace.publish(
+            _sample_listing(name="doc-writer", description="Writes documentation")
+        )
+        results = await marketplace.search("code")
+        assert len(results) == 1
+        assert results[0].name == "code-reviewer"
+
+    async def test_search_by_description(
+        self, marketplace: InMemoryAgentMarketplace
+    ) -> None:
+        await marketplace.publish(
+            _sample_listing(name="sec-scanner", description="Scans for vulnerabilities")
+        )
+        results = await marketplace.search("vulnerabilities")
+        assert len(results) == 1
+        assert results[0].name == "sec-scanner"
+
+    async def test_search_by_tags(
+        self, marketplace: InMemoryAgentMarketplace
+    ) -> None:
+        await marketplace.publish(
+            _sample_listing(name="agent-a", tags=("python", "testing"))
+        )
+        await marketplace.publish(
+            _sample_listing(name="agent-b", tags=("rust", "systems"))
+        )
+        results = await marketplace.search("", tags=["python"])
+        assert len(results) == 1
+        assert results[0].name == "agent-a"
+
+    async def test_search_empty_query_returns_all(
+        self, marketplace: InMemoryAgentMarketplace
+    ) -> None:
+        await marketplace.publish(_sample_listing(name="agent-1"))
+        await marketplace.publish(_sample_listing(name="agent-2"))
+        await marketplace.publish(_sample_listing(name="agent-3"))
+        results = await marketplace.search("")
+        assert len(results) == 3
+
+    async def test_search_respects_limit(
+        self, marketplace: InMemoryAgentMarketplace
+    ) -> None:
+        for i in range(10):
+            await marketplace.publish(_sample_listing(name=f"agent-{i}"))
+        results = await marketplace.search("", limit=3)
+        assert len(results) == 3
+
+    async def test_search_no_match_returns_empty(
+        self, marketplace: InMemoryAgentMarketplace
+    ) -> None:
+        await marketplace.publish(_sample_listing(name="code-reviewer"))
+        results = await marketplace.search("nonexistent-xyz")
+        assert results == []
+
+
+# ── Rate ─────────────────────────────────────────────────────────────
+
+
+class TestRate:
+    """Tests for rating agents."""
+
+    async def test_rate_valid(
+        self, marketplace: InMemoryAgentMarketplace
+    ) -> None:
+        await marketplace.publish(_sample_listing())
+        rating = _sample_rating(rating=5)
+        result = await marketplace.rate(rating)
+        assert result.rating == 5
+        assert result.agent_name == "code-reviewer"
+
+    async def test_rate_updates_avg_rating(
+        self, marketplace: InMemoryAgentMarketplace
+    ) -> None:
+        await marketplace.publish(_sample_listing())
+        await marketplace.rate(_sample_rating(user_id="u1", rating=4))
+        await marketplace.rate(_sample_rating(user_id="u2", rating=2))
+        listing = await marketplace.get_listing("code-reviewer")
+        assert listing is not None
+        assert listing.avg_rating == pytest.approx(3.0)
+
+    async def test_rate_invalid_range_raises(
+        self, marketplace: InMemoryAgentMarketplace
+    ) -> None:
+        await marketplace.publish(_sample_listing())
+        with pytest.raises(ValueError, match="between 1 and 5"):
+            await marketplace.rate(_sample_rating(rating=0))
+        with pytest.raises(ValueError, match="between 1 and 5"):
+            await marketplace.rate(_sample_rating(rating=6))
+
+    async def test_rate_unknown_agent_raises(
+        self, marketplace: InMemoryAgentMarketplace
+    ) -> None:
+        rating = _sample_rating(agent_name="nonexistent")
+        with pytest.raises(ValueError, match="not found"):
+            await marketplace.rate(rating)
+
+
+# ── Get ratings ──────────────────────────────────────────────────────
+
+
+class TestGetRatings:
+    """Tests for retrieving ratings."""
+
+    async def test_get_ratings_returns_all(
+        self, marketplace: InMemoryAgentMarketplace
+    ) -> None:
+        await marketplace.publish(_sample_listing())
+        await marketplace.rate(_sample_rating(user_id="u1", rating=5))
+        await marketplace.rate(_sample_rating(user_id="u2", rating=3))
+        ratings = await marketplace.get_ratings("code-reviewer")
+        assert len(ratings) == 2
+        assert {r.user_id for r in ratings} == {"u1", "u2"}
+
+    async def test_get_ratings_empty(
+        self, marketplace: InMemoryAgentMarketplace
+    ) -> None:
+        ratings = await marketplace.get_ratings("nonexistent")
+        assert ratings == []
+
+
+# ── Get listing ──────────────────────────────────────────────────────
+
+
+class TestGetListing:
+    """Tests for retrieving a single listing."""
+
+    async def test_get_listing_exists(
+        self, marketplace: InMemoryAgentMarketplace
+    ) -> None:
+        await marketplace.publish(_sample_listing())
+        listing = await marketplace.get_listing("code-reviewer")
+        assert listing is not None
+        assert listing.name == "code-reviewer"
+
+    async def test_get_listing_not_found(
+        self, marketplace: InMemoryAgentMarketplace
+    ) -> None:
+        listing = await marketplace.get_listing("nonexistent")
+        assert listing is None


### PR DESCRIPTION
Closes #138. InMemoryAgentMarketplace with publish, search (text+tags), rate (1-5 with avg), get_ratings, get_listing. 17 tests.