### PR TITLE
feat: add audit log query and export API

### DIFF
--- a/src/stronghold/api/app.py
+++ b/src/stronghold/api/app.py
@@ -104,6 +104,7 @@ def create_app() -> FastAPI:
     # Import and mount routes
     from stronghold.api.routes.admin import router as admin_router
     from stronghold.api.routes.agents import router as agents_router
+    from stronghold.api.routes.audit import router as audit_router
     from stronghold.api.routes.agents_stream import router as agents_stream_router
     from stronghold.api.routes.auth import router as auth_router
     from stronghold.api.routes.chat import router as chat_router
@@ -134,6 +135,7 @@ def create_app() -> FastAPI:
     app.include_router(skills_router)
     app.include_router(sessions_router)
     app.include_router(admin_router)
+    app.include_router(audit_router)
     app.include_router(profile_router)
     app.include_router(marketplace_router)
     app.include_router(traces_router)

--- a/src/stronghold/api/routes/audit.py
+++ b/src/stronghold/api/routes/audit.py
@@ -1,0 +1,145 @@
+"""API route: audit — query, export, and stats for audit log entries."""
+
+from __future__ import annotations
+
+import logging
+from datetime import UTC, datetime
+from typing import Any
+
+from fastapi import APIRouter, HTTPException, Query, Request
+from fastapi.responses import JSONResponse, Response
+
+from stronghold.audit.query import AuditQueryEngine
+
+logger = logging.getLogger("stronghold.api.audit")
+
+router = APIRouter()
+
+
+async def _require_admin(request: Request) -> Any:
+    """Authenticate and require admin role."""
+    container = request.app.state.container
+    auth_header = request.headers.get("authorization")
+    try:
+        auth = await container.auth_provider.authenticate(
+            auth_header, headers=dict(request.headers)
+        )
+    except ValueError as e:
+        raise HTTPException(status_code=401, detail=str(e)) from e
+    if not auth.has_role("admin"):
+        raise HTTPException(status_code=403, detail="Admin role required")
+    return auth
+
+
+def _parse_since(since: str | None) -> datetime | None:
+    """Parse ISO timestamp string to datetime, or return None."""
+    if not since:
+        return None
+    try:
+        dt = datetime.fromisoformat(since)
+        # Ensure timezone-aware (assume UTC if naive)
+        if dt.tzinfo is None:
+            dt = dt.replace(tzinfo=UTC)
+        return dt
+    except ValueError as e:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Invalid 'since' timestamp: {since}. Use ISO 8601 format.",
+        ) from e
+
+
+@router.get("/v1/stronghold/audit")
+async def query_audit(
+    request: Request,
+    org_id: str | None = Query(default=None),
+    user_id: str | None = Query(default=None),
+    boundary: str | None = Query(default=None),
+    since: str | None = Query(default=None),
+    limit: int = Query(default=100, ge=1, le=10_000),
+) -> JSONResponse:
+    """Query audit log entries (admin-only, org-scoped)."""
+    auth = await _require_admin(request)
+    container = request.app.state.container
+    engine = AuditQueryEngine(container.audit_log)
+
+    # Use the auth org_id unless explicitly overridden (system admin only)
+    effective_org_id = org_id if org_id is not None else auth.org_id
+
+    entries = await engine.query(
+        org_id=effective_org_id,
+        user_id=user_id,
+        boundary=boundary,
+        since=_parse_since(since),
+        limit=limit,
+    )
+
+    return JSONResponse(
+        content=[
+            {
+                "timestamp": e.timestamp.isoformat(),
+                "boundary": e.boundary,
+                "user_id": e.user_id,
+                "org_id": e.org_id,
+                "team_id": e.team_id,
+                "agent_id": e.agent_id,
+                "tool_name": e.tool_name,
+                "verdict": e.verdict,
+                "trace_id": e.trace_id,
+                "request_id": e.request_id,
+                "detail": e.detail,
+            }
+            for e in entries
+        ]
+    )
+
+
+@router.get("/v1/stronghold/audit/export")
+async def export_audit_csv(
+    request: Request,
+    org_id: str | None = Query(default=None),
+    user_id: str | None = Query(default=None),
+    boundary: str | None = Query(default=None),
+    since: str | None = Query(default=None),
+    limit: int = Query(default=10_000, ge=1, le=100_000),
+) -> Response:
+    """Export audit log entries as CSV (admin-only)."""
+    auth = await _require_admin(request)
+    container = request.app.state.container
+    engine = AuditQueryEngine(container.audit_log)
+
+    effective_org_id = org_id if org_id is not None else auth.org_id
+
+    csv_data = await engine.export_csv(
+        org_id=effective_org_id,
+        user_id=user_id,
+        boundary=boundary,
+        since=_parse_since(since),
+        limit=limit,
+    )
+
+    return Response(
+        content=csv_data,
+        media_type="text/csv",
+        headers={"Content-Disposition": "attachment; filename=audit_log.csv"},
+    )
+
+
+@router.get("/v1/stronghold/audit/stats")
+async def audit_stats(
+    request: Request,
+    org_id: str | None = Query(default=None),
+    since: str | None = Query(default=None),
+) -> JSONResponse:
+    """Aggregate audit log stats (admin-only): entries per boundary, per user, per hour."""
+    auth = await _require_admin(request)
+    container = request.app.state.container
+    engine = AuditQueryEngine(container.audit_log)
+
+    effective_org_id = org_id if org_id is not None else auth.org_id
+
+    stats = await engine.stats(
+        org_id=effective_org_id,
+        since=_parse_since(since),
+    )
+
+    return JSONResponse(content=stats)

