### PR TITLE
feat: routing explanation API with debug endpoint

### DIFF
--- a/src/stronghold/api/app.py
+++ b/src/stronghold/api/app.py
@@ -126,6 +126,7 @@ def create_app() -> FastAPI:
     from stronghold.api.routes.auth import router as auth_router
     from stronghold.api.routes.chat import router as chat_router
     from stronghold.api.routes.dashboard import router as dashboard_router
+    from stronghold.api.routes.debug import router as debug_router
     from stronghold.api.routes.gate_endpoint import router as gate_router
     from stronghold.api.routes.marketplace import router as marketplace_router
     from stronghold.api.routes.mcp import router as mcp_router
@@ -152,6 +153,7 @@ def create_app() -> FastAPI:
     app.include_router(skills_router)
     app.include_router(sessions_router)
     app.include_router(admin_router)
+    app.include_router(debug_router)
     app.include_router(profile_router)
     app.include_router(marketplace_router)
     app.include_router(traces_router)

--- a/src/stronghold/api/routes/debug.py
+++ b/src/stronghold/api/routes/debug.py
@@ -1,0 +1,123 @@
+"""Debug endpoints — routing dry-run and diagnostics."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from fastapi import APIRouter, HTTPException, Request
+from fastapi.responses import JSONResponse
+
+from stronghold.router.explainer import explain_candidates, explain_selection
+from stronghold.types.model import ModelConfig, ProviderConfig
+
+logger = logging.getLogger("stronghold.api.debug")
+
+router = APIRouter()
+
+
+async def _require_admin(request: Request) -> Any:
+    """Authenticate and require admin role."""
+    container = request.app.state.container
+    auth_header = request.headers.get("authorization")
+    try:
+        auth = await container.auth_provider.authenticate(
+            auth_header, headers=dict(request.headers)
+        )
+    except ValueError as e:
+        raise HTTPException(status_code=401, detail=str(e)) from e
+    if not auth.has_role("admin"):
+        raise HTTPException(status_code=403, detail="Admin role required")
+    return auth
+
+
+@router.post("/v1/stronghold/debug/route-explain")
+async def route_explain(request: Request) -> JSONResponse:
+    """Dry-run classification + routing. Returns what WOULD happen.
+
+    Does NOT dispatch to an agent — purely diagnostic.
+
+    Body:
+        messages: list of {role, content} dicts
+        intent_hint: optional string to override classification
+
+    Response:
+        intent: classification result
+        candidates: scored candidate breakdown
+        decision: selected model id
+        explanation: human-readable summary
+    """
+    await _require_admin(request)
+
+    container = request.app.state.container
+    body = await request.json()
+    messages: list[dict[str, Any]] = body.get("messages", [])
+    intent_hint: str = body.get("intent_hint", "")
+
+    # ── 1. Classify intent ──
+    if intent_hint and intent_hint in container.config.task_types:
+        from stronghold.types.intent import Intent
+
+        user_text = ""
+        for m in reversed(messages):
+            if m.get("role") == "user":
+                user_text = str(m.get("content", ""))
+                break
+        intent = Intent(
+            task_type=intent_hint,
+            classified_by="hint",
+            user_text=user_text,
+        )
+    else:
+        intent = await container.classifier.classify(messages, container.config.task_types)
+
+    # ── 2. Model selection ──
+    _prov_fields = {f.name for f in ProviderConfig.__dataclass_fields__.values()}
+    providers: dict[str, ProviderConfig] = {
+        k: ProviderConfig(**{fk: fv for fk, fv in v.items() if fk in _prov_fields})
+        if isinstance(v, dict)
+        else v
+        for k, v in container.config.providers.items()
+    }
+
+    _model_fields = {f.name for f in ModelConfig.__dataclass_fields__.values()}
+    models: dict[str, ModelConfig] = {
+        k: ModelConfig(**{fk: fv for fk, fv in v.items() if fk in _model_fields})
+        if isinstance(v, dict)
+        else v
+        for k, v in container.config.models.items()
+    }
+
+    try:
+        selection = container.router.select(intent, models, providers, container.config.routing)
+    except Exception:
+        logger.warning("Router selection failed in debug endpoint", exc_info=True)
+        selection = None
+
+    # ── 3. Build explanation ──
+    if selection is not None:
+        explanation = explain_selection(selection, intent)
+        candidates = explain_candidates(selection, intent)
+        decision = selection.model_id
+    else:
+        explanation = (
+            f"{intent.task_type.capitalize()} task detected. "
+            "No model could be selected — routing failed."
+        )
+        candidates = []
+        decision = "none"
+
+    return JSONResponse(
+        content={
+            "intent": {
+                "task_type": intent.task_type,
+                "complexity": intent.complexity,
+                "priority": intent.priority,
+                "classified_by": intent.classified_by,
+                "keyword_score": intent.keyword_score,
+            },
+            "candidates": candidates,
+            "decision": decision,
+            "explanation": explanation,
+        }
+    )

--- a/src/stronghold/conduit.py
+++ b/src/stronghold/conduit.py
@@ -19,6 +19,7 @@ import asyncio
 import logging
 from typing import TYPE_CHECKING, Any
 
+from stronghold.router.explainer import explain_selection
 from stronghold.types.model import ModelConfig, ProviderConfig
 from stronghold.types.reactor import Event
 
@@ -616,6 +617,11 @@ class Conduit:
             )
         )
 
+        # Build routing explanation
+        explanation = (
+            explain_selection(selection, intent) if selection else "Fallback routing used."
+        )
+
         return self._build_response(
             response_id=f"stronghold-{intent.task_type}",
             model=model_to_use,
@@ -630,6 +636,7 @@ class Conduit:
                 "model": model_to_use,
                 "agent": agent.identity.name,
                 "reason": selection.reason if selection else "default",
+                "explanation": explanation,
             },
             include_usage=True,
         )

--- a/src/stronghold/router/explainer.py
+++ b/src/stronghold/router/explainer.py
@@ -1,0 +1,132 @@
+"""Human-readable routing explanations."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from stronghold.types.intent import Intent
+    from stronghold.types.model import ModelSelection
+
+
+def explain_selection(selection: ModelSelection, intent: Intent) -> str:
+    """Generate a 1-2 sentence explanation of why this model was selected.
+
+    Handles both normal selections (with candidates) and fallback selections
+    (no candidates, score=0).
+    """
+    # Fallback path — no candidates scored
+    if not selection.candidates:
+        return (
+            f"{intent.task_type.capitalize()} task detected "
+            f"(classified by {intent.classified_by}). "
+            f"Fallback to {selection.model_id} — no models matched routing filters."
+        )
+
+    best = selection.candidates[0]
+
+    # Build classification context
+    classification_note = f"keyword score {intent.keyword_score}"
+    if intent.classified_by == "llm":
+        classification_note = "LLM classification"
+    elif intent.classified_by == "hint":
+        classification_note = "explicit hint"
+
+    # Build advantage description
+    advantages: list[str] = []
+    advantages.append(f"quality {best.quality}")
+    if best.tier:
+        advantages.append(f"{best.tier} tier")
+    if best.usage_pct < 0.5:
+        advantages.append("low quota usage")
+
+    advantage_str = ", ".join(advantages)
+
+    summary = (
+        f"{intent.task_type.capitalize()} task detected ({classification_note}). "
+        f"{selection.model_id} selected: {advantage_str}."
+    )
+
+    # Mention runner-up if there are multiple candidates
+    if len(selection.candidates) > 1:
+        runner = selection.candidates[1]
+        gap = round(best.score - runner.score, 4)
+        summary += f" Runner-up: {runner.model_id} (score gap {gap})."
+
+    return summary
+
+
+def explain_candidates(
+    selection: ModelSelection,
+    intent: Intent,
+) -> list[dict[str, Any]]:
+    """Generate detailed breakdown of all candidates and their scores.
+
+    Returns a list of dicts, one per candidate, each containing:
+    - model: the model_id
+    - score: the computed score
+    - selected: whether this candidate was chosen
+    - tier: the model tier
+    - quality: adjusted quality
+    - effective_cost: cost after scarcity adjustments
+    - usage_pct: current quota usage percentage
+    - reasons: list of human-readable reason strings
+    """
+    if not selection.candidates:
+        return []
+
+    result: list[dict[str, Any]] = []
+    best_id = selection.model_id
+
+    for candidate in selection.candidates:
+        reasons: list[str] = []
+
+        # Quality assessment
+        if candidate.quality >= 0.8:
+            reasons.append("high quality model")
+        elif candidate.quality >= 0.5:
+            reasons.append("moderate quality")
+        else:
+            reasons.append("lower quality")
+
+        # Tier info
+        reasons.append(f"{candidate.tier} tier")
+
+        # Cost assessment
+        if candidate.effective_cost < 0.001:
+            reasons.append("very low cost")
+        elif candidate.effective_cost < 0.01:
+            reasons.append("moderate cost")
+        else:
+            reasons.append("higher cost")
+
+        # Quota headroom
+        if candidate.usage_pct < 0.3:
+            reasons.append("plenty of quota remaining")
+        elif candidate.usage_pct < 0.7:
+            reasons.append("moderate quota usage")
+        else:
+            reasons.append("high quota usage")
+
+        # Selection outcome
+        is_selected = candidate.model_id == best_id
+        if is_selected:
+            reasons.append(f"SELECTED (score {candidate.score})")
+        else:
+            gap = round(selection.score - candidate.score, 4)
+            reasons.append(f"not selected (score gap {gap} vs winner)")
+
+        result.append(
+            {
+                "model": candidate.model_id,
+                "score": candidate.score,
+                "selected": is_selected,
+                "tier": candidate.tier,
+                "quality": candidate.quality,
+                "effective_cost": candidate.effective_cost,
+                "usage_pct": candidate.usage_pct,
+                "reasons": reasons,
+            }
+        )
+
+    return result

