### PR TITLE
chore(docs): scrub customer/vendor names from BACKLOG.md and ARCHITECTURE.md

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -601,8 +601,8 @@ Every external dependency behind a protocol interface. Implementations are swapp
 
 | Protocol | Methods | Current Impl | Swap Target |
 |----------|---------|-------------|-------------|
-| `ModelProxy` | complete(), stream(), list_models() | LiteLLM | Archestra, direct provider SDKs |
-| `ToolGateway` | list_tools(), call_tool(), register_*() | LiteLLM MCP gateway | Archestra, Kong, standalone |
+| `ModelProxy` | complete(), stream(), list_models() | LiteLLM | direct provider SDKs, alternative gateways |
+| `ToolGateway` | list_tools(), call_tool(), register_*() | LiteLLM MCP gateway | Kong, alternative MCP gateways, standalone |
 | `AuthProvider` | authenticate() | Keycloak, Entra ID | Any OIDC provider |
 | `PromptManager` | get(), get_with_config(), upsert() | PostgreSQL (stronghold.prompts) | Langfuse (legacy adapter) |
 | `TracingBackend` | create_trace() → Trace, Span | Arize Enterprise | Phoenix, PostgreSQL, noop |

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -476,7 +476,7 @@ class AuthProvider(Protocol):
 | Provider | Use Case | Claims |
 |----------|----------|--------|
 | Keycloak OIDC | Homelab, open-source default | realm_access.roles |
-| Entra ID | Enterprise (JedAI) | roles (app roles) |
+| Entra ID | Enterprise (Microsoft-shop customers) | roles (app roles) |
 | Static API key | Service-to-service, backward compat | Maps to system admin context |
 | OpenWebUI headers | Thin client passthrough | X-OpenWebUI-User-* headers |
 

--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -134,7 +134,7 @@ bypass all application-level security controls.
 
 - [ ] **R20: Container reaches host SSH via Docker gateway** — from inside the stronghold container, `172.17.0.1:22` (Docker default gateway = host) is reachable. Combined with R1 (privileged mode), an attacker with code execution in the container can SSH to the host. **Fix:** R1 fix (remove privileged) eliminates the worst case; additionally consider Docker network isolation (`internal: true` on stronghold network). (`docker-compose.yml:176-180`)
 
-- [ ] **R21: Forged JWT enables cross-tenant agent visibility** — forged Disney org JWT could see ALL agents including T0 builtins from `agent-stronghold` org. Confirms C1 from code audit is exploitable. Created `disney-spy` agent as forged Disney admin. **Cross-ref:** C1, C2, C3 in code audit. (`api/routes/agents.py`)
+- [ ] **R21: Forged JWT enables cross-tenant agent visibility** — a forged JWT for an arbitrary `org_id` could see ALL agents including T0 builtins from the `agent-stronghold` org. Confirms C1 from code audit is exploitable. The red team created a spoof-org admin agent via this path. **Cross-ref:** C1, C2, C3 in code audit. (`api/routes/agents.py`)
 
 - [ ] **R22: Strikes not persisted (in-memory only)** — `InMemoryStrikeTracker` stores all strike data in a Python dict. Container restart (maintenance, deployment, OOM-kill, `docker compose restart`) clears ALL strikes and lockouts. Attacker can trigger 2 strikes → get locked → wait for restart → get 2 more free strikes → infinite cycle. Lockouts have zero durability. **Fix:** persist strikes to PostgreSQL (add `strikes` table). Load on startup, write on every violation. (`security/strikes.py`)
 


### PR DESCRIPTION
## Summary
- Replaces customer-name references in BACKLOG.md R21 (Forged JWT entry) with generic spoof-org phrasing
- Replaces enterprise customer name in ARCHITECTURE.md auth row
- Replaces vendor product name in ARCHITECTURE.md protocol interface swap-target column

## Why
Clean-room provenance discipline: the docs should not name specific upstream projects, customers, or competitor products. References should describe the *capability* or *category*, not the specific brand. Both commits are docs-only with no code or behavior changes.

## Test plan
- [x] No code changes — no tests to run
- [x] Forbidden-strings sweep returns zero matches on tracked files in this branch
- [x] Reviewer spot-checks the two diffs to confirm meaning is preserved