### PR TITLE
feat: add OIDC auth provider with JWKS cache (Keycloak + Entra ID)

### DIFF
--- a/src/stronghold/security/auth_oidc.py
+++ b/src/stronghold/security/auth_oidc.py
@@ -1,0 +1,229 @@
+"""OIDC authentication provider — configurable for Keycloak, Entra ID, and any OIDC IdP.
+
+Validates RS256 JWTs against a JWKS endpoint, extracts user identity
+via configurable claims_mapping, and optionally translates IdP roles
+to Stronghold roles via role_mapping.
+
+Usage:
+    # Keycloak
+    provider = OIDCAuthProvider(
+        issuer_url="https://sso.example.com/realms/stronghold",
+        audience="stronghold-api",
+        jwks_url="https://sso.example.com/realms/stronghold/protocol/openid-connect/certs",
+        claims_mapping={
+            "user_id": "sub",
+            "username": "preferred_username",
+            "roles": "realm_access.roles",
+            "org_id": "organization_id",
+            "team_id": "team_id",
+        },
+    )
+
+    # Entra ID
+    provider = OIDCAuthProvider(
+        issuer_url="https://login.microsoftonline.com/{tenant}/v2.0",
+        audience="api://stronghold",
+        jwks_url="https://login.microsoftonline.com/{tenant}/discovery/v2.0/keys",
+        claims_mapping={
+            "user_id": "sub",
+            "username": "preferred_username",
+            "roles": "roles",
+            "org_id": "tid",
+            "team_id": "",
+        },
+        role_mapping={"GlobalAdmin": "admin", "Reader": "viewer"},
+    )
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import jwt as pyjwt
+from jwt.exceptions import ExpiredSignatureError
+
+from stronghold.security.jwks import JWKSCache
+from stronghold.types.auth import AuthContext, IdentityKind
+from stronghold.types.errors import AuthError, TokenExpiredError
+
+logger = logging.getLogger("stronghold.security.auth_oidc")
+
+
+class OIDCAuthProvider:
+    """Authenticates requests via OIDC JWT tokens.
+
+    Implements the AuthProvider protocol.
+
+    Args:
+        issuer_url: Expected ``iss`` claim value.
+        audience: Expected ``aud`` claim value.
+        jwks_url: URL to the JWKS endpoint for signature verification.
+        claims_mapping: Maps Stronghold fields to JWT claim paths.
+            Required keys: ``user_id``, ``username``, ``roles``.
+            Optional keys: ``org_id``, ``team_id``.
+            Values use dot-notation for nested claims (e.g., ``realm_access.roles``).
+            Empty string means "not mapped" (field defaults to empty).
+        role_mapping: Optional dict mapping IdP role names to Stronghold role names.
+            Unmapped roles are passed through unchanged.
+        jwks_ttl: TTL for the JWKS cache in seconds (default: 3600).
+        algorithms: Allowed JWT signing algorithms (default: RS256).
+    """
+
+    def __init__(
+        self,
+        issuer_url: str,
+        audience: str,
+        jwks_url: str,
+        claims_mapping: dict[str, str],
+        role_mapping: dict[str, str] | None = None,
+        jwks_ttl: float = 3600.0,
+        algorithms: list[str] | None = None,
+    ) -> None:
+        self._issuer = issuer_url
+        self._audience = audience
+        self._claims_mapping = claims_mapping
+        self._role_mapping = role_mapping or {}
+        self._algorithms = algorithms or ["RS256"]
+        self._jwks_cache = JWKSCache(url=jwks_url, ttl=jwks_ttl)
+
+    async def authenticate(
+        self,
+        authorization: str | None,
+        headers: dict[str, str] | None = None,
+    ) -> AuthContext:
+        """Validate an OIDC JWT and return an AuthContext.
+
+        Raises AuthError (or TokenExpiredError) on failure.
+        """
+        token = self._extract_bearer_token(authorization)
+        claims = await self._decode_and_validate(token)
+
+        # Extract identity fields via claims_mapping
+        user_id = self._extract_claim(claims, "user_id")
+        username = self._extract_claim(claims, "username") or user_id
+        raw_roles = self._extract_claim_value(claims, "roles")
+        org_id = self._extract_claim(claims, "org_id")
+        team_id = self._extract_claim(claims, "team_id")
+
+        if not user_id:
+            raise AuthError(
+                "Token missing user_id claim (mapped from "
+                f"'{self._claims_mapping.get('user_id', 'sub')}')"
+            )
+
+        # Normalize roles to list
+        roles_list: list[str]
+        if isinstance(raw_roles, list):
+            roles_list = [str(r) for r in raw_roles]
+        elif isinstance(raw_roles, str):
+            roles_list = [raw_roles]
+        else:
+            roles_list = []
+
+        # Apply role mapping
+        if self._role_mapping:
+            roles_list = [self._role_mapping.get(r, r) for r in roles_list]
+
+        return AuthContext(
+            user_id=str(user_id),
+            username=str(username),
+            roles=frozenset(roles_list),
+            org_id=str(org_id) if org_id else "",
+            team_id=str(team_id) if team_id else "",
+            kind=IdentityKind.USER,
+            auth_method="oidc",
+        )
+
+    # ── Private helpers ─────────────────────────────────────────────
+
+    @staticmethod
+    def _extract_bearer_token(authorization: str | None) -> str:
+        """Extract and validate the Bearer token from the Authorization header."""
+        if not authorization:
+            raise AuthError("Missing Authorization header")
+        if not authorization.startswith("Bearer "):
+            raise AuthError("Invalid authorization format (expected 'Bearer <token>')")
+        token = authorization.removeprefix("Bearer ").strip()
+        if not token:
+            raise AuthError("Empty token")
+        return token
+
+    async def _decode_and_validate(self, token: str) -> dict[str, Any]:
+        """Decode JWT, verify signature against JWKS, validate exp/iss/aud."""
+        # Extract kid from unverified header
+        try:
+            unverified_header = pyjwt.get_unverified_header(token)
+        except pyjwt.exceptions.DecodeError as e:
+            raise AuthError(f"JWT validation failed: malformed token ({e})") from e
+
+        kid = unverified_header.get("kid", "")
+        if not kid:
+            raise AuthError("JWT validation failed: missing kid in header")
+
+        # Fetch the signing key from JWKS
+        jwk_data = await self._jwks_cache.get_key(kid)
+        if jwk_data is None:
+            raise AuthError(f"JWT validation failed: unknown signing key (kid={kid})")
+
+        # Build a PyJWK from the raw JWK dict
+        try:
+            signing_key = pyjwt.PyJWK(jwk_data)
+        except Exception as e:
+            raise AuthError(f"JWT validation failed: invalid JWK ({e})") from e
+
+        # Decode and validate
+        try:
+            decoded: dict[str, Any] = pyjwt.decode(
+                token,
+                signing_key,
+                algorithms=self._algorithms,
+                issuer=self._issuer,
+                audience=self._audience,
+                options={"require": ["exp", "iss", "aud"]},
+            )
+        except ExpiredSignatureError as e:
+            raise TokenExpiredError("Token has expired") from e
+        except pyjwt.exceptions.PyJWTError as e:
+            raise AuthError(f"JWT validation failed: {e}") from e
+
+        return decoded
+
+    def _extract_claim(self, claims: dict[str, Any], field: str) -> str:
+        """Extract a single string claim via the claims_mapping."""
+        value = self._extract_claim_value(claims, field)
+        if value is None:
+            return ""
+        return str(value)
+
+    def _extract_claim_value(self, claims: dict[str, Any], field: str) -> Any:
+        """Extract a claim value (any type) via the claims_mapping."""
+        path = self._claims_mapping.get(field, "")
+        if not path:
+            return None
+        return self._extract_nested(claims, path)
+
+    @staticmethod
+    def _extract_nested(claims: dict[str, Any], path: str) -> Any:
+        """Extract a nested value using dot-notation path.
+
+        Example: "realm_access.roles" -> claims["realm_access"]["roles"]
+
+        Handles URL-style claim names (e.g., "https://myapp.com/roles")
+        by checking exact match first.
+        """
+        if not path:
+            return None
+
+        # Exact match first (handles URL-style claim names)
+        if path in claims:
+            return claims[path]
+
+        # Dot-notation traversal
+        current: Any = claims
+        for part in path.split("."):
+            if isinstance(current, dict):
+                current = current.get(part)
+            else:
+                return None
+        return current

--- a/src/stronghold/security/jwks.py
+++ b/src/stronghold/security/jwks.py
@@ -1,0 +1,96 @@
+"""JWKS (JSON Web Key Set) cache for OIDC token validation.
+
+Fetches public keys from an IdP's JWKS endpoint and caches them
+with a configurable TTL. Used by OIDCAuthProvider to verify JWT
+signatures without importing PyJWKClient (which is synchronous).
+
+Stampede prevention: an asyncio.Lock ensures only one task fetches
+at a time; others wait or use stale cache.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+from typing import Any
+
+import httpx
+
+logger = logging.getLogger("stronghold.security.jwks")
+
+
+class JWKSCache:
+    """Fetches and caches JWKS keys from an OIDC provider.
+
+    Args:
+        url: JWKS endpoint URL (e.g., https://sso.example.com/.well-known/jwks.json).
+        ttl: Cache time-to-live in seconds (default: 3600).
+    """
+
+    def __init__(self, url: str, ttl: float = 3600.0) -> None:
+        self._url = url
+        self._ttl = ttl
+        self._keys: dict[str, dict[str, Any]] = {}
+        self._fetched_at: float = 0.0
+        self._lock = asyncio.Lock()
+
+    async def get_key(self, kid: str) -> dict[str, Any] | None:
+        """Return the JWK for the given key ID, or None if not found.
+
+        If the cache is empty or expired, fetches from the JWKS endpoint.
+        If the kid is not found in a fresh cache, triggers one refresh
+        (handles key rotation), then returns None if still missing.
+        """
+        # Ensure cache is populated
+        if not self._keys or self._is_expired():
+            await self._fetch()
+
+        # Fast path: key found
+        if kid in self._keys:
+            return self._keys[kid]
+
+        # Key not found — might be a rotation; refresh once
+        await self.refresh()
+        return self._keys.get(kid)
+
+    async def refresh(self) -> None:
+        """Force-refresh the JWKS cache regardless of TTL."""
+        await self._fetch()
+
+    def _is_expired(self) -> bool:
+        """Check if the cache TTL has elapsed."""
+        return (time.monotonic() - self._fetched_at) >= self._ttl
+
+    async def _fetch(self) -> None:
+        """Fetch JWKS from the endpoint. Lock prevents stampede."""
+        async with self._lock:
+            # Double-check: another waiter may have already refreshed
+            # Skip this optimization on force-refresh (called from refresh())
+            # by always fetching when explicitly requested.
+            try:
+                async with httpx.AsyncClient() as client:
+                    resp = await client.get(self._url, timeout=10.0)
+                    resp.raise_for_status()
+                    data = resp.json()
+
+                keys: dict[str, dict[str, Any]] = {}
+                for key in data.get("keys", []):
+                    kid = key.get("kid")
+                    if kid:
+                        keys[str(kid)] = dict(key)
+
+                self._keys = keys
+                self._fetched_at = time.monotonic()
+                logger.info("JWKS refreshed from %s (%d keys)", self._url, len(keys))
+
+            except Exception:
+                # If we have stale keys, keep using them
+                if self._keys:
+                    logger.warning(
+                        "JWKS refresh failed, using stale cache (%d keys)",
+                        len(self._keys),
+                    )
+                else:
+                    logger.error("JWKS refresh failed and no stale cache available")
+                    raise

