### PR TITLE
feat: add constant-time token comparison utility

### DIFF
--- a/src/stronghold/security/constant_time.py
+++ b/src/stronghold/security/constant_time.py
@@ -1,0 +1,42 @@
+"""Constant-time comparison utilities for security-sensitive token checks.
+
+Addresses conductor_security.md #17 #44: Bearer token comparison must be
+constant-time to prevent timing side-channel attacks.
+
+Uses ``hmac.compare_digest`` under the hood, which is implemented in C and
+runs in constant time regardless of where the first difference occurs.
+
+Usage::
+
+    from stronghold.security.constant_time import secure_compare
+
+    if not secure_compare(user_token, expected_token):
+        raise AuthError("Invalid token")
+"""
+
+from __future__ import annotations
+
+import hmac
+
+
+def secure_compare(a: str, b: str) -> bool:
+    """Constant-time string comparison.
+
+    Encodes both strings to UTF-8 bytes and delegates to
+    ``hmac.compare_digest``. This handles non-ASCII characters
+    (which ``compare_digest`` rejects when passed as ``str``).
+
+    Both arguments must be ``str``. For bytes, use :func:`secure_compare_bytes`.
+    """
+    return hmac.compare_digest(a.encode("utf-8"), b.encode("utf-8"))
+
+
+def secure_compare_bytes(a: bytes, b: bytes) -> bool:
+    """Constant-time bytes comparison.
+
+    Wraps ``hmac.compare_digest`` for bytes inputs. Prevents timing
+    side-channel attacks on token/key validation.
+
+    Both arguments must be ``bytes``. For strings, use :func:`secure_compare`.
+    """
+    return hmac.compare_digest(a, b)