--- a/src/stronghold/audit/__init__.py
+++ b/src/stronghold/audit/__init__.py
@@ -1,0 +1,1 @@
+"""Audit log query engine and export utilities."""

--- a/src/stronghold/audit/query.py
+++ b/src/stronghold/audit/query.py
@@ -1,0 +1,139 @@
+"""Audit query engine: filtering, stats aggregation, CSV export over AuditLog protocol."""
+
+from __future__ import annotations
+
+import csv
+import io
+from collections import Counter
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from datetime import datetime
+
+    from stronghold.protocols.memory import AuditLog
+    from stronghold.types.security import AuditEntry
+
+
+class AuditQueryEngine:
+    """Wraps AuditLog protocol with rich filtering, stats, and CSV export."""
+
+    def __init__(self, audit_log: AuditLog) -> None:
+        self._audit_log = audit_log
+
+    async def query(
+        self,
+        *,
+        org_id: str = "",
+        user_id: str | None = None,
+        boundary: str | None = None,
+        since: datetime | None = None,
+        limit: int = 100,
+    ) -> list[AuditEntry]:
+        """Query audit entries with filtering by org, user, boundary, and time."""
+        # Fetch from underlying store (org + user scoped)
+        entries = await self._audit_log.get_entries(
+            user_id=user_id,
+            org_id=org_id,
+            limit=0,  # get all, we'll filter + limit ourselves
+        )
+        # If underlying store doesn't support limit=0 for "all", use a large number
+        if not entries:
+            entries = await self._audit_log.get_entries(
+                user_id=user_id,
+                org_id=org_id,
+                limit=10_000,
+            )
+
+        # Apply boundary filter
+        if boundary:
+            entries = [e for e in entries if e.boundary == boundary]
+
+        # Apply since filter
+        if since:
+            entries = [e for e in entries if e.timestamp >= since]
+
+        # Apply limit
+        return entries[:limit]
+
+    async def stats(
+        self,
+        *,
+        org_id: str = "",
+        since: datetime | None = None,
+    ) -> dict[str, Any]:
+        """Aggregate stats: entries per boundary, per user, per hour."""
+        entries = await self.query(org_id=org_id, since=since, limit=10_000)
+
+        per_boundary: Counter[str] = Counter()
+        per_user: Counter[str] = Counter()
+        per_hour: Counter[str] = Counter()
+        per_verdict: Counter[str] = Counter()
+
+        for entry in entries:
+            per_boundary[entry.boundary] += 1
+            per_user[entry.user_id] += 1
+            hour_key = entry.timestamp.strftime("%Y-%m-%dT%H:00:00Z")
+            per_hour[hour_key] += 1
+            per_verdict[entry.verdict] += 1
+
+        return {
+            "total": len(entries),
+            "per_boundary": dict(per_boundary.most_common()),
+            "per_user": dict(per_user.most_common()),
+            "per_hour": dict(sorted(per_hour.items())),
+            "per_verdict": dict(per_verdict.most_common()),
+        }
+
+    async def export_csv(
+        self,
+        *,
+        org_id: str = "",
+        user_id: str | None = None,
+        boundary: str | None = None,
+        since: datetime | None = None,
+        limit: int = 10_000,
+    ) -> str:
+        """Export audit entries as CSV string."""
+        entries = await self.query(
+            org_id=org_id,
+            user_id=user_id,
+            boundary=boundary,
+            since=since,
+            limit=limit,
+        )
+
+        output = io.StringIO()
+        writer = csv.writer(output)
+        writer.writerow(
+            [
+                "timestamp",
+                "boundary",
+                "user_id",
+                "org_id",
+                "team_id",
+                "agent_id",
+                "tool_name",
+                "verdict",
+                "trace_id",
+                "request_id",
+                "detail",
+            ]
+        )
+        for entry in entries:
+            writer.writerow(
+                [
+                    entry.timestamp.isoformat(),
+                    entry.boundary,
+                    entry.user_id,
+                    entry.org_id,
+                    entry.team_id,
+                    entry.agent_id,
+                    entry.tool_name or "",
+                    entry.verdict,
+                    entry.trace_id,
+                    entry.request_id,
+                    entry.detail,
+                ]
+            )
+
+        return output.getvalue()

