### PR TITLE
feat: add prompt version diffing with API endpoint

### DIFF
--- a/src/stronghold/prompts/diff.py
+++ b/src/stronghold/prompts/diff.py
@@ -7,7 +7,8 @@ for the API and dashboard to consume.
 from __future__ import annotations
 
 import difflib
-from dataclasses import dataclass
+import re
+from dataclasses import dataclass, field
 
 
 @dataclass(frozen=True)
@@ -18,6 +19,19 @@ class DiffLine:
     content: str
     old_lineno: int | None = None
     new_lineno: int | None = None
+
+
+@dataclass(frozen=True)
+class PromptDiff:
+    """Structured diff between two prompt versions."""
+
+    old_version: int
+    new_version: int
+    old_content: str
+    new_content: str
+    additions: int
+    deletions: int
+    diff_lines: list[str] = field(default_factory=list)
 
 
 def compute_diff(
@@ -81,3 +95,67 @@ def compute_diff(
             new_lineno += 1
 
     return result
+
+
+def diff_versions(old_content: str, new_content: str) -> PromptDiff:
+    """Compute a structured diff between two prompt content strings.
+
+    Returns a PromptDiff with addition/deletion counts and unified diff lines.
+    Version numbers default to 0 (caller can override via the dataclass).
+    """
+    old_lines = old_content.splitlines(keepends=True)
+    new_lines = new_content.splitlines(keepends=True)
+
+    raw_diff = list(
+        difflib.unified_diff(
+            old_lines,
+            new_lines,
+            fromfile="old",
+            tofile="new",
+        )
+    )
+
+    additions = 0
+    deletions = 0
+    for line in raw_diff:
+        if line.startswith("+") and not line.startswith("+++"):
+            additions += 1
+        elif line.startswith("-") and not line.startswith("---"):
+            deletions += 1
+
+    diff_strings = [line.rstrip("\n") for line in raw_diff]
+
+    return PromptDiff(
+        old_version=0,
+        new_version=0,
+        old_content=old_content,
+        new_content=new_content,
+        additions=additions,
+        deletions=deletions,
+        diff_lines=diff_strings,
+    )
+
+
+def diff_summary(diff: PromptDiff) -> str:
+    """Human-readable summary of a PromptDiff.
+
+    Returns e.g. "Version 2->3: +5 lines, -2 lines"
+    """
+    return (
+        f"Version {diff.old_version}\u2192{diff.new_version}: "
+        f"+{diff.additions} lines, -{diff.deletions} lines"
+    )
+
+
+_WS_PATTERN = re.compile(r"\s+")
+
+
+def has_semantic_change(old: str, new: str) -> bool:
+    """True if content differs after normalizing whitespace.
+
+    Collapses all runs of whitespace (spaces, tabs, newlines) to a single
+    space, then strips leading/trailing whitespace before comparing.
+    """
+    normalized_old = _WS_PATTERN.sub(" ", old).strip()
+    normalized_new = _WS_PATTERN.sub(" ", new).strip()
+    return normalized_old != normalized_new

--- a/src/stronghold/prompts/routes.py
+++ b/src/stronghold/prompts/routes.py
@@ -206,10 +206,15 @@ _approvals: dict[str, list[Any]] = {}
 async def get_diff(
     name: str,
     request: Request,
-    from_version: int = 1,
-    to_version: int = 2,
+    v1: int = 1,
+    v2: int = 2,
 ) -> JSONResponse:
-    """Get unified diff between two versions of a prompt."""
+    """Get unified diff between two versions of a prompt.
+
+    Query params: ?v1=<old_version>&v2=<new_version>
+    Returns structured PromptDiff with additions/deletions counts, summary,
+    semantic change flag, and per-line diff detail.
+    """
     await _require_auth(request)
     container = request.app.state.container
     pm = container.prompt_manager
@@ -218,29 +223,50 @@ async def get_diff(
     if not versions:
         raise HTTPException(status_code=404, detail=f"Prompt '{name}' not found")
 
-    old_content = versions.get(from_version, ("", {}))[0]
-    new_content = versions.get(to_version, ("", {}))[0]
+    if v1 not in versions:
+        raise HTTPException(status_code=404, detail=f"Version {v1} not found")
+    if v2 not in versions:
+        raise HTTPException(status_code=404, detail=f"Version {v2} not found")
 
-    if not old_content and not new_content:
-        raise HTTPException(
-            status_code=404,
-            detail=f"Version {from_version} or {to_version} not found",
-        )
+    old_content = versions[v1][0]
+    new_content = versions[v2][0]
 
-    from stronghold.prompts.diff import compute_diff  # noqa: PLC0415
+    from stronghold.prompts.diff import (  # noqa: PLC0415
+        PromptDiff,
+        compute_diff,
+        diff_summary,
+        diff_versions,
+        has_semantic_change,
+    )
 
-    diff_lines = compute_diff(
+    raw_diff = diff_versions(old_content, new_content)
+    prompt_diff = PromptDiff(
+        old_version=v1,
+        new_version=v2,
+        old_content=old_content,
+        new_content=new_content,
+        additions=raw_diff.additions,
+        deletions=raw_diff.deletions,
+        diff_lines=raw_diff.diff_lines,
+    )
+
+    detail_lines = compute_diff(
         old_content,
         new_content,
-        old_label=f"v{from_version}",
-        new_label=f"v{to_version}",
+        old_label=f"v{v1}",
+        new_label=f"v{v2}",
     )
 
     return JSONResponse(
         content={
             "name": name,
-            "from_version": from_version,
-            "to_version": to_version,
+            "old_version": v1,
+            "new_version": v2,
+            "additions": prompt_diff.additions,
+            "deletions": prompt_diff.deletions,
+            "summary": diff_summary(prompt_diff),
+            "has_semantic_change": has_semantic_change(old_content, new_content),
+            "diff_lines": prompt_diff.diff_lines,
             "diff": [
                 {
                     "op": d.op,
@@ -248,7 +274,7 @@ async def get_diff(
                     "old_lineno": d.old_lineno,
                     "new_lineno": d.new_lineno,
                 }
-                for d in diff_lines
+                for d in detail_lines
             ],
         }
     )

--- a/tests/prompts/test_diff.py
+++ b/tests/prompts/test_diff.py
@@ -1,8 +1,18 @@
-"""Tests for prompt diff engine."""
+"""Tests for prompt diff engine: PromptDiff, diff_versions, diff_summary, has_semantic_change."""
 
 from __future__ import annotations
 
-from stronghold.prompts.diff import DiffLine, compute_diff
+from stronghold.prompts.diff import (
+    DiffLine,
+    PromptDiff,
+    compute_diff,
+    diff_summary,
+    diff_versions,
+    has_semantic_change,
+)
+
+
+# ── compute_diff (existing) ────────────────────────────────────────
 
 
 class TestComputeDiff:
@@ -82,3 +92,232 @@ class TestComputeDiff:
         header_content = " ".join(d.content for d in result if d.op == "header")
         assert "previous" in header_content
         assert "current" in header_content
+
+
+# ── PromptDiff dataclass ────────────────────────────────────────────
+
+
+class TestPromptDiff:
+    def test_prompt_diff_fields(self) -> None:
+        pd = PromptDiff(
+            old_version=1,
+            new_version=2,
+            old_content="old",
+            new_content="new",
+            additions=3,
+            deletions=1,
+            diff_lines=["+added line", "-removed line"],
+        )
+        assert pd.old_version == 1
+        assert pd.new_version == 2
+        assert pd.old_content == "old"
+        assert pd.new_content == "new"
+        assert pd.additions == 3
+        assert pd.deletions == 1
+        assert len(pd.diff_lines) == 2
+
+    def test_prompt_diff_frozen(self) -> None:
+        pd = PromptDiff(
+            old_version=1,
+            new_version=2,
+            old_content="a",
+            new_content="b",
+            additions=0,
+            deletions=0,
+            diff_lines=[],
+        )
+        try:
+            pd.old_version = 5  # type: ignore[misc]
+            raise AssertionError("Should not allow mutation")
+        except AttributeError:
+            pass  # frozen dataclass
+
+    def test_prompt_diff_zero_counts(self) -> None:
+        pd = PromptDiff(
+            old_version=1,
+            new_version=1,
+            old_content="same",
+            new_content="same",
+            additions=0,
+            deletions=0,
+            diff_lines=[],
+        )
+        assert pd.additions == 0
+        assert pd.deletions == 0
+        assert pd.diff_lines == []
+
+
+# ── diff_versions ───────────────────────────────────────────────────
+
+
+class TestDiffVersions:
+    def test_basic_diff(self) -> None:
+        result = diff_versions("line1\nline2\n", "line1\nline3\n")
+        assert isinstance(result, PromptDiff)
+        assert result.additions >= 1
+        assert result.deletions >= 1
+        assert len(result.diff_lines) > 0
+
+    def test_identical_content(self) -> None:
+        result = diff_versions("same\n", "same\n")
+        assert result.additions == 0
+        assert result.deletions == 0
+        assert result.diff_lines == []
+
+    def test_only_additions(self) -> None:
+        result = diff_versions("line1\n", "line1\nline2\nline3\n")
+        assert result.additions == 2
+        assert result.deletions == 0
+
+    def test_only_deletions(self) -> None:
+        result = diff_versions("line1\nline2\nline3\n", "line1\n")
+        assert result.additions == 0
+        assert result.deletions == 2
+
+    def test_mixed_changes(self) -> None:
+        old = "alpha\nbeta\ngamma\n"
+        new = "alpha\nBETA\ngamma\ndelta\n"
+        result = diff_versions(old, new)
+        assert result.additions >= 1
+        assert result.deletions >= 1
+
+    def test_empty_to_content(self) -> None:
+        result = diff_versions("", "new line\n")
+        assert result.additions == 1
+        assert result.deletions == 0
+
+    def test_content_to_empty(self) -> None:
+        result = diff_versions("old line\n", "")
+        assert result.additions == 0
+        assert result.deletions == 1
+
+    def test_diff_lines_are_strings(self) -> None:
+        result = diff_versions("a\n", "b\n")
+        for line in result.diff_lines:
+            assert isinstance(line, str)
+
+    def test_diff_lines_contain_unified_format(self) -> None:
+        result = diff_versions("old\n", "new\n")
+        # Unified diff should contain +/- prefix lines
+        has_plus = any(line.startswith("+") for line in result.diff_lines)
+        has_minus = any(line.startswith("-") for line in result.diff_lines)
+        assert has_plus
+        assert has_minus
+
+    def test_stores_old_and_new_content(self) -> None:
+        result = diff_versions("old content\n", "new content\n")
+        assert result.old_content == "old content\n"
+        assert result.new_content == "new content\n"
+
+    def test_version_numbers_default_zero(self) -> None:
+        result = diff_versions("a\n", "b\n")
+        assert result.old_version == 0
+        assert result.new_version == 0
+
+    def test_multiline_complex_diff(self) -> None:
+        old = "header\nfoo\nbar\nbaz\nfooter\n"
+        new = "header\nfoo\nQUX\nbaz\nextra\nfooter\n"
+        result = diff_versions(old, new)
+        # bar -> QUX (1 del + 1 add), plus 'extra' (1 add)
+        assert result.additions >= 2
+        assert result.deletions >= 1
+
+
+# ── diff_summary ────────────────────────────────────────────────────
+
+
+class TestDiffSummary:
+    def test_summary_format(self) -> None:
+        pd = PromptDiff(
+            old_version=2,
+            new_version=3,
+            old_content="",
+            new_content="",
+            additions=5,
+            deletions=2,
+            diff_lines=[],
+        )
+        summary = diff_summary(pd)
+        assert summary == "Version 2\u21923: +5 lines, -2 lines"
+
+    def test_summary_zero_changes(self) -> None:
+        pd = PromptDiff(
+            old_version=1,
+            new_version=2,
+            old_content="",
+            new_content="",
+            additions=0,
+            deletions=0,
+            diff_lines=[],
+        )
+        summary = diff_summary(pd)
+        assert summary == "Version 1\u21922: +0 lines, -0 lines"
+
+    def test_summary_large_numbers(self) -> None:
+        pd = PromptDiff(
+            old_version=10,
+            new_version=11,
+            old_content="",
+            new_content="",
+            additions=100,
+            deletions=50,
+            diff_lines=[],
+        )
+        summary = diff_summary(pd)
+        assert summary == "Version 10\u219211: +100 lines, -50 lines"
+
+    def test_summary_only_additions(self) -> None:
+        pd = PromptDiff(
+            old_version=1,
+            new_version=2,
+            old_content="",
+            new_content="",
+            additions=3,
+            deletions=0,
+            diff_lines=[],
+        )
+        summary = diff_summary(pd)
+        assert "+3 lines" in summary
+        assert "-0 lines" in summary
+
+
+# ── has_semantic_change ─────────────────────────────────────────────
+
+
+class TestHasSemanticChange:
+    def test_identical_strings(self) -> None:
+        assert has_semantic_change("hello world", "hello world") is False
+
+    def test_different_content(self) -> None:
+        assert has_semantic_change("hello world", "goodbye world") is True
+
+    def test_whitespace_normalization_spaces(self) -> None:
+        assert has_semantic_change("hello   world", "hello world") is False
+
+    def test_whitespace_normalization_tabs(self) -> None:
+        assert has_semantic_change("hello\tworld", "hello world") is False
+
+    def test_whitespace_normalization_leading_trailing(self) -> None:
+        assert has_semantic_change("  hello world  ", "hello world") is False
+
+    def test_whitespace_normalization_newlines(self) -> None:
+        assert has_semantic_change("hello\n\n\nworld", "hello\nworld") is False
+
+    def test_empty_strings(self) -> None:
+        assert has_semantic_change("", "") is False
+
+    def test_empty_vs_whitespace(self) -> None:
+        assert has_semantic_change("", "   ") is False
+
+    def test_real_content_change_with_whitespace(self) -> None:
+        assert has_semantic_change("  foo  bar  ", "  foo  baz  ") is True
+
+    def test_multiline_whitespace_only(self) -> None:
+        old = "line1\n  line2\n\nline3\n"
+        new = "line1\nline2\nline3\n"
+        assert has_semantic_change(old, new) is False
+
+    def test_multiline_real_change(self) -> None:
+        old = "line1\nline2\nline3\n"
+        new = "line1\nchanged\nline3\n"
+        assert has_semantic_change(old, new) is True

--- a/tests/prompts/test_routes.py
+++ b/tests/prompts/test_routes.py
@@ -347,23 +347,14 @@ class TestGetDiff:
         # get_prompt route for simple names. We test through the app.routes
         # directly by calling the diff endpoint using a dedicated app where
         # the diff route is registered before the catch-all.
-        # For the production router, this hits get_prompt with name="test.soul/diff"
-        # which returns 404 (no prompt with that name).
-        # We verify the diff logic works by calling the route function directly.
-        import asyncio
-        from unittest.mock import AsyncMock, MagicMock
+        from stronghold.prompts.routes import get_diff
 
         container = prompts_app.state.container
         pm = container.prompt_manager
         versions = pm._versions.get("test.soul", {})
         assert len(versions) == 2
 
-        # Build a dedicated app with diff route registered first to test the handler
-        from fastapi import FastAPI as FA
-
-        from stronghold.prompts.routes import get_diff
-
-        diff_app = FA()
+        diff_app = FastAPI()
         diff_app.add_api_route(
             "/v1/stronghold/prompts/{name:path}/diff",
             get_diff,
@@ -373,16 +364,65 @@ class TestGetDiff:
 
         with TestClient(diff_app) as client:
             resp = client.get(
-                "/v1/stronghold/prompts/test.soul/diff?from_version=1&to_version=2",
+                "/v1/stronghold/prompts/test.soul/diff?v1=1&v2=2",
                 headers=AUTH_HEADER,
             )
             assert resp.status_code == 200
             data = resp.json()
             assert data["name"] == "test.soul"
-            assert data["from_version"] == 1
-            assert data["to_version"] == 2
+            assert data["old_version"] == 1
+            assert data["new_version"] == 2
+            assert isinstance(data["additions"], int)
+            assert isinstance(data["deletions"], int)
+            assert "summary" in data
+            assert "has_semantic_change" in data
+            assert isinstance(data["diff_lines"], list)
             assert isinstance(data["diff"], list)
             assert len(data["diff"]) > 0
+
+    def test_diff_returns_semantic_change_flag(self, prompts_app: FastAPI) -> None:
+        from stronghold.prompts.routes import get_diff
+
+        container = prompts_app.state.container
+
+        diff_app = FastAPI()
+        diff_app.add_api_route(
+            "/v1/stronghold/prompts/{name:path}/diff",
+            get_diff,
+            methods=["GET"],
+        )
+        diff_app.state.container = container
+
+        with TestClient(diff_app) as client:
+            resp = client.get(
+                "/v1/stronghold/prompts/test.soul/diff?v1=1&v2=2",
+                headers=AUTH_HEADER,
+            )
+            assert resp.status_code == 200
+            data = resp.json()
+            # v1 and v2 have different content, so semantic change is True
+            assert data["has_semantic_change"] is True
+
+    def test_diff_returns_summary(self, prompts_app: FastAPI) -> None:
+        from stronghold.prompts.routes import get_diff
+
+        container = prompts_app.state.container
+
+        diff_app = FastAPI()
+        diff_app.add_api_route(
+            "/v1/stronghold/prompts/{name:path}/diff",
+            get_diff,
+            methods=["GET"],
+        )
+        diff_app.state.container = container
+
+        with TestClient(diff_app) as client:
+            resp = client.get(
+                "/v1/stronghold/prompts/test.soul/diff?v1=1&v2=2",
+                headers=AUTH_HEADER,
+            )
+            data = resp.json()
+            assert "Version 1\u21922" in data["summary"]
 
     def test_nonexistent_prompt_returns_404(self, prompts_app: FastAPI) -> None:
         from stronghold.prompts.routes import get_diff
@@ -397,7 +437,25 @@ class TestGetDiff:
 
         with TestClient(diff_app) as client:
             resp = client.get(
-                "/v1/stronghold/prompts/nonexistent.soul/diff?from_version=1&to_version=2",
+                "/v1/stronghold/prompts/nonexistent.soul/diff?v1=1&v2=2",
+                headers=AUTH_HEADER,
+            )
+            assert resp.status_code == 404
+
+    def test_nonexistent_version_returns_404(self, prompts_app: FastAPI) -> None:
+        from stronghold.prompts.routes import get_diff
+
+        diff_app = FastAPI()
+        diff_app.add_api_route(
+            "/v1/stronghold/prompts/{name:path}/diff",
+            get_diff,
+            methods=["GET"],
+        )
+        diff_app.state.container = prompts_app.state.container
+
+        with TestClient(diff_app) as client:
+            resp = client.get(
+                "/v1/stronghold/prompts/test.soul/diff?v1=1&v2=99",
                 headers=AUTH_HEADER,
             )
             assert resp.status_code == 404


### PR DESCRIPTION
PromptDiff dataclass, diff_versions, diff_summary, has_semantic_change. GET /prompts/{name}/diff?v1=&v2=. 49 tests.