--- a/tests/memory/test_scopes.py
+++ b/tests/memory/test_scopes.py
@@ -1,0 +1,192 @@
+"""Tests for memory scope filtering (build_scope_filter).
+
+Validates the hierarchical scope filter builder:
+  GLOBAL > ORGANIZATION > TEAM > USER > AGENT > SESSION
+
+Each test uses real types — no mocks per project rules.
+"""
+
+from __future__ import annotations
+
+from stronghold.memory.scopes import build_scope_filter
+from stronghold.types.memory import MemoryScope
+
+
+class TestGlobalScope:
+    """Global scope is always present regardless of arguments."""
+
+    def test_global_always_included_with_no_args(self) -> None:
+        result = build_scope_filter()
+        assert (MemoryScope.GLOBAL, None) in result
+
+    def test_global_always_included_with_all_args(self) -> None:
+        result = build_scope_filter(
+            agent_id="agent-1",
+            user_id="user-1",
+            team_id="team-1",
+            org_id="org-1",
+        )
+        assert (MemoryScope.GLOBAL, None) in result
+
+    def test_global_is_first_filter(self) -> None:
+        result = build_scope_filter(org_id="org-1", team_id="team-1")
+        assert result[0] == (MemoryScope.GLOBAL, None)
+
+
+class TestOrganizationScope:
+    """Organization scope only appears when org_id is provided."""
+
+    def test_org_scope_included_when_org_id_provided(self) -> None:
+        result = build_scope_filter(org_id="acme-corp")
+        assert (MemoryScope.ORGANIZATION, "acme-corp") in result
+
+    def test_org_scope_excluded_when_no_org_id(self) -> None:
+        result = build_scope_filter(user_id="user-1")
+        scopes = [s for s, _ in result]
+        assert MemoryScope.ORGANIZATION not in scopes
+
+    def test_org_scope_excluded_for_empty_org_id(self) -> None:
+        result = build_scope_filter(org_id="")
+        scopes = [s for s, _ in result]
+        assert MemoryScope.ORGANIZATION not in scopes
+
+
+class TestTeamScope:
+    """Team scope only appears when team_id is provided."""
+
+    def test_team_scope_included_when_team_id_provided(self) -> None:
+        result = build_scope_filter(team_id="backend-team")
+        assert (MemoryScope.TEAM, "backend-team") in result
+
+    def test_team_scope_excluded_when_no_team_id(self) -> None:
+        result = build_scope_filter(org_id="org-1")
+        scopes = [s for s, _ in result]
+        assert MemoryScope.TEAM not in scopes
+
+
+class TestUserScope:
+    """User scope only appears when user_id is provided."""
+
+    def test_user_scope_included_when_user_id_provided(self) -> None:
+        result = build_scope_filter(user_id="alice")
+        assert (MemoryScope.USER, "alice") in result
+
+    def test_user_scope_excluded_when_no_user_id(self) -> None:
+        result = build_scope_filter(team_id="team-1")
+        scopes = [s for s, _ in result]
+        assert MemoryScope.USER not in scopes
+
+
+class TestAgentScope:
+    """Agent scope only appears when agent_id is provided."""
+
+    def test_agent_scope_included_when_agent_id_provided(self) -> None:
+        result = build_scope_filter(agent_id="artificer")
+        assert (MemoryScope.AGENT, "artificer") in result
+
+    def test_agent_scope_excluded_when_no_agent_id(self) -> None:
+        result = build_scope_filter(user_id="alice")
+        scopes = [s for s, _ in result]
+        assert MemoryScope.AGENT not in scopes
+
+
+class TestSessionScope:
+    """Session scope is never included by build_scope_filter.
+
+    Session filtering is handled at a different layer (session store),
+    so build_scope_filter never emits SESSION tuples.
+    """
+
+    def test_session_scope_never_in_output(self) -> None:
+        result = build_scope_filter(agent_id="a", user_id="u", team_id="t", org_id="o")
+        scopes = [s for s, _ in result]
+        assert MemoryScope.SESSION not in scopes
+
+
+class TestScopeHierarchy:
+    """Scope ordering follows the hierarchy: GLOBAL > ORG > TEAM > USER > AGENT."""
+
+    def test_full_hierarchy_order(self) -> None:
+        result = build_scope_filter(
+            org_id="org-1",
+            team_id="team-1",
+            user_id="user-1",
+            agent_id="agent-1",
+        )
+        scopes = [s for s, _ in result]
+        expected_order = [
+            MemoryScope.GLOBAL,
+            MemoryScope.ORGANIZATION,
+            MemoryScope.TEAM,
+            MemoryScope.USER,
+            MemoryScope.AGENT,
+        ]
+        assert scopes == expected_order
+
+    def test_hierarchy_length_with_all_params(self) -> None:
+        result = build_scope_filter(org_id="o", team_id="t", user_id="u", agent_id="a")
+        assert len(result) == 5
+
+
+class TestEmptyScope:
+    """Calling with no arguments returns only the global filter."""
+
+    def test_no_args_returns_only_global(self) -> None:
+        result = build_scope_filter()
+        assert result == [(MemoryScope.GLOBAL, None)]
+
+    def test_no_args_length_is_one(self) -> None:
+        result = build_scope_filter()
+        assert len(result) == 1
+
+
+class TestMultipleScopesCombine:
+    """Partial argument combinations produce correct filter sets."""
+
+    def test_org_and_user_without_team(self) -> None:
+        result = build_scope_filter(org_id="org-1", user_id="user-1")
+        scopes = [s for s, _ in result]
+        assert MemoryScope.GLOBAL in scopes
+        assert MemoryScope.ORGANIZATION in scopes
+        assert MemoryScope.USER in scopes
+        assert MemoryScope.TEAM not in scopes
+        assert MemoryScope.AGENT not in scopes
+
+    def test_team_and_agent_without_org_or_user(self) -> None:
+        result = build_scope_filter(team_id="team-1", agent_id="ranger")
+        expected = [
+            (MemoryScope.GLOBAL, None),
+            (MemoryScope.TEAM, "team-1"),
+            (MemoryScope.AGENT, "ranger"),
+        ]
+        assert result == expected
+
+    def test_only_agent_id(self) -> None:
+        result = build_scope_filter(agent_id="scribe")
+        assert result == [
+            (MemoryScope.GLOBAL, None),
+            (MemoryScope.AGENT, "scribe"),
+        ]
+
+
+class TestScopeValues:
+    """Values in the filter tuples match exactly what was passed in."""
+
+    def test_values_are_preserved(self) -> None:
+        result = build_scope_filter(
+            org_id="acme-corp",
+            team_id="platform",
+            user_id="blake@acme.com",
+            agent_id="artificer",
+        )
+        values = {s: v for s, v in result}
+        assert values[MemoryScope.GLOBAL] is None
+        assert values[MemoryScope.ORGANIZATION] == "acme-corp"
+        assert values[MemoryScope.TEAM] == "platform"
+        assert values[MemoryScope.USER] == "blake@acme.com"
+        assert values[MemoryScope.AGENT] == "artificer"
+
+    def test_none_values_excluded(self) -> None:
+        """Passing None explicitly still excludes the scope."""
+        result = build_scope_filter(org_id=None, team_id=None, user_id=None, agent_id=None)
+        assert result == [(MemoryScope.GLOBAL, None)]