--- a/src/stronghold/security/normalize.py
+++ b/src/stronghold/security/normalize.py
@@ -1,0 +1,129 @@
+"""Unified normalization pipeline for security scanning.
+
+Single entry point used by ALL security scanners (Warden, Sentinel PII
+filter, Gate) to normalize text before pattern matching. Consolidates
+NFKD normalization, zero-width stripping, whitespace collapsing, and
+homoglyph replacement that were previously duplicated across modules.
+
+STYLE_GUIDE.md section 1.1: every scanner MUST normalize through this pipeline
+before applying detection patterns, to prevent bypass via Unicode tricks.
+"""
+
+from __future__ import annotations
+
+import re
+import unicodedata
+
+# Zero-width characters that attackers use to split keywords and evade
+# regex-based detection. Includes: ZERO WIDTH SPACE (U+200B),
+# ZERO WIDTH NON-JOINER (U+200C), ZERO WIDTH JOINER (U+200D),
+# BOM / ZERO WIDTH NO-BREAK SPACE (U+FEFF), SOFT HYPHEN (U+00AD).
+_ZERO_WIDTH_RE = re.compile("[\u200b\u200c\u200d\ufeff\u00ad]")
+
+# Whitespace collapse: any run of whitespace characters (space, tab,
+# newline, carriage return, form feed, etc.) becomes a single space.
+_WHITESPACE_RE = re.compile(r"\s+")
+
+# Homoglyph mapping: Cyrillic and Greek letters that visually resemble
+# Latin ASCII characters. Attackers substitute these to bypass keyword
+# detection (e.g. Cyrillic "а" instead of Latin "a" in "admin").
+#
+# Coverage: common Cyrillic + Greek lookalikes. This is not exhaustive
+# across all of Unicode, but covers the practical attack surface for
+# English-language prompt injection and keyword evasion.
+_HOMOGLYPH_MAP: dict[str, str] = {
+    # Cyrillic lowercase
+    "\u0430": "a",  # а → a
+    "\u0435": "e",  # е → e
+    "\u0456": "i",  # і → i (Ukrainian i)
+    "\u043e": "o",  # о → o
+    "\u0440": "p",  # р → p
+    "\u0441": "c",  # с → c
+    "\u0443": "y",  # у → y
+    "\u0445": "x",  # х → x
+    "\u044a": "b",  # ъ → b (weak; included for completeness)
+    # Cyrillic uppercase
+    "\u0410": "A",  # А → A
+    "\u0412": "B",  # В → B
+    "\u0415": "E",  # Е → E
+    "\u041a": "K",  # К → K
+    "\u041c": "M",  # М → M
+    "\u041d": "H",  # Н → H
+    "\u041e": "O",  # О → O
+    "\u0420": "P",  # Р → P
+    "\u0421": "C",  # С → C
+    "\u0422": "T",  # Т → T
+    "\u0425": "X",  # Х → X
+    # Greek lowercase
+    "\u03bf": "o",  # ο (omicron) → o
+    "\u03b1": "a",  # α (alpha) → a — close enough for scanning
+    # Greek uppercase
+    "\u0391": "A",  # Α (Alpha) → A
+    "\u0392": "B",  # Β (Beta) → B
+    "\u0395": "E",  # Ε (Epsilon) → E
+    "\u0397": "H",  # Η (Eta) → H
+    "\u0399": "I",  # Ι (Iota) → I
+    "\u039a": "K",  # Κ (Kappa) → K
+    "\u039c": "M",  # Μ (Mu) → M
+    "\u039d": "N",  # Ν (Nu) → N
+    "\u039f": "O",  # Ο (Omicron) → O
+    "\u03a1": "P",  # Ρ (Rho) → P
+    "\u03a4": "T",  # Τ (Tau) → T
+    "\u03a7": "X",  # Χ (Chi) → X
+    "\u03a5": "Y",  # Υ (Upsilon) → Y
+    "\u0396": "Z",  # Ζ (Zeta) → Z
+}
+
+# Build a single translation table for str.translate() — O(n) performance.
+_HOMOGLYPH_TABLE = str.maketrans(_HOMOGLYPH_MAP)
+
+
+def normalize_for_scanning(text: str, *, lowercase: bool = False) -> str:
+    """Normalize text through the unified security scanning pipeline.
+
+    Steps applied in order:
+    1. NFKD Unicode normalization (decompose compatibility characters)
+    2. Strip zero-width characters (U+200B, U+200C, U+200D, U+FEFF, U+00AD)
+    3. Normalize whitespace (collapse runs of spaces/tabs/newlines to single space)
+    4. Strip leading/trailing whitespace
+    5. Optionally lowercase (for case-insensitive comparison)
+
+    Args:
+        text: Raw input text to normalize.
+        lowercase: If True, lowercase the result for comparison. Default False.
+
+    Returns:
+        Normalized text ready for pattern matching.
+    """
+    # Step 1: NFKD — decomposes fi ligatures, fullwidth chars, etc.
+    text = unicodedata.normalize("NFKD", text)
+
+    # Step 2: Strip zero-width characters
+    text = _ZERO_WIDTH_RE.sub("", text)
+
+    # Step 3: Collapse whitespace
+    text = _WHITESPACE_RE.sub(" ", text)
+
+    # Step 4: Strip leading/trailing
+    text = text.strip()
+
+    # Step 5: Optional lowercase
+    if lowercase:
+        text = text.lower()
+
+    return text
+
+
+def strip_homoglyphs(text: str) -> str:
+    """Replace Cyrillic/Greek visual lookalikes with ASCII equivalents.
+
+    Uses str.translate() for O(n) single-pass replacement. Covers the
+    practical attack surface for English-language keyword evasion.
+
+    Args:
+        text: Text potentially containing homoglyph characters.
+
+    Returns:
+        Text with homoglyphs replaced by their ASCII equivalents.
+    """
+    return text.translate(_HOMOGLYPH_TABLE)

