### PR TITLE
feat: add user-facing memory management API (view, correct, forget)

### DIFF
--- a/src/stronghold/api/app.py
+++ b/src/stronghold/api/app.py
@@ -111,6 +111,7 @@ def create_app() -> FastAPI:
     from stronghold.api.routes.gate_endpoint import router as gate_router
     from stronghold.api.routes.marketplace import router as marketplace_router
     from stronghold.api.routes.mcp import router as mcp_router
+    from stronghold.api.routes.memory import router as memory_router
     from stronghold.api.routes.models import router as models_router
     from stronghold.api.routes.profile import router as profile_router
     from stronghold.api.routes.schedules import router as schedules_router
@@ -133,6 +134,7 @@ def create_app() -> FastAPI:
     app.include_router(agents_stream_router)
     app.include_router(skills_router)
     app.include_router(sessions_router)
+    app.include_router(memory_router)
     app.include_router(admin_router)
     app.include_router(profile_router)
     app.include_router(marketplace_router)

--- a/src/stronghold/api/routes/memory.py
+++ b/src/stronghold/api/routes/memory.py
@@ -1,0 +1,140 @@
+"""API route: memory — user-facing memory management (view, correct, forget)."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi import APIRouter, HTTPException, Request
+from fastapi.responses import JSONResponse
+
+router = APIRouter()
+
+
+def _check_csrf(request: Request) -> None:
+    """Verify CSRF defense header on cookie-authenticated mutations."""
+    if request.method not in ("POST", "PUT", "DELETE"):
+        return
+    if request.headers.get("authorization"):
+        return
+    if not request.cookies:
+        return
+    if not request.headers.get("x-stronghold-request"):
+        raise HTTPException(
+            status_code=403,
+            detail="Missing X-Stronghold-Request header (CSRF protection)",
+        )
+
+
+async def _authenticate(request: Request) -> tuple[Any, Any]:
+    """Authenticate and return (auth, container)."""
+    container = request.app.state.container
+    auth_header = request.headers.get("authorization")
+    try:
+        auth = await container.auth_provider.authenticate(
+            auth_header, headers=dict(request.headers)
+        )
+    except ValueError as e:
+        raise HTTPException(status_code=401, detail=str(e)) from e
+    _check_csrf(request)
+    return auth, container
+
+
+async def _require_admin(request: Request) -> tuple[Any, Any]:
+    """Authenticate, require admin role, check CSRF."""
+    auth, container = await _authenticate(request)
+    if not auth.has_role("admin"):
+        raise HTTPException(status_code=403, detail="Admin role required")
+    return auth, container
+
+
+# ── GET routes ──────────────────────────────────────────────────────
+# /me must come before /{memory_id} so "me" isn't captured as a path param.
+
+
+@router.get("/v1/stronghold/memory/me")
+async def list_my_memories(
+    request: Request,
+    limit: int = 20,
+) -> JSONResponse:
+    """List the caller's episodic memories."""
+    auth, container = await _authenticate(request)
+    mgr = container.memory_manager
+    memories = await mgr.list_memories(
+        user_id=auth.user_id,
+        org_id=auth.org_id,
+        limit=limit,
+    )
+    return JSONResponse(content={"memories": memories, "count": len(memories)})
+
+
+@router.get("/v1/stronghold/memory/{memory_id}")
+async def get_memory(memory_id: str, request: Request) -> JSONResponse:
+    """Get a single memory by ID (org-scoped)."""
+    auth, container = await _authenticate(request)
+    mgr = container.memory_manager
+    result = await mgr.get_memory(memory_id=memory_id, org_id=auth.org_id)
+    if result is None:
+        raise HTTPException(status_code=404, detail="Memory not found")
+    return JSONResponse(content=result)
+
+
+# ── DELETE routes ───────────────────────────────────────────────────
+# Fixed-path routes (/me, /user/{id}) MUST be registered before the
+# parameterised /{memory_id} route so FastAPI doesn't swallow them.
+
+
+@router.delete("/v1/stronghold/memory/me")
+async def forget_by_keyword(
+    request: Request,
+    keyword: str = "",
+) -> JSONResponse:
+    """Bulk soft-delete memories matching a keyword (org-scoped)."""
+    auth, container = await _authenticate(request)
+    if not keyword:
+        raise HTTPException(status_code=400, detail="'keyword' query parameter required")
+    mgr = container.memory_manager
+    count = await mgr.forget_by_keyword(
+        user_id=auth.user_id,
+        org_id=auth.org_id,
+        keyword=keyword,
+    )
+    return JSONResponse(content={"status": "forgotten", "count": count, "keyword": keyword})
+
+
+@router.delete("/v1/stronghold/memory/user/{user_id}")
+async def purge_user_memories(user_id: str, request: Request) -> JSONResponse:
+    """GDPR: purge all memories for a user (admin only, org-scoped)."""
+    auth, container = await _require_admin(request)
+    mgr = container.memory_manager
+    count = await mgr.purge_user(user_id=user_id, org_id=auth.org_id)
+    return JSONResponse(content={"status": "purged", "user_id": user_id, "count": count})
+
+
+@router.put("/v1/stronghold/memory/{memory_id}")
+async def correct_memory(memory_id: str, request: Request) -> JSONResponse:
+    """Correct a memory's content (org-scoped)."""
+    auth, container = await _authenticate(request)
+    body = await request.json()
+    new_content = body.get("content")
+    if not new_content or not isinstance(new_content, str):
+        raise HTTPException(status_code=400, detail="'content' field required (string)")
+    mgr = container.memory_manager
+    ok = await mgr.correct_memory(
+        memory_id=memory_id,
+        org_id=auth.org_id,
+        new_content=new_content,
+    )
+    if not ok:
+        raise HTTPException(status_code=404, detail="Memory not found")
+    return JSONResponse(content={"status": "corrected", "memory_id": memory_id})
+
+
+@router.delete("/v1/stronghold/memory/{memory_id}")
+async def forget_memory(memory_id: str, request: Request) -> JSONResponse:
+    """Soft-delete a single memory (org-scoped)."""
+    auth, container = await _authenticate(request)
+    mgr = container.memory_manager
+    ok = await mgr.forget_memory(memory_id=memory_id, org_id=auth.org_id)
+    if not ok:
+        raise HTTPException(status_code=404, detail="Memory not found")
+    return JSONResponse(content={"status": "forgotten", "memory_id": memory_id})