--- a/tests/security/test_constant_time.py
+++ b/tests/security/test_constant_time.py
@@ -1,0 +1,88 @@
+"""Tests for constant-time token comparison utility.
+
+Addresses conductor_security.md #17 #44: Bearer token comparison not constant-time.
+Validates that secure_compare and secure_compare_bytes wrap hmac.compare_digest
+correctly for all edge cases.
+"""
+
+from __future__ import annotations
+
+from stronghold.security.constant_time import secure_compare, secure_compare_bytes
+
+# ---------------------------------------------------------------------------
+# secure_compare (str)
+# ---------------------------------------------------------------------------
+
+
+class TestSecureCompare:
+    """Tests for string-based constant-time comparison."""
+
+    def test_equal_strings_return_true(self) -> None:
+        assert secure_compare("secret-token-abc", "secret-token-abc") is True
+
+    def test_different_strings_return_false(self) -> None:
+        assert secure_compare("secret-token-abc", "secret-token-xyz") is False
+
+    def test_different_lengths_return_false(self) -> None:
+        assert secure_compare("short", "a-much-longer-string") is False
+
+    def test_empty_strings_return_true(self) -> None:
+        assert secure_compare("", "") is True
+
+    def test_empty_vs_nonempty_returns_false(self) -> None:
+        assert secure_compare("", "nonempty") is False
+
+    def test_nonempty_vs_empty_returns_false(self) -> None:
+        assert secure_compare("nonempty", "") is False
+
+    def test_unicode_equal(self) -> None:
+        assert secure_compare("tök€n-ünîcödé", "tök€n-ünîcödé") is True
+
+    def test_unicode_different(self) -> None:
+        assert secure_compare("tök€n-a", "tök€n-b") is False
+
+    def test_single_char_difference(self) -> None:
+        assert secure_compare("abcdefg", "abcdefh") is False
+
+    def test_whitespace_matters(self) -> None:
+        assert secure_compare("token ", "token") is False
+
+    def test_case_sensitive(self) -> None:
+        assert secure_compare("Token", "token") is False
+
+
+# ---------------------------------------------------------------------------
+# secure_compare_bytes (bytes)
+# ---------------------------------------------------------------------------
+
+
+class TestSecureCompareBytes:
+    """Tests for bytes-based constant-time comparison."""
+
+    def test_equal_bytes_return_true(self) -> None:
+        assert secure_compare_bytes(b"secret", b"secret") is True
+
+    def test_different_bytes_return_false(self) -> None:
+        assert secure_compare_bytes(b"secret", b"notsec") is False
+
+    def test_different_lengths_return_false(self) -> None:
+        assert secure_compare_bytes(b"ab", b"abcdef") is False
+
+    def test_empty_bytes_return_true(self) -> None:
+        assert secure_compare_bytes(b"", b"") is True
+
+    def test_empty_vs_nonempty_returns_false(self) -> None:
+        assert secure_compare_bytes(b"", b"data") is False
+
+    def test_nonempty_vs_empty_returns_false(self) -> None:
+        assert secure_compare_bytes(b"data", b"") is False
+
+    def test_binary_data(self) -> None:
+        a = bytes(range(256))
+        b = bytes(range(256))
+        assert secure_compare_bytes(a, b) is True
+
+    def test_binary_data_different(self) -> None:
+        a = bytes(range(256))
+        b = bytes((x + 1) % 256 for x in range(256))
+        assert secure_compare_bytes(a, b) is False


### PR DESCRIPTION
Addresses conductor_security.md §17 #44. secure_compare + secure_compare_bytes. Audit: existing auth already safe. 19 tests.