### PR TITLE
fix: connect worker_main to Container and batch task queue

### DIFF
--- a/src/stronghold/agents/worker.py
+++ b/src/stronghold/agents/worker.py
@@ -1,31 +1,37 @@
-"""Agent Worker: claims tasks from the queue and runs agent pipelines.
+"""Agent Worker: claims tasks from the queue and routes them through the Container.
 
-Runs in its own pod/process. Picks up tasks, runs the agent,
-reports results back to the queue.
+Runs in its own pod/process. Picks up tasks from the shared task queue,
+routes them through container.route_request() (full Conduit pipeline),
+and reports results back to the queue.
 """
 
 from __future__ import annotations
 
+import asyncio
 import logging
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
-if TYPE_CHECKING:
-    from stronghold.agents.task_queue import InMemoryTaskQueue
-    from stronghold.protocols.llm import LLMClient
+from stronghold.types.auth import SYSTEM_AUTH, AuthContext, IdentityKind
 
 logger = logging.getLogger("stronghold.worker")
 
 
 class AgentWorker:
-    """Claims tasks from the queue and processes them via agents."""
+    """Claims tasks from the queue and processes them via the Container pipeline.
 
-    def __init__(
-        self,
-        queue: InMemoryTaskQueue,
-        llm: LLMClient,
-    ) -> None:
-        self._queue = queue
-        self._llm = llm
+    The worker uses container.task_queue to poll for pending tasks and
+    container.route_request() to process them through the full Conduit
+    pipeline (classify, route, agent.handle).
+    """
+
+    def __init__(self, container: Any) -> None:
+        self._container = container
+        self._queue = container.task_queue
+        self._shutdown_requested = False
+
+    def request_shutdown(self) -> None:
+        """Signal the worker to stop after the current task completes."""
+        self._shutdown_requested = True
 
     async def process_one(self) -> bool:
         """Claim and process one task. Returns True if a task was processed."""
@@ -33,11 +39,11 @@ class AgentWorker:
         if task is None:
             return False
 
-        task_id = task["id"]
-        payload = task.get("payload", {})
+        task_id: str = task["id"]
+        payload: dict[str, Any] = task.get("payload", {})
 
         try:
-            result = await self._run_agent(payload)
+            result = await self._route_task(payload)
             await self._queue.complete(task_id, result)
         except Exception as exc:
             logger.exception("Task %s failed", task_id)
@@ -45,32 +51,61 @@ class AgentWorker:
 
         return True
 
-    async def _run_agent(self, payload: dict[str, Any]) -> dict[str, Any]:
-        """Run the agent pipeline for a task payload."""
-        messages = payload.get("messages", [])
-        model = payload.get("model", "auto")
+    async def _route_task(self, payload: dict[str, Any]) -> dict[str, Any]:
+        """Route a task through the Container's Conduit pipeline."""
+        messages: list[dict[str, Any]] = payload.get("messages", [])
+        session_id: str | None = payload.get("session_id")
+        intent_hint: str = payload.get("intent_hint", "")
 
-        # Call LLM directly for now — full agent pipeline integration later
-        response = await self._llm.complete(messages, model)
+        # Build auth context from payload or fall back to SYSTEM_AUTH
+        auth = self._build_auth(payload.get("auth"))
+
+        response: dict[str, Any] = await self._container.route_request(
+            messages,
+            auth=auth,
+            session_id=session_id,
+            intent_hint=intent_hint,
+        )
+
+        # Extract content from the OpenAI-compatible response
         content = response.get("choices", [{}])[0].get("message", {}).get("content", "")
 
         return {
             "content": content,
-            "agent": payload.get("agent", "default"),
-            "model": model,
+            "model": response.get("model", "unknown"),
+            "response": response,
         }
 
+    @staticmethod
+    def _build_auth(auth_data: dict[str, Any] | None) -> AuthContext:
+        """Build an AuthContext from task payload data, or use SYSTEM_AUTH."""
+        if auth_data is None:
+            return SYSTEM_AUTH
+
+        roles_raw = auth_data.get("roles", [])
+        roles = frozenset(roles_raw) if isinstance(roles_raw, list) else frozenset()
+
+        return AuthContext(
+            user_id=auth_data.get("user_id", "system"),
+            username=auth_data.get("username", ""),
+            org_id=auth_data.get("org_id", ""),
+            team_id=auth_data.get("team_id", ""),
+            roles=roles,
+            kind=IdentityKind(auth_data.get("kind", "system")),
+            auth_method=auth_data.get("auth_method", "task_queue"),
+        )
+
     async def run_loop(self, max_idle_seconds: float = 5.0) -> None:
-        """Run the worker loop: claim → process → repeat.
+        """Run the worker loop: claim -> process -> repeat.
 
-        Stops after max_idle_seconds with no tasks.
+        Exits when:
+        - Shutdown is requested via request_shutdown()
+        - No tasks are claimed for max_idle_seconds
         """
-        import asyncio
-
         idle_time = 0.0
-        poll_interval = 0.5
+        poll_interval = 0.1
 
-        while idle_time < max_idle_seconds:
+        while not self._shutdown_requested and idle_time < max_idle_seconds:
             processed = await self.process_one()
             if processed:
                 idle_time = 0.0

--- a/src/stronghold/worker_main.py
+++ b/src/stronghold/worker_main.py
@@ -1,39 +1,45 @@
 """Worker entry point: runs as a separate pod/process.
 
-Claims tasks from the queue, runs agent pipelines, reports results.
+Creates a full Container (same wiring as the API), then polls the
+task queue and routes each task through container.route_request().
+
+Usage:
+    python -m stronghold.worker_main
+
+In production, this runs as a separate K8s Deployment sharing the
+same DATABASE_URL / REDIS_URL as the API pods, so the task queue
+is backed by PostgreSQL or Redis (not in-memory).
 """
 
 from __future__ import annotations
 
 import asyncio
 import logging
+import signal
 
-from stronghold.agents.task_queue import InMemoryTaskQueue
 from stronghold.agents.worker import AgentWorker
-from stronghold.api.litellm_client import LiteLLMClient
 from stronghold.config.loader import load_config
+from stronghold.container import create_container
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger("stronghold.worker")
 
 
 async def main() -> None:
-    """Start the worker loop."""
+    """Start the worker loop with proper Container wiring and signal handling."""
     config = load_config()
+    container = await create_container(config)
 
-    llm = LiteLLMClient(
-        base_url=config.litellm_url,
-        api_key=config.litellm_key,
-    )
+    worker = AgentWorker(container=container)
 
-    # For demo: in-process queue (shared with API via import)
-    # For production: PostgreSQL-backed queue
-    queue = InMemoryTaskQueue()
+    # Register signal handlers for graceful shutdown
+    loop = asyncio.get_running_loop()
+    for sig in (signal.SIGINT, signal.SIGTERM):
+        loop.add_signal_handler(sig, worker.request_shutdown)
 
-    worker = AgentWorker(queue=queue, llm=llm)
-
-    logger.info("Worker started. Polling for tasks...")
+    logger.info("Worker started. Polling task queue...")
     await worker.run_loop(max_idle_seconds=3600)
+    logger.info("Worker stopped.")
 
 
 if __name__ == "__main__":

--- a/tests/agents/test_worker.py
+++ b/tests/agents/test_worker.py
@@ -1,20 +1,51 @@
-"""Tests for the agent worker: claims tasks, runs agent pipeline, reports results."""
+"""Tests for the agent worker: claims tasks, routes through container, reports results."""
+
+from __future__ import annotations
+
+from typing import Any
 
 import pytest
 
 from stronghold.agents.task_queue import InMemoryTaskQueue
 from stronghold.agents.worker import AgentWorker
-from tests.fakes import FakeLLMClient
+
+
+class _FakeContainer:
+    """Minimal container fake with task_queue and route_request."""
+
+    def __init__(self, task_queue: InMemoryTaskQueue) -> None:
+        self.task_queue = task_queue
+
+    async def route_request(
+        self,
+        messages: list[dict[str, Any]],
+        *,
+        auth: Any = None,
+        session_id: str | None = None,
+        intent_hint: str = "",
+        status_callback: Any = None,
+    ) -> dict[str, Any]:
+        content = "Hello from the worker!"
+        return {
+            "id": "stronghold-test",
+            "object": "chat.completion",
+            "model": "test/model",
+            "choices": [
+                {
+                    "index": 0,
+                    "message": {"role": "assistant", "content": content},
+                    "finish_reason": "stop",
+                }
+            ],
+        }
 
 
 class TestAgentWorker:
     @pytest.mark.asyncio
     async def test_processes_pending_task(self) -> None:
         queue = InMemoryTaskQueue()
-        llm = FakeLLMClient()
-        llm.set_simple_response("Hello from the worker!")
-
-        worker = AgentWorker(queue=queue, llm=llm)
+        container = _FakeContainer(task_queue=queue)
+        worker = AgentWorker(container=container)
 
         # Submit a task
         task_id = await queue.submit(
@@ -38,8 +69,8 @@ class TestAgentWorker:
     @pytest.mark.asyncio
     async def test_returns_false_when_empty(self) -> None:
         queue = InMemoryTaskQueue()
-        llm = FakeLLMClient()
-        worker = AgentWorker(queue=queue, llm=llm)
+        container = _FakeContainer(task_queue=queue)
+        worker = AgentWorker(container=container)
 
         processed = await worker.process_one()
         assert processed is False
@@ -47,10 +78,8 @@ class TestAgentWorker:
     @pytest.mark.asyncio
     async def test_handles_llm_error(self) -> None:
         queue = InMemoryTaskQueue()
-        llm = FakeLLMClient()
-        # Set no responses — will return default
-
-        worker = AgentWorker(queue=queue, llm=llm)
+        container = _FakeContainer(task_queue=queue)
+        worker = AgentWorker(container=container)
         task_id = await queue.submit(
             {
                 "messages": [{"role": "user", "content": "hello"}],
@@ -64,5 +93,5 @@ class TestAgentWorker:
 
         task = await queue.get(task_id)
         assert task is not None
-        # Should complete (FakeLLM returns default response)
+        # Should complete (FakeContainer returns canned response)
         assert task["status"] == "completed"

--- a/tests/agents/test_worker_extended.py
+++ b/tests/agents/test_worker_extended.py
@@ -4,36 +4,53 @@ from __future__ import annotations
 
 from typing import Any
 
-import pytest
-
 from stronghold.agents.task_queue import InMemoryTaskQueue
 from stronghold.agents.worker import AgentWorker
-from tests.fakes import FakeLLMClient
 
 
-class FailingLLMClient:
-    """LLM client that always raises an exception on complete()."""
+class _FakeContainer:
+    """Minimal container fake with task_queue and route_request."""
 
-    def __init__(self, error_message: str = "LLM service unavailable") -> None:
-        self._error_message = error_message
-        self.calls: list[dict[str, Any]] = []
+    def __init__(
+        self,
+        task_queue: InMemoryTaskQueue,
+        *,
+        error: Exception | None = None,
+    ) -> None:
+        self.task_queue = task_queue
+        self._error = error
 
-    async def complete(
+    async def route_request(
         self,
         messages: list[dict[str, Any]],
-        model: str,
-        **kwargs: Any,
+        *,
+        auth: Any = None,
+        session_id: str | None = None,
+        intent_hint: str = "",
+        status_callback: Any = None,
     ) -> dict[str, Any]:
-        self.calls.append({"messages": messages, "model": model})
-        raise RuntimeError(self._error_message)
+        if self._error is not None:
+            raise self._error
+        return {
+            "id": "stronghold-test",
+            "object": "chat.completion",
+            "model": "test/model",
+            "choices": [
+                {
+                    "index": 0,
+                    "message": {"role": "assistant", "content": "looped response"},
+                    "finish_reason": "stop",
+                }
+            ],
+        }
 
 
 class TestWorkerProcessOneNoTasks:
     async def test_no_tasks_returns_false(self) -> None:
         """process_one with empty queue returns False."""
         queue = InMemoryTaskQueue()
-        llm = FakeLLMClient()
-        worker = AgentWorker(queue=queue, llm=llm)
+        container = _FakeContainer(task_queue=queue)
+        worker = AgentWorker(container=container)
 
         result = await worker.process_one()
         assert result is False
@@ -41,12 +58,10 @@ class TestWorkerProcessOneNoTasks:
 
 class TestWorkerProcessOneSuccess:
     async def test_task_available_processes_and_completes(self) -> None:
-        """process_one claims a task, runs the LLM, and marks it completed."""
+        """process_one claims a task, routes through container, and marks it completed."""
         queue = InMemoryTaskQueue()
-        llm = FakeLLMClient()
-        llm.set_simple_response("worker output here")
-
-        worker = AgentWorker(queue=queue, llm=llm)
+        container = _FakeContainer(task_queue=queue)
+        worker = AgentWorker(container=container)
 
         task_id = await queue.submit(
             {
@@ -62,17 +77,18 @@ class TestWorkerProcessOneSuccess:
         task = await queue.get(task_id)
         assert task is not None
         assert task["status"] == "completed"
-        assert task["result"]["content"] == "worker output here"
-        assert task["result"]["agent"] == "arbiter"
-        assert task["result"]["model"] == "test/model"
+        assert task["result"]["content"] == "looped response"
 
 
-class TestWorkerProcessOneLLMFailure:
-    async def test_llm_failure_marks_task_as_failed(self) -> None:
-        """When the LLM raises, the task is marked as failed with the error."""
+class TestWorkerProcessOneFailure:
+    async def test_route_failure_marks_task_as_failed(self) -> None:
+        """When route_request raises, the task is marked as failed with the error."""
         queue = InMemoryTaskQueue()
-        failing_llm = FailingLLMClient("connection refused")
-        worker = AgentWorker(queue=queue, llm=failing_llm)
+        container = _FakeContainer(
+            task_queue=queue,
+            error=RuntimeError("connection refused"),
+        )
+        worker = AgentWorker(container=container)
 
         task_id = await queue.submit(
             {
@@ -95,10 +111,8 @@ class TestWorkerRunLoop:
     async def test_run_loop_processes_tasks_then_idles_out(self) -> None:
         """run_loop processes all available tasks then exits after idle timeout."""
         queue = InMemoryTaskQueue()
-        llm = FakeLLMClient()
-        llm.set_simple_response("looped response")
-
-        worker = AgentWorker(queue=queue, llm=llm)
+        container = _FakeContainer(task_queue=queue)
+        worker = AgentWorker(container=container)
 
         # Submit 3 tasks
         ids = []
@@ -113,7 +127,7 @@ class TestWorkerRunLoop:
             ids.append(task_id)
 
         # Run with short idle timeout so it exits quickly after tasks are done
-        await worker.run_loop(max_idle_seconds=1.0)
+        await worker.run_loop(max_idle_seconds=0.5)
 
         # All 3 tasks should be completed
         for task_id in ids:
@@ -124,8 +138,8 @@ class TestWorkerRunLoop:
     async def test_run_loop_exits_on_idle_with_no_tasks(self) -> None:
         """run_loop exits quickly when there are no tasks at all."""
         queue = InMemoryTaskQueue()
-        llm = FakeLLMClient()
-        worker = AgentWorker(queue=queue, llm=llm)
+        container = _FakeContainer(task_queue=queue)
+        worker = AgentWorker(container=container)
 
         # Should return without error after idle timeout
-        await worker.run_loop(max_idle_seconds=1.0)
+        await worker.run_loop(max_idle_seconds=0.3)

--- a/tests/test_new_modules_2.py
+++ b/tests/test_new_modules_2.py
@@ -966,20 +966,57 @@ class TestSkillsTestRoute:
 # ═══════════════════════════════════════════════════════════════════
 
 
+class _WorkerFakeContainer:
+    """Minimal container fake for worker tests."""
+
+    def __init__(
+        self,
+        task_queue: InMemoryTaskQueue,
+        *,
+        error: Exception | None = None,
+        content: str = "Worker response",
+    ) -> None:
+        self.task_queue = task_queue
+        self._error = error
+        self._content = content
+
+    async def route_request(
+        self,
+        messages: list[dict[str, Any]],
+        *,
+        auth: Any = None,
+        session_id: str | None = None,
+        intent_hint: str = "",
+        status_callback: Any = None,
+    ) -> dict[str, Any]:
+        if self._error is not None:
+            raise self._error
+        return {
+            "id": "stronghold-test",
+            "object": "chat.completion",
+            "model": "test/model",
+            "choices": [
+                {
+                    "index": 0,
+                    "message": {"role": "assistant", "content": self._content},
+                    "finish_reason": "stop",
+                }
+            ],
+        }
+
+
 class TestAgentWorkerProcessOne:
     async def test_process_one_no_tasks(self) -> None:
         queue = InMemoryTaskQueue()
-        llm = FakeLLMClient()
-        llm.set_simple_response("Hello from worker")
-        worker = AgentWorker(queue=queue, llm=llm)
+        container = _WorkerFakeContainer(task_queue=queue, content="Hello from worker")
+        worker = AgentWorker(container=container)
         result = await worker.process_one()
         assert result is False
 
     async def test_process_one_with_task(self) -> None:
         queue = InMemoryTaskQueue()
-        llm = FakeLLMClient()
-        llm.set_simple_response("Worker response")
-        worker = AgentWorker(queue=queue, llm=llm)
+        container = _WorkerFakeContainer(task_queue=queue, content="Worker response")
+        worker = AgentWorker(container=container)
 
         task_id = await queue.submit(
             {"messages": [{"role": "user", "content": "hello"}], "model": "test", "agent": "arbiter"}
@@ -994,15 +1031,11 @@ class TestAgentWorkerProcessOne:
 
     async def test_process_one_llm_failure(self) -> None:
         queue = InMemoryTaskQueue()
-
-        class FailingLLM:
-            async def complete(
-                self, messages: list[dict[str, Any]], model: str, **kwargs: Any
-            ) -> dict[str, Any]:
-                msg = "LLM error"
-                raise RuntimeError(msg)
-
-        worker = AgentWorker(queue=queue, llm=FailingLLM())  # type: ignore[arg-type]
+        container = _WorkerFakeContainer(
+            task_queue=queue,
+            error=RuntimeError("LLM error"),
+        )
+        worker = AgentWorker(container=container)
         task_id = await queue.submit({"messages": [{"role": "user", "content": "hi"}]})
         result = await worker.process_one()
         assert result is True
@@ -1015,24 +1048,22 @@ class TestAgentWorkerProcessOne:
 class TestAgentWorkerRunLoop:
     async def test_run_loop_exits_on_idle(self) -> None:
         queue = InMemoryTaskQueue()
-        llm = FakeLLMClient()
-        llm.set_simple_response("ok")
-        worker = AgentWorker(queue=queue, llm=llm)
+        container = _WorkerFakeContainer(task_queue=queue, content="ok")
+        worker = AgentWorker(container=container)
 
         # Should exit after max_idle_seconds with no tasks
-        await worker.run_loop(max_idle_seconds=1.0)
+        await worker.run_loop(max_idle_seconds=0.5)
 
     async def test_run_loop_processes_then_exits(self) -> None:
         queue = InMemoryTaskQueue()
-        llm = FakeLLMClient()
-        llm.set_simple_response("loop response")
-        worker = AgentWorker(queue=queue, llm=llm)
+        container = _WorkerFakeContainer(task_queue=queue, content="loop response")
+        worker = AgentWorker(container=container)
 
         task_id = await queue.submit(
             {"messages": [{"role": "user", "content": "work"}], "model": "auto"}
         )
 
-        await worker.run_loop(max_idle_seconds=1.0)
+        await worker.run_loop(max_idle_seconds=0.5)
 
         task = await queue.get(task_id)
         assert task is not None

--- a/tests/test_worker_main.py
+++ b/tests/test_worker_main.py
@@ -1,0 +1,267 @@
+"""Tests for the background worker: connects to Container, polls task queue, routes requests."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+from stronghold.agents.task_queue import InMemoryTaskQueue
+from stronghold.agents.worker import AgentWorker
+from stronghold.types.auth import AuthContext
+
+
+class _FakeContainer:
+    """Minimal fake Container for worker tests.
+
+    Provides a task_queue and a route_request that records calls.
+    No mocks — just a simple class with the required interface.
+    """
+
+    def __init__(self, task_queue: InMemoryTaskQueue) -> None:
+        self.task_queue = task_queue
+        self.routed_requests: list[dict[str, Any]] = []
+        self._route_error: Exception | None = None
+
+    def set_route_error(self, error: Exception) -> None:
+        """Configure route_request to raise an error."""
+        self._route_error = error
+
+    async def route_request(
+        self,
+        messages: list[dict[str, Any]],
+        *,
+        auth: Any = None,
+        session_id: str | None = None,
+        intent_hint: str = "",
+        status_callback: Any = None,
+    ) -> dict[str, Any]:
+        """Fake route_request that records calls and returns canned responses."""
+        self.routed_requests.append(
+            {
+                "messages": messages,
+                "auth": auth,
+                "session_id": session_id,
+                "intent_hint": intent_hint,
+            }
+        )
+        if self._route_error is not None:
+            raise self._route_error
+
+        content = "Worker processed: " + (messages[-1].get("content", "") if messages else "")
+        return {
+            "id": "stronghold-worker",
+            "object": "chat.completion",
+            "model": "test/model",
+            "choices": [
+                {
+                    "index": 0,
+                    "message": {"role": "assistant", "content": content},
+                    "finish_reason": "stop",
+                }
+            ],
+        }
+
+
+def _make_worker(
+    *,
+    route_error: Exception | None = None,
+) -> tuple[AgentWorker, _FakeContainer, InMemoryTaskQueue]:
+    """Create a worker with a fake container and shared task queue."""
+    queue = InMemoryTaskQueue()
+    container = _FakeContainer(task_queue=queue)
+    if route_error is not None:
+        container.set_route_error(route_error)
+    worker = AgentWorker(container=container)
+    return worker, container, queue
+
+
+class TestWorkerStartsAndStops:
+    """Worker lifecycle: starts polling, shuts down cleanly."""
+
+    async def test_worker_starts_and_stops_on_idle(self) -> None:
+        """Worker loop exits after idle timeout with no tasks."""
+        worker, _, _ = _make_worker()
+        # max_idle_seconds=0.2 → should exit quickly with no tasks
+        await worker.run_loop(max_idle_seconds=0.2)
+        # If we get here, the worker exited cleanly
+
+    async def test_worker_shutdown_signal_stops_loop(self) -> None:
+        """Worker respects shutdown signal and exits the loop."""
+        worker, _, queue = _make_worker()
+        worker.request_shutdown()
+        # Even with a long idle timeout, shutdown signal should stop immediately
+        await worker.run_loop(max_idle_seconds=60.0)
+
+
+class TestWorkerProcessesTask:
+    """Worker claims and processes tasks via container.route_request."""
+
+    async def test_processes_single_task(self) -> None:
+        """Worker claims a task, routes through container, marks completed."""
+        worker, container, queue = _make_worker()
+
+        task_id = await queue.submit(
+            {
+                "messages": [{"role": "user", "content": "hello world"}],
+                "session_id": "sess-1",
+            }
+        )
+
+        processed = await worker.process_one()
+        assert processed is True
+
+        # Verify route_request was called
+        assert len(container.routed_requests) == 1
+        req = container.routed_requests[0]
+        assert req["messages"] == [{"role": "user", "content": "hello world"}]
+        assert req["session_id"] == "sess-1"
+        assert req["auth"] is not None  # Worker provides system auth
+
+        # Verify task marked completed
+        task = await queue.get(task_id)
+        assert task is not None
+        assert task["status"] == "completed"
+        assert "Worker processed: hello world" in task["result"]["content"]
+
+    async def test_processes_task_with_auth_context(self) -> None:
+        """Worker passes auth from task payload if provided."""
+        worker, container, queue = _make_worker()
+
+        await queue.submit(
+            {
+                "messages": [{"role": "user", "content": "test"}],
+                "auth": {
+                    "user_id": "user-42",
+                    "username": "alice",
+                    "org_id": "org-1",
+                    "roles": ["admin"],
+                },
+            }
+        )
+
+        await worker.process_one()
+
+        req = container.routed_requests[0]
+        auth = req["auth"]
+        assert isinstance(auth, AuthContext)
+        assert auth.user_id == "user-42"
+        assert auth.org_id == "org-1"
+
+    async def test_processes_multiple_tasks_in_loop(self) -> None:
+        """Worker processes all pending tasks then exits on idle."""
+        worker, container, queue = _make_worker()
+
+        await queue.submit({"messages": [{"role": "user", "content": "task 1"}]})
+        await queue.submit({"messages": [{"role": "user", "content": "task 2"}]})
+        await queue.submit({"messages": [{"role": "user", "content": "task 3"}]})
+
+        await worker.run_loop(max_idle_seconds=0.3)
+
+        assert len(container.routed_requests) == 3
+        # All three tasks should be completed
+        tasks = await queue.list_tasks(status="completed")
+        assert len(tasks) == 3
+
+
+class TestWorkerHandlesEmptyQueue:
+    """Worker behavior when queue is empty."""
+
+    async def test_returns_false_on_empty_queue(self) -> None:
+        """process_one returns False when no tasks are pending."""
+        worker, _, _ = _make_worker()
+        processed = await worker.process_one()
+        assert processed is False
+
+    async def test_idle_loop_exits_after_timeout(self) -> None:
+        """Worker loop exits after max_idle_seconds with empty queue."""
+        worker, _, _ = _make_worker()
+        import time
+
+        start = time.monotonic()
+        await worker.run_loop(max_idle_seconds=0.3)
+        elapsed = time.monotonic() - start
+        # Should have waited roughly 0.3s (with some tolerance)
+        assert 0.2 < elapsed < 1.0
+
+
+class TestWorkerHandlesErrors:
+    """Worker error handling: task failures, exceptions."""
+
+    async def test_task_failure_marks_task_failed(self) -> None:
+        """When route_request raises, task is marked failed with error."""
+        worker, _, queue = _make_worker(route_error=RuntimeError("LLM exploded"))
+
+        task_id = await queue.submit({"messages": [{"role": "user", "content": "boom"}]})
+
+        processed = await worker.process_one()
+        assert processed is True
+
+        task = await queue.get(task_id)
+        assert task is not None
+        assert task["status"] == "failed"
+        assert "LLM exploded" in task["error"]
+
+    async def test_failed_task_does_not_stop_loop(self) -> None:
+        """A failed task does not crash the worker loop."""
+        queue = InMemoryTaskQueue()
+        container = _FakeContainer(task_queue=queue)
+
+        # First task will fail
+        container.set_route_error(RuntimeError("fail"))
+        await queue.submit({"messages": [{"role": "user", "content": "fail task"}]})
+
+        worker = AgentWorker(container=container)
+        processed = await worker.process_one()
+        assert processed is True
+
+        # Clear the error — next task should succeed
+        container._route_error = None
+        await queue.submit({"messages": [{"role": "user", "content": "ok task"}]})
+
+        processed = await worker.process_one()
+        assert processed is True
+
+        tasks = await queue.list_tasks()
+        statuses = {t["id"]: t["status"] for t in tasks}
+        assert "failed" in statuses.values()
+        assert "completed" in statuses.values()
+
+
+class TestWorkerSignalHandling:
+    """Signal handling for graceful shutdown."""
+
+    async def test_shutdown_flag_stops_processing(self) -> None:
+        """request_shutdown sets the flag that stops the run loop."""
+        worker, _, queue = _make_worker()
+
+        # Submit tasks but request shutdown before loop starts
+        for i in range(5):
+            await queue.submit({"messages": [{"role": "user", "content": f"task {i}"}]})
+
+        worker.request_shutdown()
+        await worker.run_loop(max_idle_seconds=10.0)
+
+        # Loop should exit immediately without processing tasks
+        pending = await queue.list_tasks(status="pending")
+        assert len(pending) == 5  # None processed
+
+    async def test_shutdown_during_loop(self) -> None:
+        """Shutdown during active processing stops after current task."""
+        worker, container, queue = _make_worker()
+
+        # Submit a task
+        await queue.submit({"messages": [{"role": "user", "content": "last task"}]})
+
+        # Schedule shutdown after a brief delay
+        async def _delayed_shutdown() -> None:
+            await asyncio.sleep(0.05)
+            worker.request_shutdown()
+
+        # Run loop and delayed shutdown concurrently
+        await asyncio.gather(
+            worker.run_loop(max_idle_seconds=10.0),
+            _delayed_shutdown(),
+        )
+
+        # The first task may or may not have been processed
+        # but the loop should have exited


### PR DESCRIPTION
Worker now uses create_container() for full DI wiring. Tasks route through Conduit pipeline (classification, routing, Warden). Graceful SIGINT/SIGTERM shutdown. 11 new tests.