--- a/tests/api/test_debug_route.py
+++ b/tests/api/test_debug_route.py
@@ -1,0 +1,241 @@
+"""Tests for the debug route-explain endpoint.
+
+POST /v1/stronghold/debug/route-explain
+Dry-run classification + routing without dispatching to an agent.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from stronghold.agents.base import Agent
+from stronghold.agents.context_builder import ContextBuilder
+from stronghold.agents.intents import IntentRegistry
+from stronghold.agents.strategies.direct import DirectStrategy
+from stronghold.api.routes.debug import router as debug_router
+from stronghold.classifier.engine import ClassifierEngine
+from stronghold.container import Container
+from stronghold.memory.learnings.extractor import ToolCorrectionExtractor
+from stronghold.memory.learnings.store import InMemoryLearningStore
+from stronghold.memory.outcomes import InMemoryOutcomeStore
+from stronghold.prompts.store import InMemoryPromptManager
+from stronghold.quota.tracker import InMemoryQuotaTracker
+from stronghold.router.selector import RouterEngine
+from stronghold.security.auth_static import StaticKeyAuthProvider
+from stronghold.security.gate import Gate
+from stronghold.security.sentinel.audit import InMemoryAuditLog
+from stronghold.security.sentinel.policy import Sentinel
+from stronghold.security.warden.detector import Warden
+from stronghold.sessions.store import InMemorySessionStore
+from stronghold.tools.executor import ToolDispatcher
+from stronghold.tools.registry import InMemoryToolRegistry
+from stronghold.tracing.noop import NoopTracingBackend
+from stronghold.types.agent import AgentIdentity
+from stronghold.types.auth import PermissionTable
+from stronghold.types.config import StrongholdConfig, TaskTypeConfig
+from tests.fakes import FakeAuthProvider, FakeLLMClient
+
+
+@pytest.fixture
+def debug_app() -> FastAPI:
+    """Create a FastAPI app with the debug route and a real container."""
+    app = FastAPI()
+    app.include_router(debug_router)
+
+    fake_llm = FakeLLMClient()
+    fake_llm.set_simple_response("ok")
+
+    config = StrongholdConfig(
+        providers={
+            "test": {"status": "active", "billing_cycle": "monthly", "free_tokens": 1000000000},
+        },
+        models={
+            "test-model": {
+                "provider": "test",
+                "litellm_id": "test/model",
+                "tier": "medium",
+                "quality": 0.7,
+                "speed": 500,
+                "strengths": ["code", "chat"],
+            },
+        },
+        task_types={
+            "chat": TaskTypeConfig(keywords=["hello"], preferred_strengths=["chat"]),
+            "code": TaskTypeConfig(
+                keywords=["code", "function", "bug"],
+                min_tier="medium",
+                preferred_strengths=["code"],
+            ),
+        },
+        permissions={"admin": ["*"], "user": ["web_search"]},
+        router_api_key="sk-test",
+    )
+
+    prompts = InMemoryPromptManager()
+    warden = Warden()
+    context_builder = ContextBuilder()
+    audit_log = InMemoryAuditLog()
+
+    async def setup() -> Container:
+        await prompts.upsert("agent.arbiter.soul", "You are helpful.", label="production")
+
+        default_agent = Agent(
+            identity=AgentIdentity(
+                name="arbiter",
+                soul_prompt_name="agent.arbiter.soul",
+                model="test/model",
+            ),
+            strategy=DirectStrategy(),
+            llm=fake_llm,
+            context_builder=context_builder,
+            prompt_manager=prompts,
+            warden=warden,
+        )
+
+        return Container(
+            config=config,
+            auth_provider=StaticKeyAuthProvider(api_key="sk-test"),
+            permission_table=PermissionTable.from_config({"admin": ["*"]}),
+            router=RouterEngine(InMemoryQuotaTracker()),
+            classifier=ClassifierEngine(),
+            quota_tracker=InMemoryQuotaTracker(),
+            prompt_manager=prompts,
+            learning_store=InMemoryLearningStore(),
+            learning_extractor=ToolCorrectionExtractor(),
+            outcome_store=InMemoryOutcomeStore(),
+            session_store=InMemorySessionStore(),
+            audit_log=audit_log,
+            warden=warden,
+            gate=Gate(warden=warden),
+            sentinel=Sentinel(
+                warden=warden,
+                permission_table=PermissionTable.from_config(config.permissions),
+                audit_log=audit_log,
+            ),
+            tracer=NoopTracingBackend(),
+            context_builder=context_builder,
+            intent_registry=IntentRegistry(),
+            llm=fake_llm,
+            tool_registry=InMemoryToolRegistry(),
+            tool_dispatcher=ToolDispatcher(InMemoryToolRegistry()),
+            agents={"arbiter": default_agent},
+        )
+
+    container = asyncio.get_event_loop().run_until_complete(setup())
+    app.state.container = container
+    return app
+
+
+class TestDebugRouteExplain:
+    """Tests for POST /v1/stronghold/debug/route-explain."""
+
+    def test_returns_200_with_explanation(self, debug_app: FastAPI) -> None:
+        with TestClient(debug_app) as client:
+            resp = client.post(
+                "/v1/stronghold/debug/route-explain",
+                json={
+                    "messages": [{"role": "user", "content": "Write a function to sort a list"}],
+                },
+                headers={"Authorization": "Bearer sk-test"},
+            )
+            assert resp.status_code == 200
+            data = resp.json()
+            assert "intent" in data
+            assert "explanation" in data
+            assert "candidates" in data
+            assert "decision" in data
+
+    def test_returns_intent_details(self, debug_app: FastAPI) -> None:
+        with TestClient(debug_app) as client:
+            resp = client.post(
+                "/v1/stronghold/debug/route-explain",
+                json={
+                    "messages": [{"role": "user", "content": "Write a function to sort a list"}],
+                },
+                headers={"Authorization": "Bearer sk-test"},
+            )
+            data = resp.json()
+            intent = data["intent"]
+            assert "task_type" in intent
+            assert "complexity" in intent
+            assert "classified_by" in intent
+
+    def test_intent_hint_overrides_classification(self, debug_app: FastAPI) -> None:
+        with TestClient(debug_app) as client:
+            resp = client.post(
+                "/v1/stronghold/debug/route-explain",
+                json={
+                    "messages": [{"role": "user", "content": "hello"}],
+                    "intent_hint": "code",
+                },
+                headers={"Authorization": "Bearer sk-test"},
+            )
+            data = resp.json()
+            assert data["intent"]["task_type"] == "code"
+
+    def test_requires_admin_auth_401(self, debug_app: FastAPI) -> None:
+        """Missing auth header returns 401."""
+        with TestClient(debug_app) as client:
+            resp = client.post(
+                "/v1/stronghold/debug/route-explain",
+                json={
+                    "messages": [{"role": "user", "content": "hello"}],
+                },
+            )
+            assert resp.status_code == 401
+
+    def test_requires_admin_role_403(self, debug_app: FastAPI) -> None:
+        """Non-admin user gets 403."""
+        # Reconfigure auth to return a non-admin user
+        container = debug_app.state.container
+        from stronghold.types.auth import AuthContext
+
+        non_admin = AuthContext(
+            user_id="user1",
+            username="regular",
+            roles=frozenset({"user"}),
+            auth_method="api_key",
+        )
+
+        container.auth_provider = FakeAuthProvider(auth_context=non_admin)  # type: ignore[assignment]
+
+        with TestClient(debug_app) as client:
+            resp = client.post(
+                "/v1/stronghold/debug/route-explain",
+                json={
+                    "messages": [{"role": "user", "content": "hello"}],
+                },
+                headers={"Authorization": "Bearer fake-token"},
+            )
+            assert resp.status_code == 403
+
+    def test_explanation_is_nonempty_string(self, debug_app: FastAPI) -> None:
+        with TestClient(debug_app) as client:
+            resp = client.post(
+                "/v1/stronghold/debug/route-explain",
+                json={
+                    "messages": [{"role": "user", "content": "Fix the bug in my code"}],
+                },
+                headers={"Authorization": "Bearer sk-test"},
+            )
+            data = resp.json()
+            assert isinstance(data["explanation"], str)
+            assert len(data["explanation"]) > 0
+
+    def test_candidates_have_scores(self, debug_app: FastAPI) -> None:
+        with TestClient(debug_app) as client:
+            resp = client.post(
+                "/v1/stronghold/debug/route-explain",
+                json={
+                    "messages": [{"role": "user", "content": "hello"}],
+                },
+                headers={"Authorization": "Bearer sk-test"},
+            )
+            data = resp.json()
+            for cand in data["candidates"]:
+                assert "model" in cand
+                assert "score" in cand

--- a/tests/routing/test_explainer.py
+++ b/tests/routing/test_explainer.py
@@ -1,0 +1,174 @@
+"""Tests for routing explanation API.
+
+Verifies that explain_selection() and explain_candidates() produce
+human-readable routing explanations and candidate breakdowns.
+"""
+
+from __future__ import annotations
+
+from stronghold.router.explainer import explain_candidates, explain_selection
+from stronghold.types.model import ModelCandidate, ModelSelection
+from tests.factories import build_intent
+
+
+def _make_candidates() -> tuple[ModelCandidate, ...]:
+    """Build a realistic set of scored candidates."""
+    return (
+        ModelCandidate(
+            model_id="mistral-large",
+            litellm_id="azure/mistral-large",
+            provider="azure",
+            score=0.85,
+            quality=0.68,
+            effective_cost=0.002,
+            usage_pct=0.30,
+            tier="frontier",
+        ),
+        ModelCandidate(
+            model_id="gpt-4o",
+            litellm_id="openai/gpt-4o",
+            provider="openai",
+            score=0.72,
+            quality=0.75,
+            effective_cost=0.005,
+            usage_pct=0.60,
+            tier="frontier",
+        ),
+        ModelCandidate(
+            model_id="claude-sonnet",
+            litellm_id="anthropic/claude-sonnet",
+            provider="anthropic",
+            score=0.55,
+            quality=0.60,
+            effective_cost=0.004,
+            usage_pct=0.45,
+            tier="large",
+        ),
+    )
+
+
+def _make_selection(candidates: tuple[ModelCandidate, ...] | None = None) -> ModelSelection:
+    """Build a ModelSelection with candidates."""
+    cands = candidates or _make_candidates()
+    best = cands[0]
+    return ModelSelection(
+        model_id=best.model_id,
+        litellm_id=best.litellm_id,
+        provider=best.provider,
+        score=best.score,
+        reason="task=code; complexity=moderate; priority=normal",
+        candidates=cands,
+    )
+
+
+class TestExplainSelection:
+    """Tests for explain_selection()."""
+
+    def test_returns_nonempty_string(self) -> None:
+        selection = _make_selection()
+        intent = build_intent(task_type="code", keyword_score=4.2)
+        result = explain_selection(selection, intent)
+        assert isinstance(result, str)
+        assert len(result) > 0
+
+    def test_mentions_task_type(self) -> None:
+        selection = _make_selection()
+        intent = build_intent(task_type="code", keyword_score=4.2)
+        result = explain_selection(selection, intent)
+        assert "code" in result.lower()
+
+    def test_mentions_selected_model(self) -> None:
+        selection = _make_selection()
+        intent = build_intent(task_type="code", keyword_score=4.2)
+        result = explain_selection(selection, intent)
+        assert "mistral-large" in result.lower()
+
+    def test_handles_none_selection(self) -> None:
+        """When selection is the fallback path (no candidates), still produces output."""
+        fallback = ModelSelection(
+            model_id="auto",
+            litellm_id="auto",
+            provider="unknown",
+            score=0.0,
+            reason="fallback — no models matched filters",
+            candidates=(),
+        )
+        intent = build_intent(task_type="chat")
+        result = explain_selection(fallback, intent)
+        assert isinstance(result, str)
+        assert len(result) > 0
+        assert "fallback" in result.lower()
+
+    def test_mentions_classification_method(self) -> None:
+        selection = _make_selection()
+        intent = build_intent(task_type="code", classified_by="keywords", keyword_score=4.5)
+        result = explain_selection(selection, intent)
+        assert "keyword" in result.lower()
+
+    def test_mentions_runner_up_when_close(self) -> None:
+        """When there are multiple candidates, mention the runner-up."""
+        selection = _make_selection()
+        intent = build_intent(task_type="code")
+        result = explain_selection(selection, intent)
+        # Should mention the runner-up model since there are multiple candidates
+        assert "gpt-4o" in result.lower()
+
+    def test_single_candidate_no_runner_up(self) -> None:
+        """With only one candidate, no runner-up is mentioned."""
+        single = _make_candidates()[:1]
+        selection = _make_selection(candidates=single)
+        intent = build_intent(task_type="chat")
+        result = explain_selection(selection, intent)
+        assert "gpt-4o" not in result.lower()
+
+
+class TestExplainCandidates:
+    """Tests for explain_candidates()."""
+
+    def test_returns_list(self) -> None:
+        selection = _make_selection()
+        intent = build_intent(task_type="code")
+        result = explain_candidates(selection, intent)
+        assert isinstance(result, list)
+
+    def test_lists_all_candidates(self) -> None:
+        selection = _make_selection()
+        intent = build_intent(task_type="code")
+        result = explain_candidates(selection, intent)
+        assert len(result) == 3
+        model_ids = [c["model"] for c in result]
+        assert "mistral-large" in model_ids
+        assert "gpt-4o" in model_ids
+        assert "claude-sonnet" in model_ids
+
+    def test_each_candidate_has_score_and_reasons(self) -> None:
+        selection = _make_selection()
+        intent = build_intent(task_type="code")
+        result = explain_candidates(selection, intent)
+        for candidate in result:
+            assert "model" in candidate
+            assert "score" in candidate
+            assert "reasons" in candidate
+            assert isinstance(candidate["reasons"], list)
+            assert len(candidate["reasons"]) > 0
+
+    def test_winner_is_marked(self) -> None:
+        selection = _make_selection()
+        intent = build_intent(task_type="code")
+        result = explain_candidates(selection, intent)
+        assert result[0]["selected"] is True
+        assert result[1]["selected"] is False
+
+    def test_empty_candidates(self) -> None:
+        """Fallback selection with no candidates returns empty list."""
+        fallback = ModelSelection(
+            model_id="auto",
+            litellm_id="auto",
+            provider="unknown",
+            score=0.0,
+            reason="fallback",
+            candidates=(),
+        )
+        intent = build_intent(task_type="chat")
+        result = explain_candidates(fallback, intent)
+        assert result == []


### PR DESCRIPTION
## Summary
- Adds \`explain_selection()\` / \`explain_candidates()\` in \`router/explainer.py\` — human-readable 1–2 sentence explanations of why a model was picked
- Adds admin-only \`POST /v1/stronghold/debug/route-explain\` endpoint for dry-run classification + routing without dispatching to an agent
- Wires \`explain_selection()\` into Conduit so every response carries an \`explanation\` field in \`_routing\` metadata
- 19 new tests (12 explainer + 7 debug route) covering happy paths, fallbacks, and admin auth

## Provenance
Salvaged from #173, which targeted the now-retired \`develop\` branch and was contaminated with ~80 \`.claude/worktrees/agent-*\` files that made a clean rebase impossible. The 6 useful files have been cherry-picked onto a fresh branch off \`main\`.

## Test plan
- [x] \`pytest tests/routing/test_explainer.py tests/api/test_debug_route.py\` — 19 passed
- [x] \`ruff check\` / \`ruff format\` clean
- [x] \`mypy --strict\` clean on touched files
- [x] \`bandit -ll\` clean
- [x] Full \`pytest tests/\` — only pre-existing main failures (e2e tests needing phoenix, github tool needing network); none introduced by this PR