--- a/tests/security/test_auth_oidc.py
+++ b/tests/security/test_auth_oidc.py
@@ -1,0 +1,440 @@
+"""Tests for OIDC auth provider with JWKS cache (Keycloak + Entra ID).
+
+Uses real JWTs signed with an ephemeral RSA key. JWKS endpoint
+is faked via respx so no external HTTP calls are made.
+"""
+
+from __future__ import annotations
+
+import time
+from typing import Any
+
+import jwt as pyjwt
+import pytest
+import respx
+from cryptography.hazmat.primitives.asymmetric import rsa
+from httpx import Response
+
+from stronghold.security.auth_oidc import OIDCAuthProvider
+from stronghold.security.jwks import JWKSCache
+from stronghold.types.auth import AuthContext, IdentityKind
+from stronghold.types.errors import AuthError, TokenExpiredError
+
+# ── Fixtures: ephemeral RSA keypair + JWKS ──────────────────────────
+
+
+def _generate_rsa_keypair() -> tuple[rsa.RSAPrivateKey, dict[str, Any]]:
+    """Generate an RSA private key and its JWK representation."""
+    private_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    public_key = private_key.public_key()
+    public_numbers = public_key.public_numbers()
+
+    # Encode as base64url integers (no padding)
+    def _int_to_base64url(n: int, length: int) -> str:
+        data = n.to_bytes(length, byteorder="big")
+        import base64
+
+        return base64.urlsafe_b64encode(data).rstrip(b"=").decode("ascii")
+
+    jwk: dict[str, Any] = {
+        "kty": "RSA",
+        "kid": "test-key-1",
+        "use": "sig",
+        "alg": "RS256",
+        "n": _int_to_base64url(public_numbers.n, 256),
+        "e": _int_to_base64url(public_numbers.e, 3),
+    }
+    return private_key, jwk
+
+
+_PRIVATE_KEY, _JWK = _generate_rsa_keypair()
+_PRIVATE_KEY_2, _JWK_2 = _generate_rsa_keypair()
+_JWK_2["kid"] = "test-key-2"
+
+_JWKS_URL = "https://sso.example.com/.well-known/jwks.json"
+_ISSUER = "https://sso.example.com"
+_AUDIENCE = "stronghold-api"
+
+
+def _jwks_response(*jwks: dict[str, Any]) -> Response:
+    """Build a mock JWKS HTTP response."""
+    body = {"keys": list(jwks)}
+    return Response(200, json=body)
+
+
+def _sign_token(
+    claims: dict[str, Any],
+    kid: str = "test-key-1",
+    private_key: rsa.RSAPrivateKey | None = None,
+) -> str:
+    """Sign a JWT with the test RSA key."""
+    key = private_key or _PRIVATE_KEY
+    headers = {"kid": kid, "alg": "RS256"}
+    return pyjwt.encode(claims, key, algorithm="RS256", headers=headers)
+
+
+def _keycloak_claims(**overrides: Any) -> dict[str, Any]:
+    """Standard Keycloak-style token claims."""
+    claims: dict[str, Any] = {
+        "sub": "user-kc-001",
+        "preferred_username": "blake",
+        "email": "blake@example.com",
+        "realm_access": {"roles": ["admin", "user"]},
+        "organization_id": "org-emerald",
+        "team_id": "team-core",
+        "iss": _ISSUER,
+        "aud": _AUDIENCE,
+        "exp": int(time.time()) + 3600,
+        "iat": int(time.time()),
+    }
+    claims.update(overrides)
+    return claims
+
+
+def _entra_claims(**overrides: Any) -> dict[str, Any]:
+    """Standard Entra ID (Azure AD) style token claims."""
+    claims: dict[str, Any] = {
+        "sub": "user-entra-001",
+        "preferred_username": "blake@contoso.com",
+        "name": "Blake Matthews",
+        "roles": ["GlobalAdmin", "Reader"],
+        "tid": "tenant-contoso-123",
+        "iss": _ISSUER,
+        "aud": _AUDIENCE,
+        "exp": int(time.time()) + 3600,
+        "iat": int(time.time()),
+    }
+    claims.update(overrides)
+    return claims
+
+
+# ── Keycloak claims mapping ─────────────────────────────────────────
+
+_KEYCLOAK_CLAIMS_MAPPING: dict[str, str] = {
+    "user_id": "sub",
+    "username": "preferred_username",
+    "roles": "realm_access.roles",
+    "org_id": "organization_id",
+    "team_id": "team_id",
+}
+
+# ── Entra ID claims mapping ─────────────────────────────────────────
+
+_ENTRA_CLAIMS_MAPPING: dict[str, str] = {
+    "user_id": "sub",
+    "username": "preferred_username",
+    "roles": "roles",
+    "org_id": "tid",
+    "team_id": "",
+}
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# JWKSCache tests
+# ═══════════════════════════════════════════════════════════════════════
+
+
+class TestJWKSCacheFetch:
+    """JWKS key fetching and caching."""
+
+    @respx.mock
+    async def test_fetch_key_by_kid(self) -> None:
+        """Cache fetches JWKS and returns the matching key."""
+        respx.get(_JWKS_URL).mock(return_value=_jwks_response(_JWK))
+        cache = JWKSCache(url=_JWKS_URL, ttl=3600.0)
+        key = await cache.get_key("test-key-1")
+        assert key is not None
+        assert key["kid"] == "test-key-1"
+
+    @respx.mock
+    async def test_unknown_kid_returns_none(self) -> None:
+        """Unknown kid returns None after refresh attempt."""
+        respx.get(_JWKS_URL).mock(return_value=_jwks_response(_JWK))
+        cache = JWKSCache(url=_JWKS_URL, ttl=3600.0)
+        key = await cache.get_key("nonexistent-kid")
+        assert key is None
+
+    @respx.mock
+    async def test_cache_reuses_keys(self) -> None:
+        """Second call uses cached keys (no extra HTTP request)."""
+        route = respx.get(_JWKS_URL).mock(return_value=_jwks_response(_JWK))
+        cache = JWKSCache(url=_JWKS_URL, ttl=3600.0)
+        await cache.get_key("test-key-1")
+        await cache.get_key("test-key-1")
+        assert route.call_count == 1
+
+    @respx.mock
+    async def test_refresh_forces_refetch(self) -> None:
+        """Explicit refresh() bypasses TTL and refetches."""
+        route = respx.get(_JWKS_URL).mock(return_value=_jwks_response(_JWK))
+        cache = JWKSCache(url=_JWKS_URL, ttl=3600.0)
+        await cache.get_key("test-key-1")
+        assert route.call_count == 1
+        await cache.refresh()
+        assert route.call_count == 2
+
+    @respx.mock
+    async def test_unknown_kid_triggers_refresh_once(self) -> None:
+        """Looking up an unknown kid triggers one refresh, then returns None."""
+        route = respx.get(_JWKS_URL).mock(return_value=_jwks_response(_JWK))
+        cache = JWKSCache(url=_JWKS_URL, ttl=3600.0)
+        # First call: initial fetch
+        await cache.get_key("test-key-1")
+        assert route.call_count == 1
+        # Second call with unknown kid: triggers refresh, still not found
+        result = await cache.get_key("unknown-kid")
+        assert result is None
+        assert route.call_count == 2
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# OIDCAuthProvider — Keycloak
+# ═══════════════════════════════════════════════════════════════════════
+
+
+class TestOIDCKeycloak:
+    """OIDC auth with Keycloak-style claims."""
+
+    @respx.mock
+    async def test_valid_keycloak_token(self) -> None:
+        """Full happy path: valid Keycloak JWT -> AuthContext."""
+        respx.get(_JWKS_URL).mock(return_value=_jwks_response(_JWK))
+        provider = OIDCAuthProvider(
+            issuer_url=_ISSUER,
+            audience=_AUDIENCE,
+            jwks_url=_JWKS_URL,
+            claims_mapping=_KEYCLOAK_CLAIMS_MAPPING,
+        )
+        token = _sign_token(_keycloak_claims())
+        ctx = await provider.authenticate(f"Bearer {token}")
+
+        assert isinstance(ctx, AuthContext)
+        assert ctx.user_id == "user-kc-001"
+        assert ctx.username == "blake"
+        assert "admin" in ctx.roles
+        assert "user" in ctx.roles
+        assert ctx.org_id == "org-emerald"
+        assert ctx.team_id == "team-core"
+        assert ctx.auth_method == "oidc"
+        assert ctx.kind == IdentityKind.USER
+
+    @respx.mock
+    async def test_keycloak_no_org_gives_empty(self) -> None:
+        """Token without org_id claim -> empty org_id."""
+        respx.get(_JWKS_URL).mock(return_value=_jwks_response(_JWK))
+        provider = OIDCAuthProvider(
+            issuer_url=_ISSUER,
+            audience=_AUDIENCE,
+            jwks_url=_JWKS_URL,
+            claims_mapping=_KEYCLOAK_CLAIMS_MAPPING,
+        )
+        claims = _keycloak_claims()
+        del claims["organization_id"]
+        del claims["team_id"]
+        token = _sign_token(claims)
+        ctx = await provider.authenticate(f"Bearer {token}")
+        assert ctx.org_id == ""
+        assert ctx.team_id == ""
+
+    @respx.mock
+    async def test_keycloak_no_roles_gives_empty(self) -> None:
+        """Token without roles -> empty frozenset."""
+        respx.get(_JWKS_URL).mock(return_value=_jwks_response(_JWK))
+        provider = OIDCAuthProvider(
+            issuer_url=_ISSUER,
+            audience=_AUDIENCE,
+            jwks_url=_JWKS_URL,
+            claims_mapping=_KEYCLOAK_CLAIMS_MAPPING,
+        )
+        claims = _keycloak_claims()
+        del claims["realm_access"]
+        token = _sign_token(claims)
+        ctx = await provider.authenticate(f"Bearer {token}")
+        assert ctx.roles == frozenset()
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# OIDCAuthProvider — Entra ID
+# ═══════════════════════════════════════════════════════════════════════
+
+
+class TestOIDCEntraID:
+    """OIDC auth with Entra ID (Azure AD) style claims."""
+
+    @respx.mock
+    async def test_valid_entra_token(self) -> None:
+        """Full happy path: valid Entra ID JWT -> AuthContext."""
+        respx.get(_JWKS_URL).mock(return_value=_jwks_response(_JWK))
+        provider = OIDCAuthProvider(
+            issuer_url=_ISSUER,
+            audience=_AUDIENCE,
+            jwks_url=_JWKS_URL,
+            claims_mapping=_ENTRA_CLAIMS_MAPPING,
+        )
+        token = _sign_token(_entra_claims())
+        ctx = await provider.authenticate(f"Bearer {token}")
+
+        assert ctx.user_id == "user-entra-001"
+        assert ctx.username == "blake@contoso.com"
+        assert "GlobalAdmin" in ctx.roles
+        assert "Reader" in ctx.roles
+        assert ctx.org_id == "tenant-contoso-123"
+        assert ctx.team_id == ""
+        assert ctx.auth_method == "oidc"
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# OIDCAuthProvider — role_mapping
+# ═══════════════════════════════════════════════════════════════════════
+
+
+class TestOIDCRoleMapping:
+    """Role mapping translates IdP roles to Stronghold roles."""
+
+    @respx.mock
+    async def test_role_mapping_translates(self) -> None:
+        """IdP roles are mapped to Stronghold roles via role_mapping."""
+        respx.get(_JWKS_URL).mock(return_value=_jwks_response(_JWK))
+        provider = OIDCAuthProvider(
+            issuer_url=_ISSUER,
+            audience=_AUDIENCE,
+            jwks_url=_JWKS_URL,
+            claims_mapping=_ENTRA_CLAIMS_MAPPING,
+            role_mapping={"GlobalAdmin": "admin", "Reader": "viewer"},
+        )
+        token = _sign_token(_entra_claims())
+        ctx = await provider.authenticate(f"Bearer {token}")
+        assert ctx.roles == frozenset({"admin", "viewer"})
+
+    @respx.mock
+    async def test_unmapped_roles_are_kept(self) -> None:
+        """Roles not in role_mapping are passed through unchanged."""
+        respx.get(_JWKS_URL).mock(return_value=_jwks_response(_JWK))
+        provider = OIDCAuthProvider(
+            issuer_url=_ISSUER,
+            audience=_AUDIENCE,
+            jwks_url=_JWKS_URL,
+            claims_mapping=_KEYCLOAK_CLAIMS_MAPPING,
+            role_mapping={"admin": "org_admin"},
+        )
+        token = _sign_token(_keycloak_claims())
+        ctx = await provider.authenticate(f"Bearer {token}")
+        # "admin" -> "org_admin", "user" stays as "user"
+        assert "org_admin" in ctx.roles
+        assert "user" in ctx.roles
+        assert "admin" not in ctx.roles
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# OIDCAuthProvider — error handling
+# ═══════════════════════════════════════════════════════════════════════
+
+
+class TestOIDCErrors:
+    """Error cases for OIDC authentication."""
+
+    async def test_missing_authorization_header(self) -> None:
+        provider = OIDCAuthProvider(
+            issuer_url=_ISSUER,
+            audience=_AUDIENCE,
+            jwks_url=_JWKS_URL,
+            claims_mapping=_KEYCLOAK_CLAIMS_MAPPING,
+        )
+        with pytest.raises(AuthError, match="Missing Authorization"):
+            await provider.authenticate(None)
+
+    async def test_non_bearer_scheme(self) -> None:
+        provider = OIDCAuthProvider(
+            issuer_url=_ISSUER,
+            audience=_AUDIENCE,
+            jwks_url=_JWKS_URL,
+            claims_mapping=_KEYCLOAK_CLAIMS_MAPPING,
+        )
+        with pytest.raises(AuthError, match="Invalid authorization format"):
+            await provider.authenticate("Basic dXNlcjpwYXNz")
+
+    async def test_empty_bearer_token(self) -> None:
+        provider = OIDCAuthProvider(
+            issuer_url=_ISSUER,
+            audience=_AUDIENCE,
+            jwks_url=_JWKS_URL,
+            claims_mapping=_KEYCLOAK_CLAIMS_MAPPING,
+        )
+        with pytest.raises(AuthError, match="Empty token"):
+            await provider.authenticate("Bearer ")
+
+    @respx.mock
+    async def test_expired_token(self) -> None:
+        """Expired JWT raises TokenExpiredError."""
+        respx.get(_JWKS_URL).mock(return_value=_jwks_response(_JWK))
+        provider = OIDCAuthProvider(
+            issuer_url=_ISSUER,
+            audience=_AUDIENCE,
+            jwks_url=_JWKS_URL,
+            claims_mapping=_KEYCLOAK_CLAIMS_MAPPING,
+        )
+        claims = _keycloak_claims(exp=int(time.time()) - 3600)
+        token = _sign_token(claims)
+        with pytest.raises(TokenExpiredError):
+            await provider.authenticate(f"Bearer {token}")
+
+    @respx.mock
+    async def test_wrong_issuer(self) -> None:
+        """JWT with wrong issuer is rejected."""
+        respx.get(_JWKS_URL).mock(return_value=_jwks_response(_JWK))
+        provider = OIDCAuthProvider(
+            issuer_url=_ISSUER,
+            audience=_AUDIENCE,
+            jwks_url=_JWKS_URL,
+            claims_mapping=_KEYCLOAK_CLAIMS_MAPPING,
+        )
+        claims = _keycloak_claims(iss="https://evil.com")
+        token = _sign_token(claims)
+        with pytest.raises(AuthError, match="JWT validation failed"):
+            await provider.authenticate(f"Bearer {token}")
+
+    @respx.mock
+    async def test_wrong_audience(self) -> None:
+        """JWT with wrong audience is rejected."""
+        respx.get(_JWKS_URL).mock(return_value=_jwks_response(_JWK))
+        provider = OIDCAuthProvider(
+            issuer_url=_ISSUER,
+            audience=_AUDIENCE,
+            jwks_url=_JWKS_URL,
+            claims_mapping=_KEYCLOAK_CLAIMS_MAPPING,
+        )
+        claims = _keycloak_claims(aud="wrong-audience")
+        token = _sign_token(claims)
+        with pytest.raises(AuthError, match="JWT validation failed"):
+            await provider.authenticate(f"Bearer {token}")
+
+    @respx.mock
+    async def test_missing_sub_claim(self) -> None:
+        """Token without sub claim is rejected."""
+        respx.get(_JWKS_URL).mock(return_value=_jwks_response(_JWK))
+        provider = OIDCAuthProvider(
+            issuer_url=_ISSUER,
+            audience=_AUDIENCE,
+            jwks_url=_JWKS_URL,
+            claims_mapping=_KEYCLOAK_CLAIMS_MAPPING,
+        )
+        claims = _keycloak_claims()
+        del claims["sub"]
+        token = _sign_token(claims)
+        with pytest.raises(AuthError, match="missing user_id"):
+            await provider.authenticate(f"Bearer {token}")
+
+    @respx.mock
+    async def test_wrong_signing_key_rejected(self) -> None:
+        """Token signed with a different key is rejected."""
+        respx.get(_JWKS_URL).mock(return_value=_jwks_response(_JWK))
+        provider = OIDCAuthProvider(
+            issuer_url=_ISSUER,
+            audience=_AUDIENCE,
+            jwks_url=_JWKS_URL,
+            claims_mapping=_KEYCLOAK_CLAIMS_MAPPING,
+        )
+        # Sign with key-2 but JWKS only has key-1
+        token = _sign_token(_keycloak_claims(), kid="test-key-2", private_key=_PRIVATE_KEY_2)
+        with pytest.raises(AuthError, match="JWT validation failed"):
+            await provider.authenticate(f"Bearer {token}")


### PR DESCRIPTION
Closes #56. JWKSCache with TTL + stampede prevention. OIDCAuthProvider with configurable claims_mapping + role_mapping. Validates JWT exp/iss/aud. 19 tests with real RSA keys.