--- a/src/stronghold/container.py
+++ b/src/stronghold/container.py
@@ -88,6 +88,8 @@ class Container:
     mcp_registry: Any = None  # MCPRegistry
     schedule_store: InMemoryScheduleStore = field(default_factory=InMemoryScheduleStore)
     mcp_deployer: Any = None  # K8sDeployer
+    episodic_store: Any = None  # InMemoryEpisodicStore (episodic memory backend)
+    memory_manager: Any = None  # MemoryManager (user-facing memory ops)
     conduit: Any = None  # Conduit — wired in __post_init__ or create_container
 
     def __post_init__(self) -> None:
@@ -394,6 +396,13 @@ async def create_container(config: StrongholdConfig) -> Container:
     except Exception:
         logger.info("MCP: K8s deployer unavailable (no cluster access)")
 
+    # ── Episodic memory + user-facing memory manager ──
+    from stronghold.memory.episodic.store import InMemoryEpisodicStore  # noqa: PLC0415
+    from stronghold.memory.management import MemoryManager  # noqa: PLC0415
+
+    episodic_store = InMemoryEpisodicStore()
+    memory_manager = MemoryManager(episodic_store)
+
     container = Container(
         config=config,
         auth_provider=auth_provider,
@@ -432,6 +441,8 @@ async def create_container(config: StrongholdConfig) -> Container:
         prompt_cache=prompt_cache,
         mcp_registry=mcp_registry,
         mcp_deployer=mcp_deployer,
+        episodic_store=episodic_store,
+        memory_manager=memory_manager,
     )
 
     # Conduit pipeline is auto-wired via __post_init__

