### PR TITLE
feat: add K8s secrets manager integration with env var fallback

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,8 @@ htmlcov/
 *.pem
 *.key
 *secrets*
+!src/stronghold/config/secrets.py
+!tests/config/test_secrets.py
 *credentials*
 
 # OS

--- a/src/stronghold/config/secrets.py
+++ b/src/stronghold/config/secrets.py
@@ -1,0 +1,115 @@
+"""K8s secrets manager integration with environment variable fallback.
+
+Resolves ``${secret:path/name}`` references in config values by reading
+mounted Kubernetes secret files, falling back to environment variables
+when the file does not exist (dev/CI convenience).
+
+Pattern example::
+
+    ${secret:k8s/stronghold-secrets/jwt-signing-key}
+    → reads /var/run/secrets/k8s/stronghold-secrets/jwt-signing-key
+    → fallback: env var JWT_SIGNING_KEY  (uppercased, hyphens → underscores)
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import re
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+_SECRET_PATTERN = re.compile(r"^\$\{secret:(.+)\}$")
+
+_DEFAULT_SECRETS_ROOT = Path("/var/run/secrets")
+
+
+class SecretResolver:
+    """Resolve ``${secret:...}`` references from K8s mounts or env vars.
+
+    Args:
+        secrets_root: Base directory for mounted secrets.
+            Defaults to ``/var/run/secrets``.  Override in tests via ``tmp_path``.
+    """
+
+    def __init__(self, secrets_root: Path | None = None) -> None:
+        self._root = secrets_root or _DEFAULT_SECRETS_ROOT
+
+    # ── Public API ──────────────────────────────────────────────────────
+
+    def resolve(self, value: str) -> str:
+        """Resolve a single value.
+
+        If *value* matches ``${secret:path/name}``, attempt resolution from
+        the K8s mount first, then fall back to an environment variable.
+        Otherwise return *value* unchanged.
+        """
+        match = _SECRET_PATTERN.match(value)
+        if match is None:
+            return value
+
+        secret_path = match.group(1)
+
+        # Block absolute paths inside the pattern
+        if secret_path.startswith("/"):
+            logger.warning("Absolute path in secret reference rejected: %s", value)
+            return ""
+
+        # Resolve and validate the full filesystem path
+        full_path = (self._root / secret_path).resolve()
+        if not str(full_path).startswith(str(self._root.resolve())):
+            logger.warning("Path traversal in secret reference rejected: %s", value)
+            return ""
+
+        # Derive the env-var name from the last path segment
+        name = secret_path.rsplit("/", 1)[-1]
+
+        # Try K8s mount first
+        k8s_value = self._resolve_k8s(full_path)
+        if k8s_value is not None:
+            return k8s_value
+
+        # Fallback: environment variable
+        env_value = self._resolve_env(name)
+        if env_value is not None:
+            return env_value
+
+        logger.warning("Secret not found (no K8s mount, no env var): %s", value)
+        return ""
+
+    def resolve_config(self, config: dict[str, Any]) -> dict[str, Any]:
+        """Recursively resolve all string values in a config dict.
+
+        Returns a **new** dict; the original is not mutated.
+        """
+        result: dict[str, Any] = self._walk(config)
+        return result
+
+    # ── Private helpers ─────────────────────────────────────────────────
+
+    def _resolve_k8s(self, path: Path) -> str | None:
+        """Read a secret from a K8s-mounted file, or *None* if missing."""
+        if path.is_file():
+            return path.read_text().strip()
+        return None
+
+    def _resolve_env(self, name: str) -> str | None:
+        """Read a secret from an environment variable, or *None* if unset.
+
+        The env-var name is derived from *name* by uppercasing and replacing
+        hyphens with underscores (e.g. ``jwt-signing-key`` → ``JWT_SIGNING_KEY``).
+        """
+        env_name = name.upper().replace("-", "_")
+        return os.environ.get(env_name)
+
+    def _walk(self, obj: Any) -> Any:
+        """Recursively walk a nested structure, resolving string values."""
+        if isinstance(obj, dict):
+            return {k: self._walk(v) for k, v in obj.items()}
+        if isinstance(obj, list):
+            return [self._walk(item) for item in obj]
+        if isinstance(obj, str):
+            return self.resolve(obj)
+        return obj

--- a/tests/config/test_secrets.py
+++ b/tests/config/test_secrets.py
@@ -1,0 +1,182 @@
+"""Tests for K8s secrets manager integration with env var fallback."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from stronghold.config.secrets import SecretResolver
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    import pytest
+
+
+class TestResolvePassthrough:
+    """Values without the ${secret:...} pattern pass through unchanged."""
+
+    def test_plain_string_returned_as_is(self) -> None:
+        resolver = SecretResolver()
+        assert resolver.resolve("hello-world") == "hello-world"
+
+    def test_empty_string_returned_as_is(self) -> None:
+        resolver = SecretResolver()
+        assert resolver.resolve("") == ""
+
+    def test_partial_pattern_not_resolved(self) -> None:
+        resolver = SecretResolver()
+        assert resolver.resolve("${secret:") == "${secret:"
+
+    def test_url_without_secret_pattern(self) -> None:
+        resolver = SecretResolver()
+        assert resolver.resolve("https://example.com") == "https://example.com"
+
+
+class TestResolveK8s:
+    """K8s mounted file resolution via ${secret:k8s/namespace/name}."""
+
+    def test_resolve_from_k8s_mount(self, tmp_path: Path) -> None:
+        """Reads secret from mounted file at /var/run/secrets/{path}."""
+        secret_dir = tmp_path / "k8s" / "stronghold-secrets"
+        secret_dir.mkdir(parents=True)
+        secret_file = secret_dir / "jwt-signing-key"
+        secret_file.write_text("super-secret-jwt-key-12345")
+
+        resolver = SecretResolver(secrets_root=tmp_path)
+        result = resolver.resolve("${secret:k8s/stronghold-secrets/jwt-signing-key}")
+        assert result == "super-secret-jwt-key-12345"
+
+    def test_k8s_file_with_trailing_newline_stripped(self, tmp_path: Path) -> None:
+        """Trailing whitespace/newlines in secret files are stripped."""
+        secret_dir = tmp_path / "k8s" / "my-namespace"
+        secret_dir.mkdir(parents=True)
+        secret_file = secret_dir / "db-password"
+        secret_file.write_text("p@ssw0rd\n")
+
+        resolver = SecretResolver(secrets_root=tmp_path)
+        result = resolver.resolve("${secret:k8s/my-namespace/db-password}")
+        assert result == "p@ssw0rd"
+
+    def test_k8s_nested_path(self, tmp_path: Path) -> None:
+        """Supports multi-level paths under secrets root."""
+        secret_dir = tmp_path / "k8s" / "team-a" / "prod"
+        secret_dir.mkdir(parents=True)
+        (secret_dir / "api-key").write_text("key-abc-123")
+
+        resolver = SecretResolver(secrets_root=tmp_path)
+        result = resolver.resolve("${secret:k8s/team-a/prod/api-key}")
+        assert result == "key-abc-123"
+
+
+class TestResolveEnvFallback:
+    """When K8s mount is missing, fall back to environment variable."""
+
+    def test_env_fallback_when_k8s_missing(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """If K8s path doesn't exist, tries env var (uppercased, hyphens to underscores)."""
+        monkeypatch.setenv("JWT_SIGNING_KEY", "env-fallback-key")
+        resolver = SecretResolver(secrets_root=tmp_path)
+        result = resolver.resolve("${secret:k8s/stronghold-secrets/jwt-signing-key}")
+        assert result == "env-fallback-key"
+
+    def test_env_name_derived_from_last_path_segment(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Env var name: uppercased, hyphens to underscores from last path segment."""
+        monkeypatch.setenv("DB_PASSWORD", "from-env")
+        resolver = SecretResolver(secrets_root=tmp_path)
+        result = resolver.resolve("${secret:k8s/namespace/db-password}")
+        assert result == "from-env"
+
+    def test_no_k8s_no_env_returns_empty_string(self, tmp_path: Path) -> None:
+        """When neither K8s mount nor env var exists, returns empty string."""
+        resolver = SecretResolver(secrets_root=tmp_path)
+        result = resolver.resolve("${secret:k8s/namespace/nonexistent-secret}")
+        assert result == ""
+
+    def test_k8s_takes_precedence_over_env(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """K8s mounted file wins even when env var is also set."""
+        secret_dir = tmp_path / "k8s" / "ns"
+        secret_dir.mkdir(parents=True)
+        (secret_dir / "api-key").write_text("from-k8s")
+        monkeypatch.setenv("API_KEY", "from-env")
+
+        resolver = SecretResolver(secrets_root=tmp_path)
+        result = resolver.resolve("${secret:k8s/ns/api-key}")
+        assert result == "from-k8s"
+
+
+class TestResolveConfig:
+    """Recursive resolution of all string values in a config dict."""
+
+    def test_flat_dict(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("DB_PASSWORD", "s3cret")
+        resolver = SecretResolver(secrets_root=tmp_path)
+        config = {
+            "host": "localhost",
+            "password": "${secret:k8s/ns/db-password}",
+        }
+        resolved = resolver.resolve_config(config)
+        assert resolved == {"host": "localhost", "password": "s3cret"}
+
+    def test_nested_dict(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("JWT_KEY", "jwt-value")
+        resolver = SecretResolver(secrets_root=tmp_path)
+        config = {
+            "auth": {
+                "token": "${secret:k8s/ns/jwt-key}",
+                "issuer": "https://sso.example.com",
+            },
+        }
+        resolved = resolver.resolve_config(config)
+        assert resolved["auth"]["token"] == "jwt-value"
+        assert resolved["auth"]["issuer"] == "https://sso.example.com"
+
+    def test_list_values_resolved(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("SECRET_A", "val-a")
+        monkeypatch.setenv("SECRET_B", "val-b")
+        resolver = SecretResolver(secrets_root=tmp_path)
+        config = {
+            "keys": ["${secret:k8s/ns/secret-a}", "${secret:k8s/ns/secret-b}", "plain"],
+        }
+        resolved = resolver.resolve_config(config)
+        assert resolved["keys"] == ["val-a", "val-b", "plain"]
+
+    def test_non_string_values_unchanged(self, tmp_path: Path) -> None:
+        resolver = SecretResolver(secrets_root=tmp_path)
+        config: dict[str, object] = {
+            "port": 5432,
+            "enabled": True,
+            "ratio": 0.5,
+            "nothing": None,
+        }
+        resolved = resolver.resolve_config(config)
+        assert resolved == config
+
+    def test_original_dict_not_mutated(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("MY_SECRET", "resolved")
+        resolver = SecretResolver(secrets_root=tmp_path)
+        config = {"key": "${secret:k8s/ns/my-secret}"}
+        resolver.resolve_config(config)
+        assert config["key"] == "${secret:k8s/ns/my-secret}"
+
+
+class TestPathTraversal:
+    """Secret paths must not escape the secrets root."""
+
+    def test_path_traversal_blocked(self, tmp_path: Path) -> None:
+        """Paths with '..' that escape the root are rejected."""
+        resolver = SecretResolver(secrets_root=tmp_path)
+        result = resolver.resolve("${secret:k8s/../../../etc/passwd}")
+        assert result == ""
+
+    def test_absolute_path_in_pattern_blocked(self, tmp_path: Path) -> None:
+        """Absolute paths inside the pattern are rejected."""
+        resolver = SecretResolver(secrets_root=tmp_path)
+        result = resolver.resolve("${secret:/etc/passwd}")
+        assert result == ""


### PR DESCRIPTION
Closes #61. SecretResolver with ${secret:path/name} pattern, K8s mount → env var fallback, recursive config resolution, path traversal protection. 18 tests.