### PR TITLE
feat: add A2A container runtime for custom agent strategies

### DIFF
--- a/src/stronghold/agents/container_runtime.py
+++ b/src/stronghold/agents/container_runtime.py
@@ -1,0 +1,147 @@
+"""A2A container runtime for custom agent strategies.
+
+Provides dataclasses for container-based agent execution and an in-memory
+ContainerRuntime that simulates dispatch. Real K8s Job dispatch is a
+follow-up implementation — this module defines the interface and provides
+the in-memory version for testing and local development.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import secrets
+import uuid
+from dataclasses import dataclass, field
+from typing import Any
+
+from stronghold.types.errors import StrongholdError
+
+
+class ContainerNotAvailableError(StrongholdError):
+    """Raised when the container runtime is unavailable."""
+
+    code = "CONTAINER_NOT_AVAILABLE"
+
+
+@dataclass(frozen=True)
+class ContainerStrategy:
+    """Defines how to run an agent in a container.
+
+    Attributes:
+        image: Container image (e.g. ``stronghold/ranger:latest``).
+        command: Entrypoint command list.
+        timeout: Maximum execution time in seconds.
+        resource_limits: K8s-style resource limits (cpu, memory).
+    """
+
+    image: str
+    command: list[str]
+    timeout: int = 300
+    resource_limits: dict[str, str] = field(
+        default_factory=lambda: {"cpu": "500m", "memory": "512Mi"}
+    )
+
+
+@dataclass(frozen=True)
+class A2ATask:
+    """An agent-to-agent task for container dispatch.
+
+    Attributes:
+        task_id: Unique identifier for this task.
+        agent_name: Target agent to execute.
+        messages: Chat messages to pass to the agent.
+        callback_url: URL for completion callback.
+        token_budget: Maximum tokens the agent may consume.
+    """
+
+    task_id: str
+    agent_name: str
+    messages: list[dict[str, Any]] = field(default_factory=list)
+    callback_url: str = ""
+    token_budget: int = 0
+
+
+class ContainerRuntime:
+    """In-memory container runtime for A2A task dispatch.
+
+    Simulates container execution for testing and local development.
+    A production implementation would dispatch K8s Jobs.
+
+    Args:
+        available: Whether the runtime accepts dispatches. Set to ``False``
+            to simulate a runtime outage.
+    """
+
+    def __init__(self, *, available: bool = True) -> None:
+        self._available = available
+        self._containers: dict[str, dict[str, Any]] = {}
+
+    async def dispatch(self, task: A2ATask, strategy: ContainerStrategy) -> dict[str, Any]:
+        """Simulate dispatching a task to a container.
+
+        Args:
+            task: The A2A task to execute.
+            strategy: Container configuration for execution.
+
+        Returns:
+            A dict with task_id, status, container_id, callback_token,
+            and the strategy parameters used.
+
+        Raises:
+            ContainerNotAvailableError: If the runtime is unavailable.
+        """
+        if not self._available:
+            raise ContainerNotAvailableError("Container runtime is not available")
+
+        container_id = f"ctr-{uuid.uuid4().hex[:12]}"
+        callback_token = self._generate_callback_token(task.agent_name, task.task_id)
+
+        self._containers[container_id] = {
+            "task_id": task.task_id,
+            "agent_name": task.agent_name,
+            "status": "running",
+            "strategy": strategy,
+        }
+
+        return {
+            "task_id": task.task_id,
+            "agent_name": task.agent_name,
+            "status": "completed",
+            "container_id": container_id,
+            "callback_token": callback_token,
+            "timeout": strategy.timeout,
+            "resource_limits": dict(strategy.resource_limits),
+            "image": strategy.image,
+            "command": list(strategy.command),
+            "token_budget": task.token_budget,
+        }
+
+    async def health_check(self, container_id: str) -> bool:
+        """Check whether a container is known and healthy.
+
+        Args:
+            container_id: The container identifier returned by :meth:`dispatch`.
+
+        Returns:
+            ``True`` if the container exists, ``False`` otherwise.
+        """
+        return container_id in self._containers
+
+    @staticmethod
+    def _generate_callback_token(agent_name: str, task_id: str) -> str:
+        """Generate a short-lived token for callback authentication.
+
+        Combines agent name, task ID, and a random nonce to produce a
+        unique, unpredictable token. A production implementation would
+        issue a signed JWT with expiration.
+
+        Args:
+            agent_name: The agent this token authorises callbacks for.
+            task_id: The task this token is scoped to.
+
+        Returns:
+            A hex-encoded callback token.
+        """
+        nonce = secrets.token_hex(16)
+        raw = f"{agent_name}:{task_id}:{nonce}"
+        return hashlib.sha256(raw.encode()).hexdigest()

--- a/tests/agents/test_container_runtime.py
+++ b/tests/agents/test_container_runtime.py
@@ -1,0 +1,172 @@
+"""Tests for A2A container runtime: dispatch, health_check, callback tokens."""
+
+from __future__ import annotations
+
+import pytest
+
+from stronghold.agents.container_runtime import (
+    A2ATask,
+    ContainerNotAvailableError,
+    ContainerRuntime,
+    ContainerStrategy,
+)
+
+
+class TestContainerStrategy:
+    def test_defaults(self) -> None:
+        cs = ContainerStrategy(image="stronghold/ranger:latest", command=["python", "-m", "agent"])
+        assert cs.image == "stronghold/ranger:latest"
+        assert cs.command == ["python", "-m", "agent"]
+        assert cs.timeout == 300
+        assert cs.resource_limits == {"cpu": "500m", "memory": "512Mi"}
+
+    def test_custom_resource_limits(self) -> None:
+        cs = ContainerStrategy(
+            image="stronghold/artificer:latest",
+            command=["python", "-m", "agent"],
+            timeout=600,
+            resource_limits={"cpu": "2000m", "memory": "4Gi"},
+        )
+        assert cs.timeout == 600
+        assert cs.resource_limits["cpu"] == "2000m"
+        assert cs.resource_limits["memory"] == "4Gi"
+
+    def test_frozen(self) -> None:
+        cs = ContainerStrategy(image="img:1", command=["run"])
+        with pytest.raises(AttributeError):
+            cs.image = "img:2"  # type: ignore[misc]
+
+
+class TestA2ATask:
+    def test_construction(self) -> None:
+        task = A2ATask(
+            task_id="t-001",
+            agent_name="ranger",
+            messages=[{"role": "user", "content": "search logs"}],
+            callback_url="https://stronghold.local/callback",
+            token_budget=4096,
+        )
+        assert task.task_id == "t-001"
+        assert task.agent_name == "ranger"
+        assert len(task.messages) == 1
+        assert task.callback_url == "https://stronghold.local/callback"
+        assert task.token_budget == 4096
+
+    def test_defaults(self) -> None:
+        task = A2ATask(task_id="t-002", agent_name="scribe")
+        assert task.messages == []
+        assert task.callback_url == ""
+        assert task.token_budget == 0
+
+    def test_frozen(self) -> None:
+        task = A2ATask(task_id="t-003", agent_name="forge")
+        with pytest.raises(AttributeError):
+            task.agent_name = "ranger"  # type: ignore[misc]
+
+
+class TestContainerRuntime:
+    async def test_dispatch_returns_result(self) -> None:
+        runtime = ContainerRuntime()
+        task = A2ATask(
+            task_id="t-100",
+            agent_name="ranger",
+            messages=[{"role": "user", "content": "find file"}],
+            callback_url="https://stronghold.local/cb",
+            token_budget=2048,
+        )
+        strategy = ContainerStrategy(image="stronghold/ranger:latest", command=["python", "run.py"])
+        result = await runtime.dispatch(task, strategy)
+        assert result["task_id"] == "t-100"
+        assert result["status"] == "completed"
+        assert result["agent_name"] == "ranger"
+        assert "container_id" in result
+        assert "callback_token" in result
+
+    async def test_dispatch_stores_container(self) -> None:
+        runtime = ContainerRuntime()
+        task = A2ATask(task_id="t-101", agent_name="scribe", token_budget=1024)
+        strategy = ContainerStrategy(image="stronghold/scribe:latest", command=["python", "run.py"])
+        result = await runtime.dispatch(task, strategy)
+        container_id = result["container_id"]
+        is_healthy = await runtime.health_check(container_id)
+        assert is_healthy is True
+
+    async def test_health_check_unknown_container(self) -> None:
+        runtime = ContainerRuntime()
+        is_healthy = await runtime.health_check("nonexistent-container-id")
+        assert is_healthy is False
+
+    async def test_dispatch_respects_timeout(self) -> None:
+        runtime = ContainerRuntime()
+        task = A2ATask(task_id="t-102", agent_name="artificer", token_budget=8192)
+        strategy = ContainerStrategy(
+            image="stronghold/artificer:latest",
+            command=["python", "run.py"],
+            timeout=60,
+        )
+        result = await runtime.dispatch(task, strategy)
+        assert result["timeout"] == 60
+
+    async def test_dispatch_multiple_tasks(self) -> None:
+        runtime = ContainerRuntime()
+        strategy = ContainerStrategy(image="stronghold/ranger:latest", command=["run"])
+        ids = []
+        for i in range(5):
+            task = A2ATask(task_id=f"t-{200 + i}", agent_name="ranger", token_budget=1024)
+            result = await runtime.dispatch(task, strategy)
+            ids.append(result["container_id"])
+        # All container IDs should be unique
+        assert len(set(ids)) == 5
+
+    async def test_callback_token_unique_per_task(self) -> None:
+        runtime = ContainerRuntime()
+        strategy = ContainerStrategy(image="img:1", command=["run"])
+        task1 = A2ATask(task_id="t-300", agent_name="ranger", token_budget=1024)
+        task2 = A2ATask(task_id="t-301", agent_name="ranger", token_budget=1024)
+        r1 = await runtime.dispatch(task1, strategy)
+        r2 = await runtime.dispatch(task2, strategy)
+        assert r1["callback_token"] != r2["callback_token"]
+
+    async def test_dispatch_unavailable_raises(self) -> None:
+        runtime = ContainerRuntime(available=False)
+        task = A2ATask(task_id="t-400", agent_name="ranger", token_budget=1024)
+        strategy = ContainerStrategy(image="img:1", command=["run"])
+        with pytest.raises(ContainerNotAvailableError):
+            await runtime.dispatch(task, strategy)
+
+    async def test_container_not_available_error_inherits(self) -> None:
+        from stronghold.types.errors import StrongholdError
+
+        err = ContainerNotAvailableError("runtime down")
+        assert isinstance(err, StrongholdError)
+        assert err.code == "CONTAINER_NOT_AVAILABLE"
+        assert "runtime down" in str(err)
+
+    async def test_dispatch_includes_resource_limits(self) -> None:
+        runtime = ContainerRuntime()
+        task = A2ATask(task_id="t-500", agent_name="artificer", token_budget=4096)
+        strategy = ContainerStrategy(
+            image="stronghold/artificer:latest",
+            command=["python", "run.py"],
+            resource_limits={"cpu": "4000m", "memory": "8Gi"},
+        )
+        result = await runtime.dispatch(task, strategy)
+        assert result["resource_limits"] == {"cpu": "4000m", "memory": "8Gi"}
+
+    async def test_dispatch_includes_image_and_command(self) -> None:
+        runtime = ContainerRuntime()
+        task = A2ATask(task_id="t-600", agent_name="forge", token_budget=2048)
+        strategy = ContainerStrategy(
+            image="stronghold/forge:v2",
+            command=["python", "-m", "forge", "--safe"],
+        )
+        result = await runtime.dispatch(task, strategy)
+        assert result["image"] == "stronghold/forge:v2"
+        assert result["command"] == ["python", "-m", "forge", "--safe"]
+
+    async def test_dispatch_includes_token_budget(self) -> None:
+        runtime = ContainerRuntime()
+        task = A2ATask(task_id="t-700", agent_name="scribe", token_budget=16384)
+        strategy = ContainerStrategy(image="img:1", command=["run"])
+        result = await runtime.dispatch(task, strategy)
+        assert result["token_budget"] == 16384


### PR DESCRIPTION
Closes #59. ContainerStrategy, A2ATask, ContainerRuntime with dispatch/health_check, callback token generation. ContainerNotAvailableError. In-memory simulation (K8s Job follow-up). 17 tests.