### PR TITLE
test: add context builder token budget tests

### DIFF
--- a/tests/agents/test_context_builder_budget.py
+++ b/tests/agents/test_context_builder_budget.py
@@ -1,0 +1,592 @@
+"""Tests for ContextBuilder token budget enforcement.
+
+Covers:
+- Token budget respected (total context never exceeds limit)
+- Priority ordering (soul > promoted learnings > matched learnings)
+- Lower-priority items dropped when budget is tight
+- Empty inputs produce minimal context
+- Learnings injected in context when budget allows
+- Soul prompt never truncated even if it exceeds budget
+- Promoted and matched learnings each get their own XML blocks
+- Budget exhaustion drops learnings gracefully
+"""
+
+from __future__ import annotations
+
+from stronghold.agents.context_builder import (
+    _CHARS_PER_TOKEN,
+    ContextBuilder,
+    _estimate_tokens,
+)
+from stronghold.memory.learnings.store import InMemoryLearningStore
+from stronghold.types.agent import AgentIdentity
+from stronghold.types.memory import Learning, MemoryScope
+from tests.fakes import FakePromptManager
+
+# ── Helpers ──────────────────────────────────────────────────────────
+
+
+def _identity(
+    *,
+    name: str = "test-agent",
+    soul_prompt_name: str = "",
+    learnings: bool = True,
+) -> AgentIdentity:
+    """Build an AgentIdentity with optional learnings enabled."""
+    mem_cfg: dict[str, object] = {"learnings": True} if learnings else {}
+    return AgentIdentity(
+        name=name,
+        soul_prompt_name=soul_prompt_name,
+        memory_config=mem_cfg,
+    )
+
+
+def _learning(text: str, *, keys: list[str] | None = None, status: str = "active") -> Learning:
+    """Build a Learning with the given text and trigger keys."""
+    return Learning(
+        category="tool_correction",
+        trigger_keys=keys or [],
+        learning=text,
+        tool_name="test_tool",
+        agent_id="test-agent",
+        scope=MemoryScope.AGENT,
+        status=status,
+    )
+
+
+def _system_content(messages: list[dict[str, object]]) -> str:
+    """Extract the system message content from a message list."""
+    for msg in messages:
+        if msg.get("role") == "system":
+            return str(msg.get("content", ""))
+    return ""
+
+
+# ── Tests ────────────────────────────────────────────────────────────
+
+
+class TestEstimateTokens:
+    """Unit tests for the _estimate_tokens helper."""
+
+    def test_empty_string(self) -> None:
+        assert _estimate_tokens("") == 0
+
+    def test_known_length(self) -> None:
+        # 400 chars / 4 chars-per-token = 100 tokens
+        text = "a" * 400
+        assert _estimate_tokens(text) == 100
+
+    def test_integer_division(self) -> None:
+        # 7 chars / 4 = 1 (integer division)
+        assert _estimate_tokens("abcdefg") == 1
+
+
+class TestEmptyInputs:
+    """Context builder with no soul, no learnings, no messages."""
+
+    async def test_no_soul_no_learnings_returns_original_messages(self) -> None:
+        cb = ContextBuilder()
+        pm = FakePromptManager()
+        identity = _identity(learnings=False)
+        messages: list[dict[str, object]] = [{"role": "user", "content": "hello"}]
+
+        result = await cb.build(messages, identity, prompt_manager=pm)
+
+        # No system message injected — original messages returned as-is
+        assert len(result) == 1
+        assert result[0]["role"] == "user"
+
+    async def test_empty_messages_with_soul(self) -> None:
+        cb = ContextBuilder()
+        pm = FakePromptManager()
+        pm.seed("agent.test-agent.soul", "You are a test agent.")
+        identity = _identity()
+
+        result = await cb.build([], identity, prompt_manager=pm)
+
+        assert len(result) == 1
+        assert result[0]["role"] == "system"
+        assert result[0]["content"] == "You are a test agent."
+
+
+class TestSoulPromptPriority:
+    """Soul prompt is always included, never truncated."""
+
+    async def test_soul_included_with_generous_budget(self) -> None:
+        cb = ContextBuilder()
+        pm = FakePromptManager()
+        soul = "You are an expert coder."
+        pm.seed("agent.coder.soul", soul)
+        identity = _identity(name="coder")
+
+        result = await cb.build(
+            [{"role": "user", "content": "hi"}],
+            identity,
+            prompt_manager=pm,
+            system_token_budget=4096,
+        )
+
+        sys_content = _system_content(result)
+        assert soul in sys_content
+
+    async def test_soul_included_even_when_it_exceeds_budget(self) -> None:
+        """Soul prompt is never truncated. If it alone exceeds the budget,
+        it is still included — but learnings are dropped."""
+        cb = ContextBuilder()
+        pm = FakePromptManager()
+        # Soul: 200 chars = 50 tokens. Budget = 10 tokens (40 chars).
+        soul = "X" * 200
+        pm.seed("agent.test-agent.soul", soul)
+
+        store = InMemoryLearningStore()
+        lr = _learning("This should be dropped", keys=["hi"])
+        lr.status = "promoted"
+        await store.store(lr)
+
+        identity = _identity()
+        result = await cb.build(
+            [{"role": "user", "content": "hi"}],
+            identity,
+            prompt_manager=pm,
+            learning_store=store,
+            system_token_budget=10,
+        )
+
+        sys_content = _system_content(result)
+        # Soul present despite exceeding budget
+        assert soul in sys_content
+        # Learning was dropped (budget went negative after soul)
+        assert "This should be dropped" not in sys_content
+
+    async def test_custom_soul_prompt_name(self) -> None:
+        cb = ContextBuilder()
+        pm = FakePromptManager()
+        pm.seed("custom.soul", "I am custom.")
+        identity = _identity(soul_prompt_name="custom.soul")
+
+        result = await cb.build(
+            [{"role": "user", "content": "hi"}],
+            identity,
+            prompt_manager=pm,
+        )
+
+        assert "I am custom." in _system_content(result)
+
+
+class TestPromotedLearnings:
+    """Promoted learnings appear after soul, in their own XML block."""
+
+    async def test_promoted_learnings_injected(self) -> None:
+        cb = ContextBuilder()
+        pm = FakePromptManager()
+        pm.seed("agent.test-agent.soul", "Soul.")
+
+        store = InMemoryLearningStore()
+        lr = _learning("Use entity_id fan.bedroom", keys=["fan"])
+        await store.store(lr)
+        # Promote it
+        lr.status = "promoted"
+
+        identity = _identity()
+        result = await cb.build(
+            [{"role": "user", "content": "turn on fan"}],
+            identity,
+            prompt_manager=pm,
+            learning_store=store,
+            org_id="",
+            system_token_budget=4096,
+        )
+
+        sys_content = _system_content(result)
+        assert '<stronghold:corrections type="promoted">' in sys_content
+        assert "Use entity_id fan.bedroom" in sys_content
+
+    async def test_promoted_learnings_dropped_when_budget_exhausted(self) -> None:
+        cb = ContextBuilder()
+        pm = FakePromptManager()
+        # Soul uses most of the budget: 80 chars = 20 tokens
+        soul = "S" * 80
+        pm.seed("agent.test-agent.soul", soul)
+
+        store = InMemoryLearningStore()
+        # Each promoted learning is long — 100 chars
+        for i in range(5):
+            lr = _learning("P" * 100 + f" #{i}", keys=["fan"])
+            await store.store(lr)
+            lr.status = "promoted"
+
+        identity = _identity()
+        # Budget = 25 tokens = 100 chars. Soul uses 80, leaving 20 for learnings.
+        result = await cb.build(
+            [{"role": "user", "content": "fan"}],
+            identity,
+            prompt_manager=pm,
+            learning_store=store,
+            system_token_budget=25,
+        )
+
+        sys_content = _system_content(result)
+        assert soul in sys_content
+        # Not enough room for any 100-char promoted learning (overhead + entry > 20 chars)
+        assert "promoted" not in sys_content or sys_content.count("- P") == 0
+
+    async def test_promoted_not_injected_when_learnings_disabled(self) -> None:
+        cb = ContextBuilder()
+        pm = FakePromptManager()
+        pm.seed("agent.test-agent.soul", "Soul.")
+
+        store = InMemoryLearningStore()
+        lr = _learning("Should not appear", keys=["hi"])
+        await store.store(lr)
+        lr.status = "promoted"
+
+        identity = _identity(learnings=False)
+        result = await cb.build(
+            [{"role": "user", "content": "hi"}],
+            identity,
+            prompt_manager=pm,
+            learning_store=store,
+        )
+
+        sys_content = _system_content(result)
+        assert "Should not appear" not in sys_content
+
+
+class TestMatchedLearnings:
+    """Matched learnings appear after promoted, based on keyword relevance."""
+
+    async def test_matched_learnings_injected_by_keyword(self) -> None:
+        cb = ContextBuilder()
+        pm = FakePromptManager()
+        pm.seed("agent.test-agent.soul", "Soul.")
+
+        store = InMemoryLearningStore()
+        lr = _learning("Use full path for bedroom light", keys=["bedroom", "light"])
+        await store.store(lr)
+
+        identity = _identity()
+        result = await cb.build(
+            [{"role": "user", "content": "turn on bedroom light"}],
+            identity,
+            prompt_manager=pm,
+            learning_store=store,
+            agent_id="test-agent",
+            system_token_budget=4096,
+        )
+
+        sys_content = _system_content(result)
+        assert '<stronghold:corrections type="matched">' in sys_content
+        assert "Use full path for bedroom light" in sys_content
+
+    async def test_matched_not_injected_without_keyword_match(self) -> None:
+        cb = ContextBuilder()
+        pm = FakePromptManager()
+        pm.seed("agent.test-agent.soul", "Soul.")
+
+        store = InMemoryLearningStore()
+        lr = _learning("Irrelevant learning", keys=["garage", "door"])
+        await store.store(lr)
+
+        identity = _identity()
+        result = await cb.build(
+            [{"role": "user", "content": "turn on bedroom light"}],
+            identity,
+            prompt_manager=pm,
+            learning_store=store,
+            agent_id="test-agent",
+            system_token_budget=4096,
+        )
+
+        sys_content = _system_content(result)
+        assert "Irrelevant learning" not in sys_content
+
+    async def test_matched_learnings_dropped_when_budget_tight(self) -> None:
+        cb = ContextBuilder()
+        pm = FakePromptManager()
+        # Soul: 60 chars = 15 tokens
+        soul = "S" * 60
+        pm.seed("agent.test-agent.soul", soul)
+
+        store = InMemoryLearningStore()
+        # Long matched learning
+        lr = _learning("M" * 200, keys=["fan"])
+        await store.store(lr)
+
+        identity = _identity()
+        # Budget = 20 tokens = 80 chars. Soul uses 60, leaving 20.
+        result = await cb.build(
+            [{"role": "user", "content": "fan"}],
+            identity,
+            prompt_manager=pm,
+            learning_store=store,
+            agent_id="test-agent",
+            system_token_budget=20,
+        )
+
+        sys_content = _system_content(result)
+        assert soul in sys_content
+        # Matched learning too big to fit
+        assert "M" * 200 not in sys_content
+
+
+class TestBudgetEnforcement:
+    """Total system prompt respects token budget."""
+
+    async def test_total_context_within_budget(self) -> None:
+        cb = ContextBuilder()
+        pm = FakePromptManager()
+        soul = "You are a helpful agent."
+        pm.seed("agent.test-agent.soul", soul)
+
+        store = InMemoryLearningStore()
+        for i in range(20):
+            lr = _learning(f"Learning number {i}", keys=["hello"])
+            await store.store(lr)
+
+        # Also add promoted
+        for i in range(10):
+            lr2 = _learning(f"Promoted tip {i}", keys=["hello"])
+            await store.store(lr2)
+            lr2.status = "promoted"
+
+        identity = _identity()
+        budget = 100  # 400 chars
+        result = await cb.build(
+            [{"role": "user", "content": "hello"}],
+            identity,
+            prompt_manager=pm,
+            learning_store=store,
+            agent_id="test-agent",
+            system_token_budget=budget,
+        )
+
+        sys_content = _system_content(result)
+        # Soul is always present (not counted against budget for truncation)
+        assert soul in sys_content
+        # Verify the non-soul portion respects budget
+        non_soul = sys_content.replace(soul, "")
+        # Non-soul chars should be within the remaining budget
+        remaining_budget_chars = (budget * _CHARS_PER_TOKEN) - len(soul)
+        # Allow some slack for the "\n\n" joiners
+        assert len(non_soul) <= remaining_budget_chars + 20  # +20 for separator overhead
+
+    async def test_partial_promoted_learnings_fit(self) -> None:
+        """When budget allows some but not all promoted learnings, only a subset is included."""
+        cb = ContextBuilder()
+        pm = FakePromptManager()
+        pm.seed("agent.test-agent.soul", "Soul.")
+
+        store = InMemoryLearningStore()
+        # Each promoted learning: "- " + 40 chars = 42 chars per entry
+        for i in range(10):
+            lr = _learning("A" * 40 + f"_{i}", keys=["hi"])
+            await store.store(lr)
+            lr.status = "promoted"
+
+        identity = _identity()
+        # Budget: soul(5 chars) + overhead for XML tags (~80 chars) + space for ~2 entries
+        # 2 entries ~= 84 chars each. Total needed = 5 + 80 + 168 = 253.
+        # Set budget to allow soul + ~3 entries = 300 chars = 75 tokens.
+        result = await cb.build(
+            [{"role": "user", "content": "hi"}],
+            identity,
+            prompt_manager=pm,
+            learning_store=store,
+            system_token_budget=75,
+        )
+
+        sys_content = _system_content(result)
+        # At least one promoted learning included
+        assert "promoted" in sys_content
+        # But not all 10 (budget too small)
+        assert sys_content.count("- A") < 10
+
+    async def test_promoted_before_matched_priority(self) -> None:
+        """Promoted learnings consume budget before matched learnings."""
+        cb = ContextBuilder()
+        pm = FakePromptManager()
+        pm.seed("agent.test-agent.soul", "Soul.")
+
+        store = InMemoryLearningStore()
+        # Big promoted learning that eats most of the budget
+        lr_promoted = _learning("P" * 150, keys=["hello"])
+        await store.store(lr_promoted)
+        lr_promoted.status = "promoted"
+
+        # Matched learning that would fit if promoted wasn't there
+        lr_matched = _learning("Matched insight", keys=["hello"])
+        await store.store(lr_matched)
+
+        identity = _identity()
+        # Budget: soul(5) + promoted(~160 + overhead ~80) = ~245. ~250 chars = 62 tokens.
+        # Not enough room for matched after promoted.
+        result = await cb.build(
+            [{"role": "user", "content": "hello"}],
+            identity,
+            prompt_manager=pm,
+            learning_store=store,
+            agent_id="test-agent",
+            system_token_budget=62,
+        )
+
+        sys_content = _system_content(result)
+        # Promoted consumed the budget
+        assert "P" * 150 in sys_content
+        # Matched was dropped
+        assert "Matched insight" not in sys_content
+
+
+class TestExistingSystemMessage:
+    """Handles pre-existing system messages in the input."""
+
+    async def test_prepends_to_existing_system_message(self) -> None:
+        cb = ContextBuilder()
+        pm = FakePromptManager()
+        pm.seed("agent.test-agent.soul", "Soul prefix.")
+        identity = _identity()
+
+        messages: list[dict[str, object]] = [
+            {"role": "system", "content": "Existing system content."},
+            {"role": "user", "content": "hello"},
+        ]
+
+        result = await cb.build(messages, identity, prompt_manager=pm)
+
+        sys_content = _system_content(result)
+        # Soul is prepended to existing system message
+        assert sys_content.startswith("Soul prefix.")
+        assert "Existing system content." in sys_content
+
+    async def test_inserts_system_when_none_exists(self) -> None:
+        cb = ContextBuilder()
+        pm = FakePromptManager()
+        pm.seed("agent.test-agent.soul", "New system.")
+        identity = _identity()
+
+        messages: list[dict[str, object]] = [
+            {"role": "user", "content": "hello"},
+        ]
+
+        result = await cb.build(messages, identity, prompt_manager=pm)
+
+        assert result[0]["role"] == "system"
+        assert result[0]["content"] == "New system."
+        assert result[1]["role"] == "user"
+
+
+class TestUserTextExtraction:
+    """Matched learnings use the last user message for keyword matching."""
+
+    async def test_uses_last_user_message_for_matching(self) -> None:
+        cb = ContextBuilder()
+        pm = FakePromptManager()
+        pm.seed("agent.test-agent.soul", "Soul.")
+
+        store = InMemoryLearningStore()
+        lr = _learning("Use dimmer for lamp", keys=["lamp"])
+        await store.store(lr)
+
+        identity = _identity()
+        messages: list[dict[str, object]] = [
+            {"role": "user", "content": "turn on the fan"},
+            {"role": "assistant", "content": "Done."},
+            {"role": "user", "content": "now dim the lamp"},
+        ]
+
+        result = await cb.build(
+            messages,
+            identity,
+            prompt_manager=pm,
+            learning_store=store,
+            agent_id="test-agent",
+            system_token_budget=4096,
+        )
+
+        sys_content = _system_content(result)
+        # "lamp" matches the last user message
+        assert "Use dimmer for lamp" in sys_content
+
+    async def test_no_user_message_skips_matched(self) -> None:
+        cb = ContextBuilder()
+        pm = FakePromptManager()
+        pm.seed("agent.test-agent.soul", "Soul.")
+
+        store = InMemoryLearningStore()
+        lr = _learning("Should not match", keys=["anything"])
+        await store.store(lr)
+
+        identity = _identity()
+        # Only assistant messages — no user text to match against
+        messages: list[dict[str, object]] = [
+            {"role": "assistant", "content": "I was already talking."},
+        ]
+
+        result = await cb.build(
+            messages,
+            identity,
+            prompt_manager=pm,
+            learning_store=store,
+            agent_id="test-agent",
+            system_token_budget=4096,
+        )
+
+        sys_content = _system_content(result)
+        assert "Should not match" not in sys_content
+
+
+class TestNoLearningStore:
+    """When no learning_store is provided, only soul prompt is included."""
+
+    async def test_soul_only_without_store(self) -> None:
+        cb = ContextBuilder()
+        pm = FakePromptManager()
+        pm.seed("agent.test-agent.soul", "Just the soul.")
+        identity = _identity()
+
+        result = await cb.build(
+            [{"role": "user", "content": "hello"}],
+            identity,
+            prompt_manager=pm,
+            # No learning_store
+            system_token_budget=4096,
+        )
+
+        sys_content = _system_content(result)
+        assert sys_content == "Just the soul."
+        assert "corrections" not in sys_content
+
+
+class TestOrgIsolation:
+    """Learnings are scoped by org_id — cross-org learnings are invisible."""
+
+    async def test_org_scoped_learnings_not_leaked(self) -> None:
+        cb = ContextBuilder()
+        pm = FakePromptManager()
+        pm.seed("agent.test-agent.soul", "Soul.")
+
+        store = InMemoryLearningStore()
+        # Learning for org-A
+        lr_a = _learning("Org-A secret", keys=["hello"])
+        lr_a.org_id = "org-A"
+        await store.store(lr_a)
+
+        # Learning for org-B
+        lr_b = _learning("Org-B secret", keys=["hello"])
+        lr_b.org_id = "org-B"
+        await store.store(lr_b)
+
+        identity = _identity()
+        # Build context for org-A
+        result = await cb.build(
+            [{"role": "user", "content": "hello"}],
+            identity,
+            prompt_manager=pm,
+            learning_store=store,
+            agent_id="test-agent",
+            org_id="org-A",
+            system_token_budget=4096,
+        )
+
+        sys_content = _system_content(result)
+        assert "Org-A secret" in sys_content
+        assert "Org-B secret" not in sys_content