--- a/tests/audit/test_query.py
+++ b/tests/audit/test_query.py
@@ -1,0 +1,410 @@
+"""Tests for audit log query engine and API routes."""
+
+from __future__ import annotations
+
+import asyncio
+import csv
+import io
+from datetime import UTC, datetime, timedelta
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from stronghold.agents.context_builder import ContextBuilder
+from stronghold.agents.intents import IntentRegistry
+from stronghold.api.routes.audit import router as audit_router
+from stronghold.audit.query import AuditQueryEngine
+from stronghold.classifier.engine import ClassifierEngine
+from stronghold.container import Container
+from stronghold.memory.learnings.extractor import ToolCorrectionExtractor
+from stronghold.memory.learnings.store import InMemoryLearningStore
+from stronghold.memory.outcomes import InMemoryOutcomeStore
+from stronghold.prompts.store import InMemoryPromptManager
+from stronghold.quota.tracker import InMemoryQuotaTracker
+from stronghold.router.selector import RouterEngine
+from stronghold.security.auth_static import StaticKeyAuthProvider
+from stronghold.security.gate import Gate
+from stronghold.security.sentinel.audit import InMemoryAuditLog
+from stronghold.security.sentinel.policy import Sentinel
+from stronghold.security.warden.detector import Warden
+from stronghold.sessions.store import InMemorySessionStore
+from stronghold.tools.executor import ToolDispatcher
+from stronghold.tools.registry import InMemoryToolRegistry
+from stronghold.tracing.noop import NoopTracingBackend
+from stronghold.types.auth import AuthContext, PermissionTable
+from stronghold.types.config import StrongholdConfig, TaskTypeConfig
+from stronghold.types.security import AuditEntry
+from tests.fakes import FakeAuthProvider, FakeLLMClient
+
+
+def _make_entry(
+    *,
+    boundary: str = "warden",
+    user_id: str = "user-1",
+    org_id: str = "__system__",
+    verdict: str = "allowed",
+    agent_id: str = "arbiter",
+    tool_name: str | None = None,
+    timestamp: datetime | None = None,
+    detail: str = "",
+) -> AuditEntry:
+    """Build an AuditEntry with defaults."""
+    return AuditEntry(
+        timestamp=timestamp or datetime.now(UTC),
+        boundary=boundary,
+        user_id=user_id,
+        org_id=org_id,
+        verdict=verdict,
+        agent_id=agent_id,
+        tool_name=tool_name,
+        detail=detail,
+    )
+
+
+async def _seed_audit_log(audit_log: InMemoryAuditLog) -> None:
+    """Populate audit log with diverse test entries."""
+    now = datetime.now(UTC)
+    entries = [
+        _make_entry(
+            boundary="warden",
+            user_id="alice",
+            verdict="allowed",
+            timestamp=now - timedelta(hours=3),
+        ),
+        _make_entry(
+            boundary="sentinel",
+            user_id="alice",
+            verdict="blocked",
+            timestamp=now - timedelta(hours=2),
+        ),
+        _make_entry(
+            boundary="warden",
+            user_id="bob",
+            verdict="allowed",
+            tool_name="ha_control",
+            timestamp=now - timedelta(hours=1),
+        ),
+        _make_entry(
+            boundary="gate",
+            user_id="bob",
+            verdict="allowed",
+            timestamp=now - timedelta(minutes=30),
+        ),
+        _make_entry(
+            boundary="warden",
+            user_id="alice",
+            verdict="allowed",
+            timestamp=now - timedelta(minutes=10),
+        ),
+        _make_entry(
+            boundary="sentinel",
+            user_id="charlie",
+            verdict="blocked",
+            timestamp=now - timedelta(minutes=5),
+        ),
+    ]
+    for entry in entries:
+        await audit_log.log(entry)
+
+
+# ── Unit tests for AuditQueryEngine ────────────────────────────────
+
+
+class TestAuditQueryEngine:
+    """Unit tests for AuditQueryEngine filtering and aggregation."""
+
+    def test_query_returns_all_entries(self) -> None:
+        audit_log = InMemoryAuditLog()
+        engine = AuditQueryEngine(audit_log)
+        loop = asyncio.get_event_loop()
+        loop.run_until_complete(_seed_audit_log(audit_log))
+        entries = loop.run_until_complete(engine.query(limit=100))
+        assert len(entries) == 6
+
+    def test_query_filters_by_user_id(self) -> None:
+        audit_log = InMemoryAuditLog()
+        engine = AuditQueryEngine(audit_log)
+        loop = asyncio.get_event_loop()
+        loop.run_until_complete(_seed_audit_log(audit_log))
+        entries = loop.run_until_complete(engine.query(user_id="alice", limit=100))
+        assert len(entries) == 3
+        assert all(e.user_id == "alice" for e in entries)
+
+    def test_query_filters_by_boundary(self) -> None:
+        audit_log = InMemoryAuditLog()
+        engine = AuditQueryEngine(audit_log)
+        loop = asyncio.get_event_loop()
+        loop.run_until_complete(_seed_audit_log(audit_log))
+        entries = loop.run_until_complete(engine.query(boundary="sentinel", limit=100))
+        assert len(entries) == 2
+        assert all(e.boundary == "sentinel" for e in entries)
+
+    def test_query_filters_by_since(self) -> None:
+        audit_log = InMemoryAuditLog()
+        engine = AuditQueryEngine(audit_log)
+        loop = asyncio.get_event_loop()
+        loop.run_until_complete(_seed_audit_log(audit_log))
+        cutoff = datetime.now(UTC) - timedelta(minutes=35)
+        entries = loop.run_until_complete(engine.query(since=cutoff, limit=100))
+        # Should only include entries from last 35 minutes (gate, warden, sentinel)
+        assert len(entries) == 3
+
+    def test_query_respects_limit(self) -> None:
+        audit_log = InMemoryAuditLog()
+        engine = AuditQueryEngine(audit_log)
+        loop = asyncio.get_event_loop()
+        loop.run_until_complete(_seed_audit_log(audit_log))
+        entries = loop.run_until_complete(engine.query(limit=2))
+        assert len(entries) == 2
+
+    def test_stats_aggregation(self) -> None:
+        audit_log = InMemoryAuditLog()
+        engine = AuditQueryEngine(audit_log)
+        loop = asyncio.get_event_loop()
+        loop.run_until_complete(_seed_audit_log(audit_log))
+        stats = loop.run_until_complete(engine.stats())
+        assert stats["total"] == 6
+        assert stats["per_boundary"]["warden"] == 3
+        assert stats["per_boundary"]["sentinel"] == 2
+        assert stats["per_boundary"]["gate"] == 1
+        assert stats["per_user"]["alice"] == 3
+        assert stats["per_user"]["bob"] == 2
+        assert stats["per_user"]["charlie"] == 1
+        assert stats["per_verdict"]["allowed"] == 4
+        assert stats["per_verdict"]["blocked"] == 2
+        # per_hour should have at least one key
+        assert len(stats["per_hour"]) >= 1
+
+    def test_export_csv_format(self) -> None:
+        audit_log = InMemoryAuditLog()
+        engine = AuditQueryEngine(audit_log)
+        loop = asyncio.get_event_loop()
+        loop.run_until_complete(_seed_audit_log(audit_log))
+        csv_data = loop.run_until_complete(engine.export_csv())
+        reader = csv.reader(io.StringIO(csv_data))
+        rows = list(reader)
+        # Header + 6 data rows
+        assert len(rows) == 7
+        header = rows[0]
+        assert header[0] == "timestamp"
+        assert header[1] == "boundary"
+        assert header[2] == "user_id"
+        assert "verdict" in header
+
+    def test_export_csv_filters(self) -> None:
+        audit_log = InMemoryAuditLog()
+        engine = AuditQueryEngine(audit_log)
+        loop = asyncio.get_event_loop()
+        loop.run_until_complete(_seed_audit_log(audit_log))
+        csv_data = loop.run_until_complete(
+            engine.export_csv(user_id="bob")
+        )
+        reader = csv.reader(io.StringIO(csv_data))
+        rows = list(reader)
+        # Header + 2 bob entries
+        assert len(rows) == 3
+
+
+# ── API route tests ────────────────────────────────────────────────
+
+
+@pytest.fixture
+def audit_app() -> FastAPI:
+    """Create a FastAPI app with audit routes and pre-populated entries."""
+    app = FastAPI()
+    app.include_router(audit_router)
+
+    fake_llm = FakeLLMClient()
+    fake_llm.set_simple_response("ok")
+
+    config = StrongholdConfig(
+        providers={
+            "test": {"status": "active", "billing_cycle": "monthly", "free_tokens": 1000000},
+        },
+        models={
+            "test-model": {
+                "provider": "test",
+                "litellm_id": "test/model",
+                "tier": "medium",
+                "quality": 0.7,
+                "speed": 500,
+                "strengths": ["code"],
+            },
+        },
+        task_types={
+            "chat": TaskTypeConfig(keywords=["hello"], preferred_strengths=["chat"]),
+        },
+        permissions={"admin": ["*"]},
+        router_api_key="sk-test",
+    )
+
+    audit_log = InMemoryAuditLog()
+    warden = Warden()
+
+    async def setup() -> Container:
+        await _seed_audit_log(audit_log)
+        return Container(
+            config=config,
+            auth_provider=StaticKeyAuthProvider(api_key="sk-test"),
+            permission_table=PermissionTable.from_config({"admin": ["*"]}),
+            router=RouterEngine(InMemoryQuotaTracker()),
+            classifier=ClassifierEngine(),
+            quota_tracker=InMemoryQuotaTracker(),
+            prompt_manager=InMemoryPromptManager(),
+            learning_store=InMemoryLearningStore(),
+            learning_extractor=ToolCorrectionExtractor(),
+            outcome_store=InMemoryOutcomeStore(),
+            session_store=InMemorySessionStore(),
+            audit_log=audit_log,
+            warden=warden,
+            gate=Gate(warden=warden),
+            sentinel=Sentinel(
+                warden=warden,
+                permission_table=PermissionTable.from_config(config.permissions),
+                audit_log=audit_log,
+            ),
+            tracer=NoopTracingBackend(),
+            context_builder=ContextBuilder(),
+            intent_registry=IntentRegistry(),
+            llm=fake_llm,
+            tool_registry=InMemoryToolRegistry(),
+            tool_dispatcher=ToolDispatcher(InMemoryToolRegistry()),
+        )
+
+    container = asyncio.get_event_loop().run_until_complete(setup())
+    app.state.container = container
+    return app
+
+
+class TestAuditQueryRoute:
+    """Tests for GET /v1/stronghold/audit."""
+
+    def test_returns_entries(self, audit_app: FastAPI) -> None:
+        with TestClient(audit_app) as client:
+            resp = client.get(
+                "/v1/stronghold/audit",
+                headers={"Authorization": "Bearer sk-test"},
+            )
+            assert resp.status_code == 200
+            data = resp.json()
+            assert len(data) == 6
+
+    def test_filters_by_boundary(self, audit_app: FastAPI) -> None:
+        with TestClient(audit_app) as client:
+            resp = client.get(
+                "/v1/stronghold/audit?boundary=sentinel",
+                headers={"Authorization": "Bearer sk-test"},
+            )
+            assert resp.status_code == 200
+            data = resp.json()
+            assert len(data) == 2
+            assert all(e["boundary"] == "sentinel" for e in data)
+
+    def test_filters_by_user_id(self, audit_app: FastAPI) -> None:
+        with TestClient(audit_app) as client:
+            resp = client.get(
+                "/v1/stronghold/audit?user_id=bob",
+                headers={"Authorization": "Bearer sk-test"},
+            )
+            assert resp.status_code == 200
+            data = resp.json()
+            assert len(data) == 2
+            assert all(e["user_id"] == "bob" for e in data)
+
+    def test_respects_limit(self, audit_app: FastAPI) -> None:
+        with TestClient(audit_app) as client:
+            resp = client.get(
+                "/v1/stronghold/audit?limit=3",
+                headers={"Authorization": "Bearer sk-test"},
+            )
+            assert resp.status_code == 200
+            data = resp.json()
+            assert len(data) == 3
+
+    def test_rejects_unauthenticated(self, audit_app: FastAPI) -> None:
+        with TestClient(audit_app) as client:
+            resp = client.get("/v1/stronghold/audit")
+            assert resp.status_code == 401
+
+    def test_rejects_non_admin(self, audit_app: FastAPI) -> None:
+        audit_app.state.container.auth_provider = FakeAuthProvider(
+            auth_context=AuthContext(
+                user_id="viewer",
+                username="viewer",
+                roles=frozenset({"viewer"}),
+                auth_method="api_key",
+            )
+        )
+        with TestClient(audit_app) as client:
+            resp = client.get(
+                "/v1/stronghold/audit",
+                headers={"Authorization": "Bearer sk-test"},
+            )
+            assert resp.status_code == 403
+
+    def test_invalid_since_returns_400(self, audit_app: FastAPI) -> None:
+        with TestClient(audit_app) as client:
+            resp = client.get(
+                "/v1/stronghold/audit?since=not-a-date",
+                headers={"Authorization": "Bearer sk-test"},
+            )
+            assert resp.status_code == 400
+            assert "Invalid" in resp.json()["detail"]
+
+
+class TestAuditExportRoute:
+    """Tests for GET /v1/stronghold/audit/export."""
+
+    def test_returns_csv(self, audit_app: FastAPI) -> None:
+        with TestClient(audit_app) as client:
+            resp = client.get(
+                "/v1/stronghold/audit/export",
+                headers={"Authorization": "Bearer sk-test"},
+            )
+            assert resp.status_code == 200
+            assert resp.headers["content-type"] == "text/csv; charset=utf-8"
+            assert "attachment" in resp.headers.get("content-disposition", "")
+            reader = csv.reader(io.StringIO(resp.text))
+            rows = list(reader)
+            assert len(rows) == 7  # header + 6 entries
+
+    def test_csv_filters_by_user(self, audit_app: FastAPI) -> None:
+        with TestClient(audit_app) as client:
+            resp = client.get(
+                "/v1/stronghold/audit/export?user_id=charlie",
+                headers={"Authorization": "Bearer sk-test"},
+            )
+            assert resp.status_code == 200
+            reader = csv.reader(io.StringIO(resp.text))
+            rows = list(reader)
+            assert len(rows) == 2  # header + 1 charlie entry
+
+    def test_rejects_unauthenticated(self, audit_app: FastAPI) -> None:
+        with TestClient(audit_app) as client:
+            resp = client.get("/v1/stronghold/audit/export")
+            assert resp.status_code == 401
+
+
+class TestAuditStatsRoute:
+    """Tests for GET /v1/stronghold/audit/stats."""
+
+    def test_returns_stats(self, audit_app: FastAPI) -> None:
+        with TestClient(audit_app) as client:
+            resp = client.get(
+                "/v1/stronghold/audit/stats",
+                headers={"Authorization": "Bearer sk-test"},
+            )
+            assert resp.status_code == 200
+            data = resp.json()
+            assert data["total"] == 6
+            assert data["per_boundary"]["warden"] == 3
+            assert data["per_boundary"]["sentinel"] == 2
+            assert data["per_user"]["alice"] == 3
+            assert data["per_verdict"]["allowed"] == 4
+            assert "per_hour" in data
+
+    def test_rejects_unauthenticated(self, audit_app: FastAPI) -> None:
+        with TestClient(audit_app) as client:
+            resp = client.get("/v1/stronghold/audit/stats")
+            assert resp.status_code == 401

