### PR TITLE
fix(quartermaster): bump agentic decomposition cap from 10 to 25 (PR-Q6)

### DIFF
--- a/src/stronghold/builders/pipeline.py
+++ b/src/stronghold/builders/pipeline.py
@@ -2128,11 +2128,22 @@ class RuntimePipeline:
                 summary=f"Triage: {strategy} produced no steps",
             )
 
-        # Enumerable strategies are uncapped; agentic capped at 10
-        if strategy == "agentic" and len(steps) > 10:
+        # Enumerable strategies are uncapped; agentic capped at 25.
+        # The cap exists because LLM decompositions tend to either over-split
+        # (50 trivial steps) or under-split (3 huge steps); the cap is a
+        # heuristic ceiling that says "if you produced more than this, your
+        # parent epic is genuinely too broad and a human should split it
+        # first." 25 fits real-world v0.9 epics like 'populate priority_tier
+        # in 15+ agent.yaml files'; the prior 10 was rejecting them as
+        # 'too broad' when they were actually correctly enumerated.
+        AGENTIC_CAP = 25
+        if strategy == "agentic" and len(steps) > AGENTIC_CAP:
             return StageResult(
                 success=False,
-                summary=f"Too many steps ({len(steps)}) — parent is too broad",
+                summary=(
+                    f"Too many steps ({len(steps)} > {AGENTIC_CAP}) — "
+                    f"parent is too broad. Split it into narrower epics first."
+                ),
             )
 
         # Hard safety cap to prevent runaway issue creation


### PR DESCRIPTION
## Summary
Bumps `AGENTIC_CAP` in `RuntimePipeline.decompose_issue` from **10** to **25**.

The agentic strategy was hard-rejecting any decomposition with more than 10 steps as "parent too broad". 10 turned out to be too tight for real-world v0.9 epics: an epic that genuinely enumerates 15-20 atomic file edits (e.g., "populate priority_tier in 15+ agent.yaml files") gets rejected even though it's correctly decomposed.

## Why 25 specifically
- Still meaningful as a ceiling — if your epic truly produces >25 steps, it's almost certainly too broad and a human should split it first
- Covers the real-world v0.9 epic shapes (largest legitimate one we hit was 22 steps for the original combined PR-Agent-Tier #810)
- Leaves room for the LLM to slightly over-split without false-failing
- Far below the 100-step hard safety cap that catches runaway decompositions

## What changed
- `pipeline.py:2131` — cap is now `AGENTIC_CAP = 25` (named constant for future tuning)
- `pipeline.py:2135` — failure message now includes the actual cap value and a remediation hint ("split it into narrower epics first")
- Comment block above the cap explains *why* the cap exists

## Verification
**Manual** (after the container rebuilds with this change):

\`\`\`bash
# Re-decompose the originally-failing #810 (closed but still queryable)
curl -s -X POST -H 'Authorization: Bearer \$STRONGHOLD_KEY' \\
  -H 'Content-Type: application/json' \\
  -d '{"repo_url":"https://github.com/Agent-StrongHold/stronghold","issue_number":810}' \\
  http://localhost:8100/v1/stronghold/builders/decompose
\`\`\`

Should return \`success: true\` instead of the prior \`Too many steps (22) — parent is too broad\`.

## Test plan
- [x] No new unit tests added — the change is a constant value and the surrounding code path has no precedent for unit tests (the pipeline internals are exercised through orchestration tests, not direct mocks). Adding mock-heavy tests just for this constant would set a new precedent disproportionate to the change.
- [ ] Container rebuilt and the manual verification above runs green
- [ ] Re-decompose of #902 (which Quartermaster only emitted 10 of 15 sub-issues for) produces all 15 after the cap bump

## Out of scope
- Long-term: replacing the hard cap with a "warn and continue" pattern (emit sub-issues anyway, label parent `quartermaster:over-cap`). Worth doing as a follow-up but not in this 1-line fix.