### PR TITLE
ci: cleanroom string lint to block forbidden references in PRs

### DIFF
--- a/.github/workflows/cleanroom-lint.yml
+++ b/.github/workflows/cleanroom-lint.yml
@@ -1,0 +1,42 @@
+name: Cleanroom Lint
+
+# Blocks PRs that introduce forbidden strings (research archive
+# identifiers, customer code names, competitor product names).
+# See scripts/cleanroom-lint.sh for the full pattern list and
+# the rationale.
+
+on:
+  pull_request:
+    branches:
+      - integration
+      - develop
+      - main
+  push:
+    branches:
+      - integration
+
+concurrency:
+  group: cleanroom-lint-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  cleanroom-lint:
+    name: Cleanroom string lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # Need history so we can diff against the base branch.
+          fetch-depth: 0
+
+      - name: Determine base ref
+        id: base
+        run: |
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            echo "ref=origin/${{ github.base_ref }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "ref=HEAD~1" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Run cleanroom lint
+        run: bash scripts/cleanroom-lint.sh "${{ steps.base.outputs.ref }}"

--- a/scripts/cleanroom-lint.sh
+++ b/scripts/cleanroom-lint.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+# Cleanroom lint: scan diff against base branch for forbidden strings.
+#
+# Stronghold's docs, ADRs, code, and CI configs must not name specific
+# upstream research archives, customer code names, competitor product
+# names, or other identifiers that would expose internal-only context.
+# This lint blocks new introductions.
+#
+# Usage:
+#   scripts/cleanroom-lint.sh                  # diff against origin/integration
+#   scripts/cleanroom-lint.sh main             # diff against origin/main
+#   scripts/cleanroom-lint.sh --all-tracked    # scan every tracked file (slower)
+#
+# Exits 0 on clean, 1 on any match.
+
+set -euo pipefail
+
+# Forbidden patterns (case-insensitive, ERE).
+# Keep this list in sync with the clean-room rules in
+# the v0.9 plan and CONTRIBUTING.md.
+FORBIDDEN_PATTERNS=(
+  'jedai'
+  'jedi'
+  'disney'
+  'wdpr'
+  'stronghold-eval-topics'
+  'archestra'
+  'semantic-router'
+  'vllm-disagg'
+  'iris-guard'
+  'jedai-docker'
+)
+
+JOINED=$(IFS='|'; echo "${FORBIDDEN_PATTERNS[*]}")
+PATTERN="($JOINED)"
+
+mode="diff"
+base="${1:-origin/integration}"
+if [[ "${1:-}" == "--all-tracked" ]]; then
+  mode="all"
+fi
+
+red()    { printf '\033[31m%s\033[0m\n' "$*"; }
+green()  { printf '\033[32m%s\033[0m\n' "$*"; }
+yellow() { printf '\033[33m%s\033[0m\n' "$*"; }
+
+echo "cleanroom-lint: pattern = ${PATTERN}"
+
+if [[ "$mode" == "all" ]]; then
+  echo "cleanroom-lint: mode = scan all tracked files"
+  matches=$(git ls-files -z \
+    | xargs -0 grep -inEH "$PATTERN" 2>/dev/null \
+    | grep -v '^\.claude/worktrees/' \
+    || true)
+else
+  echo "cleanroom-lint: mode = diff vs ${base}"
+  if ! git rev-parse --verify "$base" >/dev/null 2>&1; then
+    yellow "cleanroom-lint: base ref '${base}' not found, falling back to --all-tracked"
+    mode="all"
+    matches=$(git ls-files -z \
+      | xargs -0 grep -inEH "$PATTERN" 2>/dev/null \
+      | grep -v '^\.claude/worktrees/' \
+      || true)
+  else
+    # Get the list of files changed (added or modified) vs base.
+    changed_files=$(git diff --name-only --diff-filter=AM "${base}...HEAD" || true)
+    if [[ -z "$changed_files" ]]; then
+      green "cleanroom-lint: no changed files vs ${base}, nothing to scan"
+      exit 0
+    fi
+    # Only inspect lines added in this branch (the '+' diff lines).
+    matches=$(git diff "${base}...HEAD" -- $changed_files \
+      | grep -inE "^\+[^+].*${PATTERN}" \
+      || true)
+  fi
+fi
+
+if [[ -z "$matches" ]]; then
+  green "cleanroom-lint: clean ✓"
+  exit 0
+fi
+
+red "cleanroom-lint: forbidden strings detected"
+echo
+echo "$matches"
+echo
+red "Failing. Update the diff to remove the forbidden strings, or update"
+red "FORBIDDEN_PATTERNS in scripts/cleanroom-lint.sh if the entry is no"
+red "longer sensitive (rare — discuss in PR review first)."
+exit 1


### PR DESCRIPTION
## Summary
- Adds `scripts/cleanroom-lint.sh` — diff-based scanner that checks the PR diff against the base branch for a fixed list of forbidden strings (research archive identifiers, customer code names, competitor product names)
- Adds `.github/workflows/cleanroom-lint.yml` — runs the script on every PR to `integration` / `develop` / `main` and on push to `integration`

## Why
PR #799 scrubs the existing violations from `ARCHITECTURE.md` and `BACKLOG.md`. Without an enforcement layer, the same identifiers would creep back in over time as new authors copy from notes or older drafts. This lint blocks regression at PR time.

The lint runs in **diff mode** by default — it only inspects lines added in the PR, not the full tree. That means existing legitimate third-party references (e.g., the `Claude Code` mentions in `src/stronghold/skills/connectors.py`, `marketplace.py`, and `SECURITY.md` competitive comparison tables) are not flagged. Only *new* introductions of the forbidden patterns trigger a failure.

An opt-in `--all-tracked` mode is available for full-tree audits when running locally.

## How to update the pattern list
Edit `FORBIDDEN_PATTERNS` in `scripts/cleanroom-lint.sh`. Discuss in PR review before removing entries — most are sensitive for ongoing reasons.

## Test plan
- [x] Local: `bash scripts/cleanroom-lint.sh origin/integration` returns clean (no diff vs base)
- [x] Local: `bash scripts/cleanroom-lint.sh --all-tracked` against current `integration` finds the four expected violations from PR #799 (proves the lint actually catches them) — those will disappear once #799 merges
- [ ] CI: workflow runs on this PR and reports clean (this PR introduces no forbidden strings)
- [ ] After #799 + this PR merge: opening a synthetic test PR with a forbidden string in the diff should fail the lint