--- a/tests/security/test_normalize.py
+++ b/tests/security/test_normalize.py
@@ -1,0 +1,138 @@
+"""Tests for the unified normalization pipeline.
+
+Covers NFKD normalization, zero-width character stripping, whitespace
+collapsing, homoglyph replacement, and edge cases.
+"""
+
+from __future__ import annotations
+
+from stronghold.security.normalize import normalize_for_scanning, strip_homoglyphs
+
+
+class TestNormalizeForScanning:
+    """Tests for normalize_for_scanning()."""
+
+    def test_nfkd_applied(self) -> None:
+        """NFKD decomposes compatibility characters (e.g. fi ligature)."""
+        # U+FB01 = fi ligature, NFKD decomposes to "fi"
+        result = normalize_for_scanning("\ufb01le")
+        assert "fi" in result
+
+    def test_nfkd_fullwidth_latin(self) -> None:
+        """NFKD normalizes fullwidth Latin letters to ASCII equivalents."""
+        # U+FF41 = fullwidth 'a', U+FF42 = fullwidth 'b'
+        result = normalize_for_scanning("\uff41\uff42\uff43")
+        assert result == "abc"
+
+    def test_zero_width_stripped(self) -> None:
+        """Zero-width characters are removed entirely."""
+        # U+200B ZERO WIDTH SPACE, U+200C ZERO WIDTH NON-JOINER,
+        # U+200D ZERO WIDTH JOINER, U+FEFF BOM, U+00AD SOFT HYPHEN
+        text = "he\u200bl\u200cl\u200do\ufeff w\u00adorld"
+        result = normalize_for_scanning(text)
+        assert result == "hello world"
+
+    def test_zero_width_only_input(self) -> None:
+        """Input consisting solely of zero-width characters yields empty string."""
+        text = "\u200b\u200c\u200d\ufeff\u00ad"
+        result = normalize_for_scanning(text)
+        assert result == ""
+
+    def test_whitespace_collapsed(self) -> None:
+        """Multiple spaces, tabs, and newlines collapse to single space."""
+        text = "hello   \t\t  \n\n  world"
+        result = normalize_for_scanning(text)
+        assert result == "hello world"
+
+    def test_leading_trailing_whitespace_stripped(self) -> None:
+        """Leading and trailing whitespace is removed."""
+        text = "   hello world   "
+        result = normalize_for_scanning(text)
+        assert result == "hello world"
+
+    def test_lowercase_default_off(self) -> None:
+        """By default, case is preserved."""
+        result = normalize_for_scanning("Hello World")
+        assert result == "Hello World"
+
+    def test_lowercase_enabled(self) -> None:
+        """When lowercase=True, output is lowercased."""
+        result = normalize_for_scanning("Hello WORLD", lowercase=True)
+        assert result == "hello world"
+
+    def test_empty_string(self) -> None:
+        """Empty string returns empty string."""
+        result = normalize_for_scanning("")
+        assert result == ""
+
+    def test_plain_ascii_passthrough(self) -> None:
+        """Plain ASCII text passes through unchanged (minus extra whitespace)."""
+        text = "simple test string"
+        result = normalize_for_scanning(text)
+        assert result == "simple test string"
+
+    def test_combined_pipeline(self) -> None:
+        """All steps work together: NFKD + zero-width + whitespace + lowercase."""
+        # Fullwidth 'A' + zero-width space + multiple spaces + fi ligature
+        text = "\uff21\u200b   \ufb01le"
+        result = normalize_for_scanning(text, lowercase=True)
+        assert result == "a file"
+
+    def test_carriage_return_normalized(self) -> None:
+        """Carriage returns (\\r\\n) are collapsed like other whitespace."""
+        text = "line one\r\nline two\rline three"
+        result = normalize_for_scanning(text)
+        assert result == "line one line two line three"
+
+
+class TestStripHomoglyphs:
+    """Tests for strip_homoglyphs()."""
+
+    def test_cyrillic_a_replaced(self) -> None:
+        """Cyrillic 'a' (U+0430) is replaced with ASCII 'a'."""
+        # \u0430 = Cyrillic small letter a
+        result = strip_homoglyphs("\u0430dmin")
+        assert result == "admin"
+
+    def test_cyrillic_e_replaced(self) -> None:
+        """Cyrillic 'e' (U+0435) is replaced with ASCII 'e'."""
+        result = strip_homoglyphs("s\u0435cret")
+        assert result == "secret"
+
+    def test_cyrillic_o_replaced(self) -> None:
+        """Cyrillic 'o' (U+043E) is replaced with ASCII 'o'."""
+        result = strip_homoglyphs("r\u043e\u043et")
+        assert result == "root"
+
+    def test_cyrillic_p_replaced(self) -> None:
+        """Cyrillic 'p' (U+0440) is replaced with ASCII 'p'."""
+        result = strip_homoglyphs("\u0440assword")
+        assert result == "password"
+
+    def test_greek_omicron_replaced(self) -> None:
+        """Greek small letter omicron (U+03BF) is replaced with ASCII 'o'."""
+        result = strip_homoglyphs("r\u03bf\u03bft")
+        assert result == "root"
+
+    def test_cyrillic_uppercase_replaced(self) -> None:
+        """Cyrillic uppercase lookalikes are replaced with ASCII equivalents."""
+        # \u0410 = Cyrillic A, \u0412 = Cyrillic B (looks like B),
+        # \u0421 = Cyrillic S (looks like C)
+        result = strip_homoglyphs("\u0410\u0412\u0421")
+        assert result == "ABC"
+
+    def test_mixed_cyrillic_and_ascii(self) -> None:
+        """Mixed Cyrillic homoglyphs and real ASCII are normalized."""
+        # "ignore" with Cyrillic 'i' (\u0456) and 'o' (\u043E)
+        result = strip_homoglyphs("\u0456gn\u043ere")
+        assert result == "ignore"
+
+    def test_plain_ascii_unchanged(self) -> None:
+        """Plain ASCII text passes through unchanged."""
+        result = strip_homoglyphs("hello world")
+        assert result == "hello world"
+
+    def test_empty_string(self) -> None:
+        """Empty string returns empty string."""
+        result = strip_homoglyphs("")
+        assert result == ""


### PR DESCRIPTION
AuditQueryEngine with filtering (org/user/boundary/since/limit), stats aggregation (per boundary/user/hour/verdict), CSV export. 3 admin API routes. 20 tests.