--- a/src/stronghold/memory/management.py
+++ b/src/stronghold/memory/management.py
@@ -1,0 +1,213 @@
+"""User-facing memory management: view, correct, forget.
+
+Provides list/get/correct/forget/purge operations for episodic memories,
+enforcing org-scoped tenant isolation on every operation.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from stronghold.memory.episodic.tiers import clamp_weight
+from stronghold.types.memory import WEIGHT_BOUNDS, EpisodicMemory
+
+if TYPE_CHECKING:
+    from stronghold.memory.episodic.store import InMemoryEpisodicStore
+
+
+def _memory_to_dict(mem: EpisodicMemory) -> dict[str, Any]:
+    """Serialize an EpisodicMemory to a JSON-safe dict."""
+    return {
+        "memory_id": mem.memory_id,
+        "tier": str(mem.tier),
+        "content": mem.content,
+        "weight": mem.weight,
+        "scope": str(mem.scope),
+        "source": mem.source,
+        "user_id": mem.user_id or "",
+        "org_id": mem.org_id,
+        "team_id": mem.team_id,
+        "agent_id": mem.agent_id or "",
+        "reinforcement_count": mem.reinforcement_count,
+        "created_at": mem.created_at.isoformat(),
+        "last_accessed_at": mem.last_accessed_at.isoformat(),
+    }
+
+
+class MemoryManager:
+    """User-facing memory management operations.
+
+    All methods enforce org_id isolation — callers can only see/modify
+    memories belonging to their organization.
+    """
+
+    def __init__(self, episodic_store: InMemoryEpisodicStore) -> None:
+        self._store = episodic_store
+
+    async def list_memories(
+        self,
+        user_id: str,
+        org_id: str,
+        limit: int = 20,
+    ) -> list[dict[str, Any]]:
+        """List a user's episodic memories within their org."""
+        results: list[dict[str, Any]] = []
+        for mem in self._store._memories:
+            if mem.deleted:
+                continue
+            if mem.user_id != user_id:
+                continue
+            if mem.org_id != org_id:
+                continue
+            results.append(_memory_to_dict(mem))
+            if len(results) >= limit:
+                break
+        return results
+
+    async def get_memory(
+        self,
+        memory_id: str,
+        org_id: str,
+    ) -> dict[str, Any] | None:
+        """Retrieve a single memory by ID, org-scoped."""
+        for mem in self._store._memories:
+            if mem.memory_id == memory_id and mem.org_id == org_id and not mem.deleted:
+                return _memory_to_dict(mem)
+        return None
+
+    async def correct_memory(
+        self,
+        memory_id: str,
+        org_id: str,
+        new_content: str,
+    ) -> bool:
+        """Update a memory's content and set weight to tier ceiling.
+
+        User corrections are high-confidence — clamp weight to tier max.
+        Returns True if found and updated, False if not found or wrong org.
+        """
+        for i, mem in enumerate(self._store._memories):
+            if mem.memory_id != memory_id or mem.org_id != org_id or mem.deleted:
+                continue
+            bounds = WEIGHT_BOUNDS.get(mem.tier, (0.1, 1.0))
+            ceiling = bounds[1]
+            self._store._memories[i] = EpisodicMemory(
+                memory_id=mem.memory_id,
+                tier=mem.tier,
+                content=new_content,
+                weight=clamp_weight(mem.tier, ceiling),
+                org_id=mem.org_id,
+                team_id=mem.team_id,
+                agent_id=mem.agent_id,
+                user_id=mem.user_id,
+                scope=mem.scope,
+                source=mem.source,
+                context=mem.context,
+                reinforcement_count=mem.reinforcement_count,
+                contradiction_count=mem.contradiction_count,
+                created_at=mem.created_at,
+                last_accessed_at=mem.last_accessed_at,
+                deleted=mem.deleted,
+            )
+            return True
+        return False
+
+    async def forget_memory(
+        self,
+        memory_id: str,
+        org_id: str,
+    ) -> bool:
+        """Soft-delete a single memory. Returns True if found and deleted."""
+        for i, mem in enumerate(self._store._memories):
+            if mem.memory_id != memory_id or mem.org_id != org_id or mem.deleted:
+                continue
+            self._store._memories[i] = EpisodicMemory(
+                memory_id=mem.memory_id,
+                tier=mem.tier,
+                content=mem.content,
+                weight=mem.weight,
+                org_id=mem.org_id,
+                team_id=mem.team_id,
+                agent_id=mem.agent_id,
+                user_id=mem.user_id,
+                scope=mem.scope,
+                source=mem.source,
+                context=mem.context,
+                reinforcement_count=mem.reinforcement_count,
+                contradiction_count=mem.contradiction_count,
+                created_at=mem.created_at,
+                last_accessed_at=mem.last_accessed_at,
+                deleted=True,
+            )
+            return True
+        return False
+
+    async def forget_by_keyword(
+        self,
+        user_id: str,
+        org_id: str,
+        keyword: str,
+    ) -> int:
+        """Bulk soft-delete memories matching a keyword. Returns count deleted."""
+        keyword_lower = keyword.lower()
+        count = 0
+        for i, mem in enumerate(self._store._memories):
+            if mem.deleted:
+                continue
+            if mem.user_id != user_id or mem.org_id != org_id:
+                continue
+            if keyword_lower not in mem.content.lower():
+                continue
+            self._store._memories[i] = EpisodicMemory(
+                memory_id=mem.memory_id,
+                tier=mem.tier,
+                content=mem.content,
+                weight=mem.weight,
+                org_id=mem.org_id,
+                team_id=mem.team_id,
+                agent_id=mem.agent_id,
+                user_id=mem.user_id,
+                scope=mem.scope,
+                source=mem.source,
+                context=mem.context,
+                reinforcement_count=mem.reinforcement_count,
+                contradiction_count=mem.contradiction_count,
+                created_at=mem.created_at,
+                last_accessed_at=mem.last_accessed_at,
+                deleted=True,
+            )
+            count += 1
+        return count
+
+    async def purge_user(
+        self,
+        user_id: str,
+        org_id: str,
+    ) -> int:
+        """GDPR: soft-delete ALL memories for a user within an org. Returns count."""
+        count = 0
+        for i, mem in enumerate(self._store._memories):
+            if mem.deleted:
+                continue
+            if mem.user_id != user_id or mem.org_id != org_id:
+                continue
+            self._store._memories[i] = EpisodicMemory(
+                memory_id=mem.memory_id,
+                tier=mem.tier,
+                content=mem.content,
+                weight=mem.weight,
+                org_id=mem.org_id,
+                team_id=mem.team_id,
+                agent_id=mem.agent_id,
+                user_id=mem.user_id,
+                scope=mem.scope,
+                source=mem.source,
+                context=mem.context,
+                reinforcement_count=mem.reinforcement_count,
+                contradiction_count=mem.contradiction_count,
+                created_at=mem.created_at,
+                last_accessed_at=mem.last_accessed_at,
+                deleted=True,
+            )
+            count += 1
+        return count

