### PR TITLE
feat: add Stronghold CLI for agent management and status

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,9 @@ dev = [
     "types-regex>=2024.0.0",
 ]
 
+[project.scripts]
+stronghold = "stronghold.cli.main:main"
+
 [tool.setuptools.packages.find]
 where = ["src"]
 

--- a/src/stronghold/cli/__init__.py
+++ b/src/stronghold/cli/__init__.py
@@ -1,0 +1,1 @@
+"""Stronghold CLI — agent management, status, and diagnostics."""

--- a/src/stronghold/cli/main.py
+++ b/src/stronghold/cli/main.py
@@ -1,0 +1,323 @@
+"""Stronghold CLI entry point.
+
+Subcommands:
+    agent list                  List all registered agents
+    agent import <path>         Import an agent from a GitAgent zip
+    agent export <name> <out>   Export an agent to a GitAgent zip
+    status                      Show system status (agents, intents, quota)
+    status models               List available models
+    status quota                Show quota usage per provider
+
+Environment:
+    STRONGHOLD_URL      Base URL (default: http://localhost:8100)
+    STRONGHOLD_API_KEY  API key for authentication
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import os
+import sys
+from pathlib import Path
+from typing import IO, Any
+
+import httpx
+
+
+def get_client_config() -> dict[str, str]:
+    """Read connection config from environment variables."""
+    return {
+        "base_url": os.environ.get("STRONGHOLD_URL", "http://localhost:8100"),
+        "api_key": os.environ.get("STRONGHOLD_API_KEY", ""),
+    }
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Build the CLI argument parser with all subcommands."""
+    parser = argparse.ArgumentParser(
+        prog="stronghold",
+        description="Stronghold CLI — Secure Agent Governance Platform",
+    )
+    parser.add_argument(
+        "--format",
+        choices=["json", "table"],
+        default="table",
+        help="Output format (default: table)",
+    )
+
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    # ── agent ───────────────────────────────────────────────────────
+    agent_parser = subparsers.add_parser("agent", help="Agent management")
+    agent_sub = agent_parser.add_subparsers(dest="agent_action", required=True)
+
+    # agent list
+    list_parser = agent_sub.add_parser("list", help="List all agents")
+    list_parser.add_argument(
+        "--format",
+        choices=["json", "table"],
+        default="table",
+        help="Output format",
+    )
+
+    # agent import <path>
+    import_parser = agent_sub.add_parser("import", help="Import agent from zip")
+    import_parser.add_argument("path", help="Path to GitAgent zip file")
+    import_parser.add_argument(
+        "--format",
+        choices=["json", "table"],
+        default="table",
+        help="Output format",
+    )
+
+    # agent export <name> <output>
+    export_parser = agent_sub.add_parser("export", help="Export agent to zip")
+    export_parser.add_argument("name", help="Agent name to export")
+    export_parser.add_argument("output", help="Output path for zip file")
+    export_parser.add_argument(
+        "--format",
+        choices=["json", "table"],
+        default="table",
+        help="Output format",
+    )
+
+    # ── status ──────────────────────────────────────────────────────
+    status_parser = subparsers.add_parser("status", help="System status")
+    status_parser.add_argument(
+        "--format",
+        choices=["json", "table"],
+        default="table",
+        help="Output format",
+    )
+    status_sub = status_parser.add_subparsers(dest="status_action")
+
+    # status models
+    models_parser = status_sub.add_parser("models", help="List available models")
+    models_parser.add_argument(
+        "--format",
+        choices=["json", "table"],
+        default="table",
+        help="Output format",
+    )
+
+    # status quota
+    quota_parser = status_sub.add_parser("quota", help="Show quota usage")
+    quota_parser.add_argument(
+        "--format",
+        choices=["json", "table"],
+        default="table",
+        help="Output format",
+    )
+
+    return parser
+
+
+def format_output(data: Any, *, fmt: str = "table") -> str:
+    """Format data as JSON or a human-readable table.
+
+    Handles both list-of-dicts (e.g. agent list) and single dicts (e.g. status).
+    """
+    if fmt == "json":
+        return json.dumps(data, indent=2, default=str)
+
+    # Table format
+    if isinstance(data, list):
+        if not data:
+            return "No results."
+        if isinstance(data[0], dict):
+            keys = list(data[0].keys())
+            widths = {k: max(len(k), *(len(str(row.get(k, ""))) for row in data)) for k in keys}
+            header = "  ".join(k.ljust(widths[k]) for k in keys)
+            sep = "  ".join("-" * widths[k] for k in keys)
+            rows = ["  ".join(str(row.get(k, "")).ljust(widths[k]) for k in keys) for row in data]
+            return "\n".join([header, sep, *rows])
+        return "\n".join(str(item) for item in data)
+
+    if isinstance(data, dict):
+        max_key = max(len(str(k)) for k in data) if data else 0
+        lines = [f"{str(k).ljust(max_key)}  {v}" for k, v in data.items()]
+        return "\n".join(lines)
+
+    return str(data)
+
+
+def _make_headers(api_key: str) -> dict[str, str]:
+    """Build HTTP headers for Stronghold API requests."""
+    headers: dict[str, str] = {}
+    if api_key:
+        headers["Authorization"] = f"Bearer {api_key}"
+    return headers
+
+
+async def _agent_list(
+    client: httpx.AsyncClient,
+    headers: dict[str, str],
+    fmt: str,
+    output: IO[str],
+) -> int:
+    """List all agents."""
+    resp = await client.get("/v1/stronghold/agents", headers=headers)
+    if resp.status_code != 200:  # noqa: PLR2004
+        output.write(f"Error {resp.status_code}: {resp.text}\n")
+        return 1
+    data = resp.json()
+    output.write(format_output(data, fmt=fmt) + "\n")
+    return 0
+
+
+async def _agent_import(
+    client: httpx.AsyncClient,
+    headers: dict[str, str],
+    path: str,
+    fmt: str,
+    output: IO[str],
+) -> int:
+    """Import an agent from a zip file."""
+    zip_path = Path(path)
+    if not zip_path.exists():
+        output.write(f"Error: file not found: {path}\n")
+        return 1
+    zip_data = zip_path.read_bytes()
+    resp = await client.post(
+        "/v1/stronghold/agents/import",
+        content=zip_data,
+        headers={**headers, "content-type": "application/octet-stream"},
+    )
+    if resp.status_code not in (200, 201):
+        output.write(f"Error {resp.status_code}: {resp.text}\n")
+        return 1
+    data = resp.json()
+    output.write(format_output(data, fmt=fmt) + "\n")
+    return 0
+
+
+async def _agent_export(
+    client: httpx.AsyncClient,
+    headers: dict[str, str],
+    name: str,
+    output_path: str,
+    output: IO[str],
+) -> int:
+    """Export an agent to a zip file."""
+    resp = await client.get(f"/v1/stronghold/agents/{name}/export", headers=headers)
+    if resp.status_code != 200:  # noqa: PLR2004
+        output.write(f"Error {resp.status_code}: {resp.text}\n")
+        return 1
+    Path(output_path).write_bytes(resp.content)
+    output.write(f"Exported '{name}' to {output_path}\n")
+    return 0
+
+
+async def _status(
+    client: httpx.AsyncClient,
+    headers: dict[str, str],
+    fmt: str,
+    output: IO[str],
+) -> int:
+    """Show system status."""
+    resp = await client.get("/v1/stronghold/status", headers=headers)
+    if resp.status_code != 200:  # noqa: PLR2004
+        output.write(f"Error {resp.status_code}: {resp.text}\n")
+        return 1
+    data = resp.json()
+    output.write(format_output(data, fmt=fmt) + "\n")
+    return 0
+
+
+async def _status_models(
+    client: httpx.AsyncClient,
+    headers: dict[str, str],
+    fmt: str,
+    output: IO[str],
+) -> int:
+    """List available models."""
+    resp = await client.get("/v1/models", headers=headers)
+    if resp.status_code != 200:  # noqa: PLR2004
+        output.write(f"Error {resp.status_code}: {resp.text}\n")
+        return 1
+    data = resp.json()
+    output.write(format_output(data, fmt=fmt) + "\n")
+    return 0
+
+
+async def _status_quota(
+    client: httpx.AsyncClient,
+    headers: dict[str, str],
+    fmt: str,
+    output: IO[str],
+) -> int:
+    """Show quota usage."""
+    resp = await client.get("/v1/stronghold/status", headers=headers)
+    if resp.status_code != 200:  # noqa: PLR2004
+        output.write(f"Error {resp.status_code}: {resp.text}\n")
+        return 1
+    data = resp.json()
+    quota = data.get("quota_usage", {})
+    output.write(format_output(quota, fmt=fmt) + "\n")
+    return 0
+
+
+async def run(
+    argv: list[str] | None = None,
+    *,
+    env_url: str | None = None,
+    env_key: str | None = None,
+    output: IO[str] | None = None,
+) -> int:
+    """Run the CLI with the given arguments.
+
+    Parameters allow injection for testing: env_url/env_key override environment
+    variables, output overrides sys.stdout.
+    """
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    out = output or sys.stdout
+    fmt: str = args.format
+
+    # Resolve config
+    if env_url is None or env_key is None:
+        cfg = get_client_config()
+        base_url = env_url if env_url is not None else cfg["base_url"]
+        api_key = env_key if env_key is not None else cfg["api_key"]
+    else:
+        base_url = env_url
+        api_key = env_key
+
+    headers = _make_headers(api_key)
+
+    try:
+        async with httpx.AsyncClient(base_url=base_url, timeout=30.0) as client:
+            if args.command == "agent":
+                if args.agent_action == "list":
+                    return await _agent_list(client, headers, fmt, out)
+                if args.agent_action == "import":
+                    return await _agent_import(client, headers, args.path, fmt, out)
+                if args.agent_action == "export":
+                    return await _agent_export(client, headers, args.name, args.output, out)
+            elif args.command == "status":
+                action = getattr(args, "status_action", None)
+                if action == "models":
+                    return await _status_models(client, headers, fmt, out)
+                if action == "quota":
+                    return await _status_quota(client, headers, fmt, out)
+                return await _status(client, headers, fmt, out)
+    except httpx.ConnectError as exc:
+        out.write(f"Error: could not connect to {base_url} ({exc})\n")
+        return 1
+    except httpx.HTTPError as exc:
+        out.write(f"Error: HTTP request failed ({exc})\n")
+        return 1
+
+    return 0
+
+
+def main() -> None:
+    """Console script entry point."""
+    code = asyncio.run(run())
+    sys.exit(code)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/cli/test_main.py
+++ b/tests/cli/test_main.py
@@ -1,0 +1,353 @@
+"""Tests for the Stronghold CLI.
+
+Covers argument parsing, output formatting, env var config, and HTTP interactions
+using respx to mock external calls.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from io import StringIO
+from typing import Any
+from unittest.mock import patch
+
+import httpx
+import pytest
+import respx
+
+from stronghold.cli.main import build_parser, format_output, run
+
+# ── Argument Parsing ────────────────────────────────────────────────
+
+
+class TestBuildParser:
+    """Verify argparse subcommands and options are wired correctly."""
+
+    def test_agent_list_parses(self) -> None:
+        parser = build_parser()
+        args = parser.parse_args(["agent", "list"])
+        assert args.command == "agent"
+        assert args.agent_action == "list"
+
+    def test_agent_list_with_json_format(self) -> None:
+        parser = build_parser()
+        args = parser.parse_args(["agent", "list", "--format", "json"])
+        assert args.format == "json"
+
+    def test_agent_list_with_table_format(self) -> None:
+        parser = build_parser()
+        args = parser.parse_args(["agent", "list", "--format", "table"])
+        assert args.format == "table"
+
+    def test_agent_import_requires_path(self) -> None:
+        parser = build_parser()
+        args = parser.parse_args(["agent", "import", "/tmp/agent.zip"])
+        assert args.agent_action == "import"
+        assert args.path == "/tmp/agent.zip"
+
+    def test_agent_import_missing_path_exits(self) -> None:
+        parser = build_parser()
+        with pytest.raises(SystemExit):
+            parser.parse_args(["agent", "import"])
+
+    def test_agent_export_requires_name_and_output(self) -> None:
+        parser = build_parser()
+        args = parser.parse_args(["agent", "export", "ranger", "/tmp/ranger.zip"])
+        assert args.agent_action == "export"
+        assert args.name == "ranger"
+        assert args.output == "/tmp/ranger.zip"
+
+    def test_agent_export_missing_output_exits(self) -> None:
+        parser = build_parser()
+        with pytest.raises(SystemExit):
+            parser.parse_args(["agent", "export", "ranger"])
+
+    def test_status_parses(self) -> None:
+        parser = build_parser()
+        args = parser.parse_args(["status"])
+        assert args.command == "status"
+
+    def test_status_models_parses(self) -> None:
+        parser = build_parser()
+        args = parser.parse_args(["status", "models"])
+        assert args.status_action == "models"
+
+    def test_status_quota_parses(self) -> None:
+        parser = build_parser()
+        args = parser.parse_args(["status", "quota"])
+        assert args.status_action == "quota"
+
+    def test_default_format_is_table(self) -> None:
+        parser = build_parser()
+        args = parser.parse_args(["agent", "list"])
+        assert args.format == "table"
+
+    def test_no_command_prints_help(self) -> None:
+        """No subcommand should exit with error."""
+        parser = build_parser()
+        with pytest.raises(SystemExit):
+            parser.parse_args([])
+
+
+# ── Output Formatting ───────────────────────────────────────────────
+
+
+class TestFormatOutput:
+    """Verify JSON and table rendering."""
+
+    def test_json_format_agents_list(self) -> None:
+        data: list[dict[str, Any]] = [
+            {"name": "arbiter", "description": "Triage agent", "trust_tier": "t0"},
+            {"name": "ranger", "description": "Search agent", "trust_tier": "t0"},
+        ]
+        result = format_output(data, fmt="json")
+        parsed = json.loads(result)
+        assert len(parsed) == 2
+        assert parsed[0]["name"] == "arbiter"
+
+    def test_table_format_agents_list(self) -> None:
+        data: list[dict[str, Any]] = [
+            {"name": "arbiter", "description": "Triage agent", "trust_tier": "t0"},
+        ]
+        result = format_output(data, fmt="table")
+        assert "arbiter" in result
+        assert "Triage agent" in result
+        # Table should have header row
+        assert "name" in result.lower()
+
+    def test_json_format_single_dict(self) -> None:
+        data: dict[str, Any] = {"agents": 5, "agent_names": ["a", "b"]}
+        result = format_output(data, fmt="json")
+        parsed = json.loads(result)
+        assert parsed["agents"] == 5
+
+    def test_table_format_single_dict(self) -> None:
+        data: dict[str, Any] = {"agents": 5, "status": "ok"}
+        result = format_output(data, fmt="table")
+        assert "agents" in result
+        assert "5" in result
+
+    def test_table_format_empty_list(self) -> None:
+        result = format_output([], fmt="table")
+        assert "No results" in result
+
+
+# ── Environment Variable Configuration ──────────────────────────────
+
+
+class TestEnvConfig:
+    """Verify STRONGHOLD_URL and STRONGHOLD_API_KEY are read correctly."""
+
+    def test_default_url(self) -> None:
+        env: dict[str, str] = {}
+        with patch.dict(os.environ, env, clear=True):
+            from stronghold.cli.main import get_client_config
+
+            cfg = get_client_config()
+            assert cfg["base_url"] == "http://localhost:8100"
+
+    def test_custom_url_from_env(self) -> None:
+        env = {"STRONGHOLD_URL": "https://stronghold.example.com"}
+        with patch.dict(os.environ, env, clear=True):
+            from stronghold.cli.main import get_client_config
+
+            cfg = get_client_config()
+            assert cfg["base_url"] == "https://stronghold.example.com"
+
+    def test_api_key_from_env(self) -> None:
+        env = {"STRONGHOLD_API_KEY": "sk-test-12345"}
+        with patch.dict(os.environ, env, clear=True):
+            from stronghold.cli.main import get_client_config
+
+            cfg = get_client_config()
+            assert cfg["api_key"] == "sk-test-12345"
+
+
+# ── HTTP Integration (respx) ───────────────────────────────────────
+
+
+class TestCLIAgentCommands:
+    """Test CLI agent subcommands with mocked HTTP."""
+
+    @respx.mock
+    async def test_agent_list_calls_api(self) -> None:
+        route = respx.get("http://localhost:8100/v1/stronghold/agents").mock(
+            return_value=httpx.Response(
+                200,
+                json=[
+                    {"name": "arbiter", "description": "Triage", "trust_tier": "t0"},
+                ],
+            )
+        )
+        buf = StringIO()
+        await run(
+            ["agent", "list", "--format", "json"],
+            env_url="http://localhost:8100",
+            env_key="sk-test",
+            output=buf,
+        )
+        assert route.called
+        output = json.loads(buf.getvalue())
+        assert output[0]["name"] == "arbiter"
+
+    @respx.mock
+    async def test_agent_list_table_format(self) -> None:
+        respx.get("http://localhost:8100/v1/stronghold/agents").mock(
+            return_value=httpx.Response(
+                200,
+                json=[
+                    {"name": "ranger", "description": "Search agent", "trust_tier": "t0"},
+                ],
+            )
+        )
+        buf = StringIO()
+        await run(
+            ["agent", "list", "--format", "table"],
+            env_url="http://localhost:8100",
+            env_key="sk-test",
+            output=buf,
+        )
+        text = buf.getvalue()
+        assert "ranger" in text
+
+    @respx.mock
+    async def test_agent_import_sends_file(self, tmp_path: Any) -> None:
+        zip_file = tmp_path / "agent.zip"
+        zip_file.write_bytes(b"PK\x03\x04fake-zip-data")
+
+        route = respx.post("http://localhost:8100/v1/stronghold/agents/import").mock(
+            return_value=httpx.Response(
+                201,
+                json={"name": "imported_agent", "status": "imported"},
+            )
+        )
+        buf = StringIO()
+        await run(
+            ["agent", "import", str(zip_file)],
+            env_url="http://localhost:8100",
+            env_key="sk-test",
+            output=buf,
+        )
+        assert route.called
+
+    @respx.mock
+    async def test_agent_export_saves_file(self, tmp_path: Any) -> None:
+        respx.get("http://localhost:8100/v1/stronghold/agents/ranger/export").mock(
+            return_value=httpx.Response(
+                200,
+                content=b"PK\x03\x04fake-zip-data",
+                headers={"content-type": "application/zip"},
+            )
+        )
+        output_path = tmp_path / "ranger.zip"
+        buf = StringIO()
+        await run(
+            ["agent", "export", "ranger", str(output_path)],
+            env_url="http://localhost:8100",
+            env_key="sk-test",
+            output=buf,
+        )
+        assert output_path.exists()
+        assert output_path.read_bytes() == b"PK\x03\x04fake-zip-data"
+
+
+class TestCLIStatusCommands:
+    """Test CLI status subcommands with mocked HTTP."""
+
+    @respx.mock
+    async def test_status_calls_api(self) -> None:
+        respx.get("http://localhost:8100/v1/stronghold/status").mock(
+            return_value=httpx.Response(
+                200,
+                json={"agents": 6, "agent_names": ["arbiter", "ranger"]},
+            )
+        )
+        buf = StringIO()
+        await run(
+            ["status", "--format", "json"],
+            env_url="http://localhost:8100",
+            env_key="sk-test",
+            output=buf,
+        )
+        output = json.loads(buf.getvalue())
+        assert output["agents"] == 6
+
+    @respx.mock
+    async def test_status_models_calls_api(self) -> None:
+        respx.get("http://localhost:8100/v1/models").mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "object": "list",
+                    "data": [
+                        {"id": "gpt-4", "object": "model", "owned_by": "openai"},
+                    ],
+                },
+            )
+        )
+        buf = StringIO()
+        await run(
+            ["status", "models", "--format", "json"],
+            env_url="http://localhost:8100",
+            env_key="sk-test",
+            output=buf,
+        )
+        output = json.loads(buf.getvalue())
+        assert output["data"][0]["id"] == "gpt-4"
+
+    @respx.mock
+    async def test_status_quota_calls_api(self) -> None:
+        respx.get("http://localhost:8100/v1/stronghold/status").mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "agents": 3,
+                    "agent_names": ["a"],
+                    "quota_usage": {"test_provider": {"used": 100, "limit": 1000}},
+                },
+            )
+        )
+        buf = StringIO()
+        await run(
+            ["status", "quota", "--format", "json"],
+            env_url="http://localhost:8100",
+            env_key="sk-test",
+            output=buf,
+        )
+        output = json.loads(buf.getvalue())
+        assert "test_provider" in output
+
+
+class TestCLIErrorHandling:
+    """Test error scenarios."""
+
+    @respx.mock
+    async def test_auth_failure_reports_error(self) -> None:
+        respx.get("http://localhost:8100/v1/stronghold/agents").mock(
+            return_value=httpx.Response(401, json={"detail": "Invalid API key"})
+        )
+        buf = StringIO()
+        code = await run(
+            ["agent", "list"],
+            env_url="http://localhost:8100",
+            env_key="bad-key",
+            output=buf,
+        )
+        assert code != 0
+        assert "401" in buf.getvalue() or "error" in buf.getvalue().lower()
+
+    @respx.mock
+    async def test_connection_error_reports_error(self) -> None:
+        respx.get("http://localhost:8100/v1/stronghold/agents").mock(
+            side_effect=httpx.ConnectError("Connection refused")
+        )
+        buf = StringIO()
+        code = await run(
+            ["agent", "list"],
+            env_url="http://localhost:8100",
+            env_key="sk-test",
+            output=buf,
+        )
+        assert code != 0
+        assert "error" in buf.getvalue().lower()


### PR DESCRIPTION
Closes #135. argparse CLI with agent list/import/export + status/models/quota. JSON and table output. STRONGHOLD_URL/API_KEY env vars. Console script entry point. 29 tests.