--- a/tests/mcp/test_registry.py
+++ b/tests/mcp/test_registry.py
@@ -1,0 +1,489 @@
+"""Tests for stronghold.mcp.registry — MCPRegistry.
+
+Covers: server registration (custom + catalog), listing, filtering by org,
+removal, catalog listing, status updates, image allow-list enforcement,
+known-server tool attachment, and K8s-safe naming.
+
+No mocks — uses real MCPRegistry, MCPServerSpec, MCPServer instances.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from stronghold.mcp.registry import KNOWN_MCP_SERVERS, MCPRegistry
+from stronghold.mcp.types import (
+    MCPResourceLimits,
+    MCPServer,
+    MCPServerSpec,
+    MCPServerStatus,
+    MCPSourceType,
+    MCPTransport,
+)
+
+# ── Helpers ──────────────────────────────────────────────────────────
+
+
+def _allowed_spec(name: str = "test-server", **overrides: object) -> MCPServerSpec:
+    """Build an MCPServerSpec with an allowed image prefix."""
+    defaults: dict[str, object] = {
+        "name": name,
+        "image": "ghcr.io/modelcontextprotocol/server-test:latest",
+    }
+    defaults.update(overrides)
+    return MCPServerSpec(**defaults)  # type: ignore[arg-type]
+
+
+# ── Registration ─────────────────────────────────────────────────────
+
+
+class TestRegister:
+    def test_register_returns_server(self) -> None:
+        registry = MCPRegistry()
+        spec = _allowed_spec()
+        server = registry.register(spec)
+        assert isinstance(server, MCPServer)
+        assert server.spec.name == "test-server"
+        assert server.status == MCPServerStatus.PENDING
+
+    def test_register_stores_server(self) -> None:
+        registry = MCPRegistry()
+        spec = _allowed_spec("my-server")
+        registry.register(spec)
+        assert registry.get("my-server") is not None
+        assert registry.get("my-server") is not None
+
+    def test_register_with_org_id(self) -> None:
+        registry = MCPRegistry()
+        spec = _allowed_spec()
+        server = registry.register(spec, org_id="org-42")
+        assert server.org_id == "org-42"
+
+    def test_register_with_source_type_remote(self) -> None:
+        registry = MCPRegistry()
+        spec = _allowed_spec()
+        server = registry.register(spec, source_type=MCPSourceType.REMOTE)
+        assert server.source_type == MCPSourceType.REMOTE
+
+    def test_register_default_source_type_is_managed(self) -> None:
+        registry = MCPRegistry()
+        spec = _allowed_spec()
+        server = registry.register(spec)
+        assert server.source_type == MCPSourceType.MANAGED
+
+    def test_register_replaces_existing(self) -> None:
+        """Re-registering the same name overwrites the previous entry."""
+        registry = MCPRegistry()
+        spec1 = _allowed_spec("dup", image="ghcr.io/modelcontextprotocol/server-a:1")
+        spec2 = _allowed_spec("dup", image="ghcr.io/modelcontextprotocol/server-b:2")
+        registry.register(spec1)
+        registry.register(spec2)
+        server = registry.get("dup")
+        assert server is not None
+        assert server.spec.image == "ghcr.io/modelcontextprotocol/server-b:2"
+        assert len(registry.list_all()) == 1
+
+
+# ── Image allow-list (C12) ───────────────────────────────────────────
+
+
+class TestImageAllowList:
+    def test_allowed_ghcr_modelcontextprotocol(self) -> None:
+        registry = MCPRegistry()
+        spec = MCPServerSpec(
+            name="ok",
+            image="ghcr.io/modelcontextprotocol/server-github:latest",
+        )
+        server = registry.register(spec)
+        assert server.spec.image.startswith("ghcr.io/modelcontextprotocol/")
+
+    def test_allowed_ghcr_anthropics(self) -> None:
+        registry = MCPRegistry()
+        spec = MCPServerSpec(name="ok", image="ghcr.io/anthropics/server:v1")
+        server = registry.register(spec)
+        assert server.spec.name == "ok"
+
+    def test_allowed_docker_io_library(self) -> None:
+        registry = MCPRegistry()
+        spec = MCPServerSpec(name="ok", image="docker.io/library/nginx:latest")
+        server = registry.register(spec)
+        assert server.spec.name == "ok"
+
+    def test_allowed_mcr_microsoft(self) -> None:
+        registry = MCPRegistry()
+        spec = MCPServerSpec(name="ok", image="mcr.microsoft.com/server:v1")
+        server = registry.register(spec)
+        assert server.spec.name == "ok"
+
+    def test_rejected_arbitrary_image(self) -> None:
+        registry = MCPRegistry()
+        spec = MCPServerSpec(name="evil", image="evil.io/malware:latest")
+        with pytest.raises(ValueError, match="not from an allowed registry"):
+            registry.register(spec)
+
+    def test_rejected_dockerhub_non_library(self) -> None:
+        registry = MCPRegistry()
+        spec = MCPServerSpec(name="sus", image="docker.io/randomuser/tool:v1")
+        with pytest.raises(ValueError, match="not from an allowed registry"):
+            registry.register(spec)
+
+    def test_rejected_empty_image(self) -> None:
+        registry = MCPRegistry()
+        spec = MCPServerSpec(name="empty", image="")
+        with pytest.raises(ValueError, match="not from an allowed registry"):
+            registry.register(spec)
+
+
+# ── Catalog registration ─────────────────────────────────────────────
+
+
+class TestRegisterFromCatalog:
+    def test_register_known_github(self) -> None:
+        registry = MCPRegistry()
+        server = registry.register_from_catalog("github")
+        assert server.spec.name == "github"
+        assert "github" in server.spec.image
+        assert server.spec.trust_tier == "t2"
+        assert len(server.tools) > 0
+
+    def test_register_known_filesystem(self) -> None:
+        registry = MCPRegistry()
+        server = registry.register_from_catalog("filesystem")
+        assert server.spec.name == "filesystem"
+        assert len(server.tools) > 0
+
+    def test_register_known_postgres(self) -> None:
+        registry = MCPRegistry()
+        server = registry.register_from_catalog("postgres")
+        assert server.spec.name == "postgres"
+        tool_names = [t.name for t in server.tools]
+        assert "query" in tool_names
+
+    def test_register_known_slack(self) -> None:
+        registry = MCPRegistry()
+        server = registry.register_from_catalog("slack")
+        assert server.spec.name == "slack"
+        tool_names = [t.name for t in server.tools]
+        assert "send_message" in tool_names
+
+    def test_catalog_registration_with_org(self) -> None:
+        registry = MCPRegistry()
+        server = registry.register_from_catalog("github", org_id="acme-corp")
+        assert server.org_id == "acme-corp"
+
+    def test_catalog_registration_with_env_overrides(self) -> None:
+        registry = MCPRegistry()
+        server = registry.register_from_catalog(
+            "github", env_overrides={"CUSTOM_VAR": "custom_value"}
+        )
+        assert server.spec.env == {"CUSTOM_VAR": "custom_value"}
+
+    def test_catalog_unknown_name_raises(self) -> None:
+        registry = MCPRegistry()
+        with pytest.raises(ValueError, match="Unknown MCP server"):
+            registry.register_from_catalog("nonexistent-server")
+
+    def test_catalog_unknown_name_lists_available(self) -> None:
+        registry = MCPRegistry()
+        with pytest.raises(ValueError, match="github") as exc_info:
+            registry.register_from_catalog("bogus")
+        assert "Available:" in str(exc_info.value)
+
+    def test_catalog_secrets_propagated(self) -> None:
+        registry = MCPRegistry()
+        server = registry.register_from_catalog("github")
+        assert "GITHUB_PERSONAL_ACCESS_TOKEN" in server.spec.secrets
+
+
+# ── Known server tool attachment ─────────────────────────────────────
+
+
+class TestKnownServerToolAttachment:
+    def test_known_server_gets_tools_on_register(self) -> None:
+        """Registering a spec whose name matches a catalog entry gets pre-discovered tools."""
+        registry = MCPRegistry()
+        spec = MCPServerSpec(
+            name="github",
+            image="ghcr.io/modelcontextprotocol/server-github:latest",
+        )
+        server = registry.register(spec)
+        assert len(server.tools) == len(KNOWN_MCP_SERVERS["github"]["known_tools"])
+
+    def test_unknown_server_gets_no_tools(self) -> None:
+        registry = MCPRegistry()
+        spec = _allowed_spec("custom-tool")
+        server = registry.register(spec)
+        assert server.tools == []
+
+
+# ── Listing and filtering ────────────────────────────────────────────
+
+
+class TestListAll:
+    def test_list_empty_registry(self) -> None:
+        registry = MCPRegistry()
+        assert registry.list_all() == []
+
+    def test_list_all_returns_all(self) -> None:
+        registry = MCPRegistry()
+        registry.register(_allowed_spec("a"))
+        registry.register(_allowed_spec("b"))
+        registry.register(_allowed_spec("c"))
+        assert len(registry.list_all()) == 3
+
+    def test_list_filtered_by_org(self) -> None:
+        registry = MCPRegistry()
+        registry.register(_allowed_spec("a"), org_id="org-1")
+        registry.register(_allowed_spec("b"), org_id="org-2")
+        registry.register(_allowed_spec("c"), org_id="org-1")
+        org1 = registry.list_all(org_id="org-1")
+        assert len(org1) == 2
+        assert all(s.org_id == "org-1" for s in org1)
+
+    def test_list_filtered_org_includes_global(self) -> None:
+        """Servers with empty org_id are visible to all orgs."""
+        registry = MCPRegistry()
+        registry.register(_allowed_spec("global"))  # no org_id
+        registry.register(_allowed_spec("scoped"), org_id="org-x")
+        visible = registry.list_all(org_id="org-x")
+        names = {s.spec.name for s in visible}
+        assert "global" in names
+        assert "scoped" in names
+
+    def test_list_no_filter_returns_all_orgs(self) -> None:
+        registry = MCPRegistry()
+        registry.register(_allowed_spec("a"), org_id="org-1")
+        registry.register(_allowed_spec("b"), org_id="org-2")
+        assert len(registry.list_all()) == 2
+
+
+# ── Get ──────────────────────────────────────────────────────────────
+
+
+class TestGet:
+    def test_get_existing(self) -> None:
+        registry = MCPRegistry()
+        registry.register(_allowed_spec("exists"))
+        assert registry.get("exists") is not None
+
+    def test_get_nonexistent(self) -> None:
+        registry = MCPRegistry()
+        assert registry.get("nope") is None
+
+
+# ── Remove ───────────────────────────────────────────────────────────
+
+
+class TestRemove:
+    def test_remove_existing(self) -> None:
+        registry = MCPRegistry()
+        registry.register(_allowed_spec("to-remove"))
+        removed = registry.remove("to-remove")
+        assert removed is not None
+        assert removed.spec.name == "to-remove"
+        assert registry.get("to-remove") is None
+
+    def test_remove_nonexistent(self) -> None:
+        registry = MCPRegistry()
+        assert registry.remove("ghost") is None
+
+
+# ── Catalog listing ──────────────────────────────────────────────────
+
+
+class TestCatalog:
+    def test_catalog_lists_all_known_servers(self) -> None:
+        registry = MCPRegistry()
+        entries = registry.catalog()
+        names = {e["name"] for e in entries}
+        assert names == set(KNOWN_MCP_SERVERS.keys())
+
+    def test_catalog_shows_not_installed(self) -> None:
+        registry = MCPRegistry()
+        entries = registry.catalog()
+        for entry in entries:
+            assert entry["installed"] is False
+            assert entry["status"] == "available"
+
+    def test_catalog_shows_installed(self) -> None:
+        registry = MCPRegistry()
+        registry.register_from_catalog("github")
+        entries = registry.catalog()
+        github_entry = next(e for e in entries if e["name"] == "github")
+        assert github_entry["installed"] is True
+        assert github_entry["status"] == MCPServerStatus.PENDING.value
+
+    def test_catalog_entry_fields(self) -> None:
+        registry = MCPRegistry()
+        entries = registry.catalog()
+        for entry in entries:
+            assert "name" in entry
+            assert "image" in entry
+            assert "description" in entry
+            assert "author" in entry
+            assert "trust_tier" in entry
+            assert "tool_count" in entry
+            assert isinstance(entry["tool_count"], int)
+            assert entry["tool_count"] > 0
+
+    def test_catalog_tool_counts_match_known(self) -> None:
+        registry = MCPRegistry()
+        entries = registry.catalog()
+        for entry in entries:
+            name = entry["name"]
+            expected = len(KNOWN_MCP_SERVERS[name].get("known_tools", []))
+            assert entry["tool_count"] == expected
+
+
+# ── Status updates ───────────────────────────────────────────────────
+
+
+class TestUpdateStatus:
+    def test_update_status_running(self) -> None:
+        registry = MCPRegistry()
+        registry.register(_allowed_spec("srv"))
+        registry.update_status("srv", MCPServerStatus.RUNNING)
+        server = registry.get("srv")
+        assert server is not None
+        assert server.status == MCPServerStatus.RUNNING
+
+    def test_update_status_failed_with_error(self) -> None:
+        registry = MCPRegistry()
+        registry.register(_allowed_spec("srv"))
+        registry.update_status("srv", MCPServerStatus.FAILED, error="CrashLoopBackOff")
+        server = registry.get("srv")
+        assert server is not None
+        assert server.status == MCPServerStatus.FAILED
+        assert server.error == "CrashLoopBackOff"
+
+    def test_update_status_nonexistent_is_noop(self) -> None:
+        """Updating status on a non-existent server does not raise."""
+        registry = MCPRegistry()
+        registry.update_status("ghost", MCPServerStatus.RUNNING)
+        # No exception — just a no-op
+
+    def test_status_transitions(self) -> None:
+        registry = MCPRegistry()
+        registry.register(_allowed_spec("lifecycle"))
+        server = registry.get("lifecycle")
+        assert server is not None
+        assert server.status.value == "pending"
+
+        registry.update_status("lifecycle", MCPServerStatus.DEPLOYING)
+        assert server.status.value == "deploying"
+
+        registry.update_status("lifecycle", MCPServerStatus.RUNNING)
+        assert server.status.value == "running"
+
+        registry.update_status("lifecycle", MCPServerStatus.STOPPED)
+        assert server.status.value == "stopped"
+
+        registry.update_status("lifecycle", MCPServerStatus.REMOVED)
+        assert server.status.value == "removed"
+
+
+# ── K8s-safe naming ──────────────────────────────────────────────────
+
+
+class TestK8sNaming:
+    def test_k8s_name_basic(self) -> None:
+        registry = MCPRegistry()
+        server = registry.register(_allowed_spec("github"))
+        assert server.k8s_name == "mcp-github"
+
+    def test_k8s_name_underscores_to_hyphens(self) -> None:
+        registry = MCPRegistry()
+        server = registry.register(_allowed_spec("my_custom_server"))
+        assert "_" not in server.k8s_name
+        assert server.k8s_name == "mcp-my-custom-server"
+
+    def test_k8s_name_lowercase(self) -> None:
+        registry = MCPRegistry()
+        server = registry.register(_allowed_spec("MyServer"))
+        assert server.k8s_name == server.k8s_name.lower()
+
+    def test_k8s_name_truncated_at_63(self) -> None:
+        long_name = "a" * 100
+        registry = MCPRegistry()
+        server = registry.register(_allowed_spec(long_name))
+        assert len(server.k8s_name) <= 63
+
+
+# ── MCPServer.to_dict ────────────────────────────────────────────────
+
+
+class TestServerToDict:
+    def test_to_dict_fields(self) -> None:
+        registry = MCPRegistry()
+        server = registry.register_from_catalog("github", org_id="org-99")
+        d = server.to_dict()
+        assert d["name"] == "github"
+        assert d["source_type"] == "managed"
+        assert d["status"] == "pending"
+        assert d["transport"] == "sse"
+        assert d["port"] == 3000
+        assert d["trust_tier"] == "t2"
+        assert d["org_id"] == "org-99"
+        assert d["tool_count"] == len(server.tools)
+        assert isinstance(d["tools"], list)
+        assert len(d["tools"]) > 0
+        assert "name" in d["tools"][0]
+        assert "description" in d["tools"][0]
+
+    def test_to_dict_empty_tools(self) -> None:
+        registry = MCPRegistry()
+        server = registry.register(_allowed_spec("custom"))
+        d = server.to_dict()
+        assert d["tools"] == []
+        assert d["tool_count"] == 0
+
+
+# ── KNOWN_MCP_SERVERS catalog integrity ──────────────────────────────
+
+
+class TestKnownMCPServers:
+    def test_all_known_servers_have_required_fields(self) -> None:
+        for name, entry in KNOWN_MCP_SERVERS.items():
+            assert "image" in entry, f"{name} missing image"
+            assert "description" in entry, f"{name} missing description"
+            assert "port" in entry, f"{name} missing port"
+            assert "trust_tier" in entry, f"{name} missing trust_tier"
+            assert "known_tools" in entry, f"{name} missing known_tools"
+            assert len(entry["known_tools"]) > 0, f"{name} has no known_tools"
+
+    def test_all_known_images_pass_allow_list(self) -> None:
+        """Every image in the catalog must pass the registry allow-list."""
+        registry = MCPRegistry()
+        for name in KNOWN_MCP_SERVERS:
+            # Should not raise
+            server = registry.register_from_catalog(name)
+            assert server.spec.name == name
+
+    def test_known_server_count(self) -> None:
+        """Catalog has exactly 4 known servers (github, filesystem, postgres, slack)."""
+        assert len(KNOWN_MCP_SERVERS) == 4
+        assert set(KNOWN_MCP_SERVERS.keys()) == {"github", "filesystem", "postgres", "slack"}
+
+
+# ── MCPServerSpec defaults ───────────────────────────────────────────
+
+
+class TestMCPServerSpecDefaults:
+    def test_default_transport_is_sse(self) -> None:
+        spec = MCPServerSpec(name="x", image="ghcr.io/modelcontextprotocol/test:v1")
+        assert spec.transport == MCPTransport.SSE
+
+    def test_default_port_is_3000(self) -> None:
+        spec = MCPServerSpec(name="x", image="ghcr.io/modelcontextprotocol/test:v1")
+        assert spec.port == 3000
+
+    def test_default_trust_tier_is_t3(self) -> None:
+        spec = MCPServerSpec(name="x", image="ghcr.io/modelcontextprotocol/test:v1")
+        assert spec.trust_tier == "t3"
+
+    def test_resource_limits_defaults(self) -> None:
+        limits = MCPResourceLimits()
+        assert limits.cpu_limit == "500m"
+        assert limits.memory_limit == "256Mi"
+        assert limits.cpu_request == "100m"
+        assert limits.memory_request == "64Mi"


### PR DESCRIPTION
23 tests: soul priority, promoted/matched learning injection, budget enforcement, org isolation, empty inputs, existing system messages.