--- a/tests/memory/test_management.py
+++ b/tests/memory/test_management.py
@@ -1,0 +1,247 @@
+"""Tests for user-facing memory management — view, correct, forget."""
+
+from __future__ import annotations
+
+import uuid
+
+from stronghold.memory.episodic.store import InMemoryEpisodicStore
+from stronghold.memory.management import MemoryManager
+from stronghold.types.memory import EpisodicMemory, MemoryScope, MemoryTier
+
+
+def _make_memory(
+    *,
+    user_id: str = "alice",
+    org_id: str = "acme",
+    content: str = "test memory",
+    memory_id: str = "",
+    scope: MemoryScope = MemoryScope.USER,
+    tier: MemoryTier = MemoryTier.LESSON,
+    weight: float = 0.6,
+    deleted: bool = False,
+) -> EpisodicMemory:
+    return EpisodicMemory(
+        memory_id=memory_id or f"mem-{uuid.uuid4().hex[:8]}",
+        tier=tier,
+        content=content,
+        weight=weight,
+        org_id=org_id,
+        user_id=user_id,
+        scope=scope,
+        source="test",
+        deleted=deleted,
+    )
+
+
+class TestListMemories:
+    """list_memories returns only the caller's non-deleted memories, org-scoped."""
+
+    async def test_returns_user_memories(self) -> None:
+        store = InMemoryEpisodicStore()
+        mgr = MemoryManager(store)
+        m1 = _make_memory(content="remember alpha")
+        m2 = _make_memory(content="remember beta")
+        await store.store(m1)
+        await store.store(m2)
+
+        result = await mgr.list_memories(user_id="alice", org_id="acme")
+        assert len(result) == 2
+        contents = {r["content"] for r in result}
+        assert contents == {"remember alpha", "remember beta"}
+
+    async def test_excludes_other_users(self) -> None:
+        store = InMemoryEpisodicStore()
+        mgr = MemoryManager(store)
+        await store.store(_make_memory(user_id="alice", content="alice mem"))
+        await store.store(_make_memory(user_id="bob", content="bob mem"))
+
+        result = await mgr.list_memories(user_id="alice", org_id="acme")
+        assert len(result) == 1
+        assert result[0]["content"] == "alice mem"
+
+    async def test_excludes_other_orgs(self) -> None:
+        store = InMemoryEpisodicStore()
+        mgr = MemoryManager(store)
+        await store.store(_make_memory(org_id="acme", content="acme mem"))
+        await store.store(_make_memory(org_id="globex", content="globex mem"))
+
+        result = await mgr.list_memories(user_id="alice", org_id="acme")
+        assert len(result) == 1
+        assert result[0]["content"] == "acme mem"
+
+    async def test_excludes_deleted(self) -> None:
+        store = InMemoryEpisodicStore()
+        mgr = MemoryManager(store)
+        await store.store(_make_memory(content="alive"))
+        await store.store(_make_memory(content="gone", deleted=True))
+
+        result = await mgr.list_memories(user_id="alice", org_id="acme")
+        assert len(result) == 1
+        assert result[0]["content"] == "alive"
+
+    async def test_respects_limit(self) -> None:
+        store = InMemoryEpisodicStore()
+        mgr = MemoryManager(store)
+        for i in range(5):
+            await store.store(_make_memory(content=f"mem {i}"))
+
+        result = await mgr.list_memories(user_id="alice", org_id="acme", limit=3)
+        assert len(result) == 3
+
+
+class TestGetMemory:
+    """get_memory retrieves a single memory by ID, org-scoped."""
+
+    async def test_returns_memory(self) -> None:
+        store = InMemoryEpisodicStore()
+        mgr = MemoryManager(store)
+        m = _make_memory(memory_id="mem-123", content="found it")
+        await store.store(m)
+
+        result = await mgr.get_memory(memory_id="mem-123", org_id="acme")
+        assert result is not None
+        assert result["memory_id"] == "mem-123"
+        assert result["content"] == "found it"
+
+    async def test_returns_none_for_wrong_org(self) -> None:
+        store = InMemoryEpisodicStore()
+        mgr = MemoryManager(store)
+        await store.store(_make_memory(memory_id="mem-123", org_id="acme"))
+
+        result = await mgr.get_memory(memory_id="mem-123", org_id="globex")
+        assert result is None
+
+    async def test_returns_none_for_missing(self) -> None:
+        store = InMemoryEpisodicStore()
+        mgr = MemoryManager(store)
+
+        result = await mgr.get_memory(memory_id="nonexistent", org_id="acme")
+        assert result is None
+
+    async def test_returns_none_for_deleted(self) -> None:
+        store = InMemoryEpisodicStore()
+        mgr = MemoryManager(store)
+        await store.store(_make_memory(memory_id="mem-del", deleted=True))
+
+        result = await mgr.get_memory(memory_id="mem-del", org_id="acme")
+        assert result is None
+
+
+class TestCorrectMemory:
+    """correct_memory updates content and sets high weight."""
+
+    async def test_updates_content(self) -> None:
+        store = InMemoryEpisodicStore()
+        mgr = MemoryManager(store)
+        await store.store(
+            _make_memory(memory_id="mem-fix", content="old content", weight=0.5)
+        )
+
+        ok = await mgr.correct_memory(
+            memory_id="mem-fix", org_id="acme", new_content="corrected content"
+        )
+        assert ok is True
+
+        result = await mgr.get_memory(memory_id="mem-fix", org_id="acme")
+        assert result is not None
+        assert result["content"] == "corrected content"
+        # Correction should set high weight (tier ceiling)
+        assert result["weight"] >= 0.8
+
+    async def test_rejects_wrong_org(self) -> None:
+        store = InMemoryEpisodicStore()
+        mgr = MemoryManager(store)
+        await store.store(_make_memory(memory_id="mem-fix", org_id="acme"))
+
+        ok = await mgr.correct_memory(
+            memory_id="mem-fix", org_id="globex", new_content="hacked"
+        )
+        assert ok is False
+
+
+class TestForgetMemory:
+    """forget_memory soft-deletes a single memory."""
+
+    async def test_soft_deletes(self) -> None:
+        store = InMemoryEpisodicStore()
+        mgr = MemoryManager(store)
+        await store.store(_make_memory(memory_id="mem-bye", content="forget me"))
+
+        ok = await mgr.forget_memory(memory_id="mem-bye", org_id="acme")
+        assert ok is True
+
+        result = await mgr.get_memory(memory_id="mem-bye", org_id="acme")
+        assert result is None  # deleted — invisible
+
+    async def test_rejects_wrong_org(self) -> None:
+        store = InMemoryEpisodicStore()
+        mgr = MemoryManager(store)
+        await store.store(_make_memory(memory_id="mem-bye", org_id="acme"))
+
+        ok = await mgr.forget_memory(memory_id="mem-bye", org_id="globex")
+        assert ok is False
+
+
+class TestForgetByKeyword:
+    """forget_by_keyword bulk-deletes memories matching a keyword."""
+
+    async def test_deletes_matching(self) -> None:
+        store = InMemoryEpisodicStore()
+        mgr = MemoryManager(store)
+        await store.store(_make_memory(content="pizza recipe for dinner"))
+        await store.store(_make_memory(content="pizza topping ideas"))
+        await store.store(_make_memory(content="weather today"))
+
+        count = await mgr.forget_by_keyword(
+            user_id="alice", org_id="acme", keyword="pizza"
+        )
+        assert count == 2
+
+        remaining = await mgr.list_memories(user_id="alice", org_id="acme")
+        assert len(remaining) == 1
+        assert remaining[0]["content"] == "weather today"
+
+    async def test_returns_zero_for_no_match(self) -> None:
+        store = InMemoryEpisodicStore()
+        mgr = MemoryManager(store)
+        await store.store(_make_memory(content="something else"))
+
+        count = await mgr.forget_by_keyword(
+            user_id="alice", org_id="acme", keyword="nonexistent"
+        )
+        assert count == 0
+
+
+class TestPurgeUser:
+    """purge_user GDPR: delete all of a user's memories."""
+
+    async def test_deletes_all_user_memories(self) -> None:
+        store = InMemoryEpisodicStore()
+        mgr = MemoryManager(store)
+        for i in range(4):
+            await store.store(_make_memory(user_id="alice", content=f"alice mem {i}"))
+        await store.store(_make_memory(user_id="bob", content="bob mem"))
+
+        count = await mgr.purge_user(user_id="alice", org_id="acme")
+        assert count == 4
+
+        alice_mems = await mgr.list_memories(user_id="alice", org_id="acme")
+        assert len(alice_mems) == 0
+
+        bob_mems = await mgr.list_memories(user_id="bob", org_id="acme")
+        assert len(bob_mems) == 1
+
+    async def test_respects_org_boundary(self) -> None:
+        store = InMemoryEpisodicStore()
+        mgr = MemoryManager(store)
+        await store.store(_make_memory(user_id="alice", org_id="acme", content="acme"))
+        await store.store(
+            _make_memory(user_id="alice", org_id="globex", content="globex")
+        )
+
+        count = await mgr.purge_user(user_id="alice", org_id="acme")
+        assert count == 1
+
+        # Globex memory survives
+        globex = await mgr.list_memories(user_id="alice", org_id="globex")
+        assert len(globex) == 1


### PR DESCRIPTION
Closes #137. MemoryManager with list/get/correct/forget/forget_by_keyword/purge_user. 6 API routes including GDPR purge (admin). Org-scoped. 17 tests.