### PR TITLE
feat: add config validation with CLI entry point

### DIFF
--- a/src/stronghold/config/validator.py
+++ b/src/stronghold/config/validator.py
@@ -1,0 +1,260 @@
+"""Config validation: load YAML, check against StrongholdConfig schema, report errors.
+
+Usage as CLI::
+
+    python -m stronghold.config.validator config/example.yaml
+"""
+
+from __future__ import annotations
+
+import ipaddress
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Literal
+from urllib.parse import urlparse
+
+import yaml
+
+from stronghold.types.config import StrongholdConfig
+
+_VALID_TIERS = {"small", "medium", "large"}
+
+_REQUIRED_PROVIDER_FIELDS = {"status"}
+_REQUIRED_MODEL_FIELDS = {"provider", "tier", "quality", "speed", "litellm_id", "strengths"}
+
+# URL fields that must be syntactically valid when non-empty.
+# Tuple of (field_name, allow_http).  Internal services allow http.
+_URL_FIELDS: list[tuple[str, bool]] = [
+    ("litellm_url", True),
+    ("phoenix_endpoint", True),
+    ("database_url", True),
+    ("redis_url", True),
+]
+
+# Auth URL fields that should not point at private IPs.
+_AUTH_PUBLIC_URL_FIELDS = [
+    "jwks_url",
+    "issuer",
+    "authorization_url",
+    "token_url",
+]
+
+
+@dataclass(frozen=True)
+class ConfigValidationError:
+    """A single validation finding."""
+
+    field: str
+    message: str
+    severity: Literal["error", "warning"]
+
+
+def _validate_url_syntax(
+    value: str,
+    field: str,
+    allow_http: bool,
+) -> list[ConfigValidationError]:
+    """Check that *value* is a syntactically valid URL."""
+    errors: list[ConfigValidationError] = []
+    parsed = urlparse(value)
+    valid_schemes = {"http", "https"} if allow_http else {"https"}
+    # Also accept postgres/redis schemes for DB/cache URLs
+    if field in ("database_url", "redis_url"):
+        valid_schemes |= {"postgresql", "postgres", "redis", "rediss"}
+    if parsed.scheme not in valid_schemes:
+        errors.append(
+            ConfigValidationError(
+                field=field,
+                message=(
+                    f"Invalid URL scheme {parsed.scheme!r} in {value!r}; "
+                    f"expected one of {sorted(valid_schemes)}"
+                ),
+                severity="error",
+            )
+        )
+    if not parsed.hostname:
+        errors.append(
+            ConfigValidationError(
+                field=field,
+                message=f"URL has no hostname: {value!r}",
+                severity="error",
+            )
+        )
+    return errors
+
+
+def _check_private_ip(hostname: str) -> bool:
+    """Return True if *hostname* is a literal private/loopback/link-local IP."""
+    try:
+        ip = ipaddress.ip_address(hostname)
+    except ValueError:
+        return False
+    return bool(ip.is_private or ip.is_loopback or ip.is_link_local)
+
+
+def validate_config(config_path: str) -> list[ConfigValidationError]:
+    """Load a YAML config file and validate it against the StrongholdConfig schema.
+
+    Returns a list of :class:`ConfigValidationError` instances.
+    An empty list means the config is valid.
+    """
+    errors: list[ConfigValidationError] = []
+    path = Path(config_path)
+
+    # ── File existence ──────────────────────────────────────────────
+    if not path.exists():
+        return [
+            ConfigValidationError(
+                field="config_path",
+                message=f"Config file does not exist: {config_path}",
+                severity="error",
+            )
+        ]
+
+    # ── YAML parsing ────────────────────────────────────────────────
+    try:
+        with open(path) as f:
+            raw = yaml.safe_load(f) or {}
+    except yaml.YAMLError as exc:
+        return [
+            ConfigValidationError(
+                field="config_path",
+                message=f"Invalid YAML: {exc}",
+                severity="error",
+            )
+        ]
+
+    # ── Pydantic schema validation ──────────────────────────────────
+    try:
+        config = StrongholdConfig(**raw)
+    except Exception as exc:  # noqa: BLE001
+        return [
+            ConfigValidationError(
+                field="schema",
+                message=f"Schema validation failed: {exc}",
+                severity="error",
+            )
+        ]
+
+    # ── URL format checks ───────────────────────────────────────────
+    for field_name, allow_http in _URL_FIELDS:
+        value = getattr(config, field_name, "")
+        if value:
+            errors.extend(_validate_url_syntax(value, field_name, allow_http))
+
+    # ── Auth public URL checks (no private IPs) ────────────────────
+    for auth_field in _AUTH_PUBLIC_URL_FIELDS:
+        value = getattr(config.auth, auth_field, "")
+        if not value:
+            continue
+        full_field = f"auth.{auth_field}"
+        parsed = urlparse(value)
+        hostname = parsed.hostname or ""
+        if _check_private_ip(hostname):
+            errors.append(
+                ConfigValidationError(
+                    field=full_field,
+                    message=f"Private/loopback IP in public URL: {value!r}",
+                    severity="warning",
+                )
+            )
+        # Also validate scheme
+        if parsed.scheme not in ("http", "https"):
+            errors.append(
+                ConfigValidationError(
+                    field=full_field,
+                    message=f"Invalid URL scheme {parsed.scheme!r} in {value!r}",
+                    severity="error",
+                )
+            )
+
+    # ── Provider validation ─────────────────────────────────────────
+    for name, provider_cfg in config.providers.items():
+        provider_dict = dict(provider_cfg) if isinstance(provider_cfg, dict) else {}
+        for req_field in _REQUIRED_PROVIDER_FIELDS:
+            if req_field not in provider_dict:
+                errors.append(
+                    ConfigValidationError(
+                        field=f"providers.{name}",
+                        message=f"Missing required field {req_field!r}",
+                        severity="error",
+                    )
+                )
+
+    # ── Model validation ────────────────────────────────────────────
+    for name, model_cfg in config.models.items():
+        model_dict = dict(model_cfg) if isinstance(model_cfg, dict) else {}
+        prefix = f"models.{name}"
+
+        for req_field in _REQUIRED_MODEL_FIELDS:
+            if req_field not in model_dict:
+                errors.append(
+                    ConfigValidationError(
+                        field=prefix,
+                        message=f"Missing required field {req_field!r}",
+                        severity="error",
+                    )
+                )
+
+        tier = model_dict.get("tier")
+        if tier is not None and tier not in _VALID_TIERS:
+            errors.append(
+                ConfigValidationError(
+                    field=prefix,
+                    message=f"Invalid tier {tier!r}; must be one of {sorted(_VALID_TIERS)}",
+                    severity="error",
+                )
+            )
+
+        quality = model_dict.get("quality")
+        if quality is not None:
+            try:
+                q = float(str(quality))
+                if not (0.0 <= q <= 1.0):
+                    errors.append(
+                        ConfigValidationError(
+                            field=prefix,
+                            message=f"Quality {q} out of range [0.0, 1.0]",
+                            severity="error",
+                        )
+                    )
+            except (TypeError, ValueError):
+                errors.append(
+                    ConfigValidationError(
+                        field=prefix,
+                        message=f"Quality must be a number, got {quality!r}",
+                        severity="error",
+                    )
+                )
+
+    return errors
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entry point for config validation."""
+    args = argv if argv is not None else sys.argv[1:]
+    if not args:
+        print("Usage: python -m stronghold.config.validator <config.yaml>", file=sys.stderr)
+        return 2
+
+    config_path = args[0]
+    results = validate_config(config_path)
+
+    error_count = sum(1 for e in results if e.severity == "error")
+    warning_count = sum(1 for e in results if e.severity == "warning")
+
+    for err in results:
+        tag = "ERROR" if err.severity == "error" else "WARNING"
+        print(f"[{tag}] {err.field}: {err.message}")
+
+    if error_count == 0 and warning_count == 0:
+        print(f"Config {config_path} is valid. 0 errors, 0 warnings.")
+    else:
+        print(f"\n{error_count} error(s), {warning_count} warning(s).")
+
+    return 1 if error_count > 0 else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/config/test_validator.py
+++ b/tests/config/test_validator.py
@@ -1,0 +1,248 @@
+"""Tests for config validation CLI and validate_config function."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from stronghold.config.validator import ConfigValidationError, validate_config
+
+if TYPE_CHECKING:
+    import pathlib
+
+
+class TestValidateConfigValidFile:
+    """Valid configs should return no errors."""
+
+    def test_example_config_is_valid(self) -> None:
+        """The shipped example.yaml must validate without errors."""
+        errors = validate_config("config/example.yaml")
+        error_msgs = [e for e in errors if e.severity == "error"]
+        assert error_msgs == []
+
+    def test_minimal_valid_config(self, tmp_path: pathlib.Path) -> None:
+        """A config with only defaults should validate cleanly."""
+        cfg = tmp_path / "minimal.yaml"
+        cfg.write_text("{}\n")
+        errors = validate_config(str(cfg))
+        error_msgs = [e for e in errors if e.severity == "error"]
+        assert error_msgs == []
+
+
+class TestValidateConfigMissingFile:
+    """Missing or unparseable files should produce errors."""
+
+    def test_nonexistent_file_returns_error(self) -> None:
+        errors = validate_config("/nonexistent/config.yaml")
+        assert len(errors) == 1
+        assert errors[0].severity == "error"
+        msg = errors[0].message.lower()
+        assert "not found" in msg or "does not exist" in msg
+
+    def test_invalid_yaml_returns_error(self, tmp_path: pathlib.Path) -> None:
+        bad = tmp_path / "bad.yaml"
+        bad.write_text("{ invalid: yaml: [")
+        errors = validate_config(str(bad))
+        assert any(e.severity == "error" and "yaml" in e.message.lower() for e in errors)
+
+
+class TestValidateConfigURLFormats:
+    """URL fields must have valid format."""
+
+    def test_litellm_url_invalid_scheme(self, tmp_path: pathlib.Path) -> None:
+        cfg = tmp_path / "cfg.yaml"
+        cfg.write_text("litellm_url: not-a-url\n")
+        errors = validate_config(str(cfg))
+        assert any(e.field == "litellm_url" and e.severity == "error" for e in errors)
+
+    def test_litellm_url_valid_http(self, tmp_path: pathlib.Path) -> None:
+        """http is allowed for internal service URLs (litellm, phoenix, etc.)."""
+        cfg = tmp_path / "cfg.yaml"
+        cfg.write_text("litellm_url: http://litellm:4000\n")
+        errors = validate_config(str(cfg))
+        url_errors = [e for e in errors if e.field == "litellm_url" and e.severity == "error"]
+        assert url_errors == []
+
+    def test_phoenix_endpoint_invalid(self, tmp_path: pathlib.Path) -> None:
+        cfg = tmp_path / "cfg.yaml"
+        cfg.write_text("phoenix_endpoint: ://broken\n")
+        errors = validate_config(str(cfg))
+        assert any(e.field == "phoenix_endpoint" and e.severity == "error" for e in errors)
+
+
+class TestValidateConfigPrivateIPs:
+    """Public-facing URLs must not contain private IPs."""
+
+    def test_auth_jwks_url_private_ip_warning(self, tmp_path: pathlib.Path) -> None:
+        cfg = tmp_path / "cfg.yaml"
+        cfg.write_text("auth:\n  jwks_url: https://192.168.1.1/.well-known/jwks.json\n")
+        errors = validate_config(str(cfg))
+        assert any(e.field == "auth.jwks_url" and "private" in e.message.lower() for e in errors)
+
+    def test_auth_jwks_url_loopback_warning(self, tmp_path: pathlib.Path) -> None:
+        cfg = tmp_path / "cfg.yaml"
+        cfg.write_text("auth:\n  jwks_url: https://127.0.0.1/.well-known/jwks.json\n")
+        errors = validate_config(str(cfg))
+        assert any(
+            e.field == "auth.jwks_url"
+            and ("private" in e.message.lower() or "loopback" in e.message.lower())
+            for e in errors
+        )
+
+
+class TestValidateConfigProviders:
+    """Provider configs must have required fields."""
+
+    def test_provider_missing_status(self, tmp_path: pathlib.Path) -> None:
+        cfg = tmp_path / "cfg.yaml"
+        cfg.write_text("providers:\n  bad_provider:\n    billing_cycle: monthly\n")
+        errors = validate_config(str(cfg))
+        assert any(
+            e.field.startswith("providers.bad_provider") and e.severity == "error" for e in errors
+        )
+
+    def test_provider_valid(self, tmp_path: pathlib.Path) -> None:
+        cfg = tmp_path / "cfg.yaml"
+        cfg.write_text(
+            "providers:\n"
+            "  good:\n"
+            "    status: active\n"
+            "    billing_cycle: monthly\n"
+            "    free_tokens: 1000\n"
+        )
+        errors = validate_config(str(cfg))
+        provider_errors = [
+            e for e in errors if e.field.startswith("providers.") and e.severity == "error"
+        ]
+        assert provider_errors == []
+
+
+class TestValidateConfigModels:
+    """Model configs must have required fields."""
+
+    def test_model_missing_provider(self, tmp_path: pathlib.Path) -> None:
+        cfg = tmp_path / "cfg.yaml"
+        cfg.write_text("models:\n  bad-model:\n    tier: small\n    quality: 0.5\n")
+        errors = validate_config(str(cfg))
+        assert any(e.field.startswith("models.bad-model") and e.severity == "error" for e in errors)
+
+    def test_model_invalid_tier(self, tmp_path: pathlib.Path) -> None:
+        cfg = tmp_path / "cfg.yaml"
+        cfg.write_text(
+            "models:\n"
+            "  bad-model:\n"
+            "    provider: test\n"
+            "    tier: gigantic\n"
+            "    quality: 0.5\n"
+            "    speed: 100\n"
+            "    litellm_id: test/bad\n"
+            "    strengths: [chat]\n"
+        )
+        errors = validate_config(str(cfg))
+        assert any(
+            e.field.startswith("models.bad-model") and "tier" in e.message.lower() for e in errors
+        )
+
+    def test_model_quality_out_of_range(self, tmp_path: pathlib.Path) -> None:
+        cfg = tmp_path / "cfg.yaml"
+        cfg.write_text(
+            "models:\n"
+            "  bad-model:\n"
+            "    provider: test\n"
+            "    tier: small\n"
+            "    quality: 5.0\n"
+            "    speed: 100\n"
+            "    litellm_id: test/bad\n"
+            "    strengths: [chat]\n"
+        )
+        errors = validate_config(str(cfg))
+        assert any(
+            e.field.startswith("models.bad-model") and "quality" in e.message.lower()
+            for e in errors
+        )
+
+    def test_model_valid(self, tmp_path: pathlib.Path) -> None:
+        cfg = tmp_path / "cfg.yaml"
+        cfg.write_text(
+            "providers:\n"
+            "  test:\n"
+            "    status: active\n"
+            "    billing_cycle: monthly\n"
+            "    free_tokens: 1000\n"
+            "models:\n"
+            "  good-model:\n"
+            "    provider: test\n"
+            "    tier: small\n"
+            "    quality: 0.5\n"
+            "    speed: 100\n"
+            "    litellm_id: test/good\n"
+            "    strengths: [chat]\n"
+        )
+        errors = validate_config(str(cfg))
+        model_errors = [
+            e for e in errors if e.field.startswith("models.") and e.severity == "error"
+        ]
+        assert model_errors == []
+
+
+class TestConfigValidationErrorDataclass:
+    """ConfigValidationError should be a proper dataclass."""
+
+    def test_fields(self) -> None:
+        err = ConfigValidationError(
+            field="litellm_url",
+            message="Invalid URL",
+            severity="error",
+        )
+        assert err.field == "litellm_url"
+        assert err.message == "Invalid URL"
+        assert err.severity == "error"
+
+    def test_warning_severity(self) -> None:
+        err = ConfigValidationError(
+            field="auth.jwks_url",
+            message="Private IP detected",
+            severity="warning",
+        )
+        assert err.severity == "warning"
+
+
+class TestValidateConfigCLI:
+    """The module can be invoked as python -m stronghold.config.validator."""
+
+    def test_cli_valid_config(self, tmp_path: pathlib.Path) -> None:
+        import subprocess
+        import sys
+
+        cfg = tmp_path / "valid.yaml"
+        cfg.write_text("{}\n")
+        result = subprocess.run(
+            [sys.executable, "-m", "stronghold.config.validator", str(cfg)],
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 0
+        assert "valid" in result.stdout.lower() or "0 error" in result.stdout.lower()
+
+    def test_cli_invalid_config(self, tmp_path: pathlib.Path) -> None:
+        import subprocess
+        import sys
+
+        cfg = tmp_path / "bad.yaml"
+        cfg.write_text("litellm_url: not-a-url\n")
+        result = subprocess.run(
+            [sys.executable, "-m", "stronghold.config.validator", str(cfg)],
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode != 0
+
+    def test_cli_missing_file(self) -> None:
+        import subprocess
+        import sys
+
+        result = subprocess.run(
+            [sys.executable, "-m", "stronghold.config.validator", "/no/such/file.yaml"],
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode != 0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -137,6 +137,7 @@ _HAPPY_FILES = {
     # Config
     "config/test_loader.py",
     "config/test_env_override.py",
+    "config/test_validator.py",
     # Reactor
     "reactor/test_reactor.py",
     # Tracing


### PR DESCRIPTION
Config validator: YAML loading, StrongholdConfig schema check, URL validation, private IP detection, provider/model field validation. CLI: python -m stronghold.config.validator. 20 tests.