### PR TITLE
fix(builders): post stage failures to GitHub issue (PR-Q7)

### DIFF
--- a/src/stronghold/api/routes/builders.py
+++ b/src/stronghold/api/routes/builders.py
@@ -1101,6 +1101,85 @@ async def _post_auditor_verdict_to_issue(
     )
 
 
+async def _post_stage_failure_to_issue(
+    container: Any,
+    owner: str,
+    repo: str,
+    issue_number: int,
+    run_id: str,
+    stage: str,
+    attempt: int,
+    *,
+    failure_kind: str,
+    summary: str,
+    traceback_text: str = "",
+) -> None:
+    """Post a stage-handler failure as a GitHub issue comment.
+
+    The previous behaviour swallowed handler failures into stderr only,
+    which left the issue's comment trail showing the prior approved
+    stage followed by 'BLOCKED, waiting for human guidance' with zero
+    diagnostic context. This helper makes the failure visible on the
+    issue itself so operators can see *why* a run stalled without
+    needing container log access.
+
+    failure_kind is one of:
+      - 'handler_returned_failure': handler returned StageResult(success=False)
+      - 'handler_exception':        handler raised an unhandled exception
+    """
+    # Truncate to keep GitHub comments readable. The full text is in
+    # container stderr if anyone needs the long form.
+    summary_excerpt = summary[:1500] if summary else "(no summary)"
+    body_parts = [
+        f"## Stage `{stage}` failed (attempt {attempt})",
+        "",
+        f"**Failure kind:** `{failure_kind}`",
+        f"**Run id:** `{run_id}`",
+        "",
+        "### Summary",
+        "",
+        summary_excerpt,
+    ]
+    if traceback_text:
+        body_parts += [
+            "",
+            "### Traceback",
+            "",
+            "```",
+            traceback_text[:2000],
+            "```",
+        ]
+    body_parts += [
+        "",
+        "---",
+        (
+            "_The Builders pipeline will retry from `acceptance_defined` "
+            "on the next outer loop. If this failure repeats across all "
+            "outer loops the run will exit BLOCKED and wait for human "
+            "guidance — see the comments above for the failure history._"
+        ),
+    ]
+    comment_body = "\n".join(body_parts)
+    try:
+        await container.tool_dispatcher.execute(
+            "github",
+            {
+                "action": "post_pr_comment",
+                "owner": owner,
+                "repo": repo,
+                "issue_number": issue_number,
+                "body": comment_body,
+            },
+        )
+    except Exception as e:
+        # Best-effort posting — never let a comment failure mask the
+        # original stage failure.
+        logger.warning(
+            "Failed to post stage-failure comment for run %s stage %s: %s",
+            run_id, stage, e,
+        )
+
+
 _STAGE_REQUIREMENTS: dict[str, str] = {
     "issue_analyzed": (
         "Must provide: 1) Clear problem statement, 2) List of requirements, "
@@ -1218,19 +1297,35 @@ async def _execute_one_stage(run_id: str, orch: Any, container: Any, service_aut
         print(f"[BUILDERS] Stage {stage} attempt {attempt}/{MAX_STAGE_RETRIES} for run {run_id}", flush=True)
 
         # 1. Runtime executes the stage — pass Auditor feedback from prior rejection
+        failure_kind: str | None = None
+        failure_traceback: str = ""
         try:
             handler = getattr(pipeline, handler_name)
             result = await handler(run, feedback=auditor_feedback)
             print(f"[BUILDERS] Stage {stage} result: success={result.success}, summary={result.summary[:200]}", flush=True)
         except Exception as e:
             import traceback
-            tb = traceback.format_exc()
-            print(f"[BUILDERS] Pipeline {stage} EXCEPTION: {e}\n{tb}", flush=True)
+            failure_traceback = traceback.format_exc()
+            print(f"[BUILDERS] Pipeline {stage} EXCEPTION: {e}\n{failure_traceback}", flush=True)
             result = None
+            failure_kind = "handler_exception"
 
         if result is None or not result.success:
             summary = result.summary if result else f"Stage {stage} failed"
             logger.error("Stage %s failed: %s", stage, summary)
+            if failure_kind is None:
+                failure_kind = "handler_returned_failure"
+            # Make the failure visible on the GitHub issue. Without this
+            # the issue's comment trail jumps from the previous stage's
+            # auditor verdict directly to "BLOCKED, waiting for human"
+            # with no diagnostic context.
+            await _post_stage_failure_to_issue(
+                container, owner, repo_name, run.issue_number,
+                run_id, stage, attempt,
+                failure_kind=failure_kind,
+                summary=summary,
+                traceback_text=failure_traceback,
+            )
             break
 
         # 2. Auditor reviews concrete evidence (stage-aware prompt)


### PR DESCRIPTION
## Summary
Adds visibility for Mason stage handler failures by posting a comment to the GitHub issue when `_execute_one_stage` hits the silent-failure path. Previously these failures were logged to container stderr only, leaving the issue's comment trail with no diagnostic context.

## The bug this fixes
On issues #490, #491, #492, #498 (all four currently in `failed_issues` on the live scheduler), the issue's comment trail looks like:

\`\`\`
[02:19:51] Auditor Review: issue_analyzed APPROVED
[02:20:05] Auditor Review: acceptance_defined APPROVED
[02:22:26] Auditor Review: acceptance_defined APPROVED
[02:27:23] Auditor Review: acceptance_defined APPROVED
[02:32:02] Builders: Waiting for human guidance — 3 outer loops exhausted
\`\`\`

It looks like Mason's pipeline is stuck on \`acceptance_defined\` somehow. **It isn't.** Reading container logs reveals that \`tests_written\` actually runs after each \`acceptance_defined\` approval, fails silently (returns \`success=False\` from the TDD handler), and the outer loop quietly resets to \`acceptance_defined\` and re-runs. Concrete root cause for #498:

\`\`\`
ModuleNotFoundError: No module named 'stronghold.api.routes.optimization'
\`\`\`

Mason wrote the test file but never created the module the test imports. None of this is visible from the issue itself.

## What changed
- New \`_post_stage_failure_to_issue\` helper next to the existing \`_post_auditor_verdict_to_issue\`. Posts a comment with the failure kind (\`handler_returned_failure\` vs \`handler_exception\`), the failure summary (truncated to 1500 chars), and the traceback (when applicable, truncated to 2000 chars). Best-effort: wraps the github call in its own try/except so a comment failure never masks the original stage failure.
- \`_execute_one_stage\` failure path now captures \`failure_kind\` and \`failure_traceback\` on locals, then calls the helper before breaking out of the attempt loop.
- Stage *rejections* by the Auditor are unchanged — those already flow through \`_post_auditor_verdict_to_issue\` with a \`CHANGES_REQUESTED\` verdict that's visible on the issue.

## What this PR does NOT fix
This is **Bug 1 of 4** identified in the orchestrator investigation. The remaining three are filed as follow-ups and are out of scope here:

- **Bug 2**: TDD impl phase can't create new module files (cause of the silent failures on #490..#498). The ImplPhase iterates over \`affected_files\` which only contains *existing* files; new modules from \`Files to create\` sections in issue bodies aren't picked up.
- **Bug 3**: no per-call retry on transient \`httpcore.ReadTimeout\` from model providers. 24h logs show 4 occurrences. Currently the outer loop retries the *whole pipeline* including re-running Frank, which is wasteful.
- **Bug 4**: outer-loop retry strategy is wrong for both failure modes. \"Reset to acceptance_defined and re-run Frank\" doesn't address either Mason's inability to make tests pass OR transient model timeouts.

Bug 1 is the prerequisite for diagnosing 2/3/4 without container log access, which is why it ships first. After this lands and the container rebuilds, the next time #498 (or similar) re-runs, the failure comment will surface the ModuleNotFoundError directly on the issue and Bugs 2-4 become much easier to triage.

## Test plan
- [x] Syntax check: \`python3 -c 'import ast; ast.parse(open(\"src/stronghold/api/routes/builders.py\").read())'\` clean
- [ ] Container rebuilt with this change
- [ ] Re-trigger #498 (or any failing issue) via \`POST /v1/stronghold/builders/runs\`; verify a stage-failure comment appears on the issue when \`tests_written\` fails
- [ ] Verify the failure comment includes the actual ModuleNotFoundError traceback (not just \"Stage tests_written failed\")
- [ ] Verify Auditor rejections still post normally (no double-posting of the same failure)

## Out of scope
No tests added — there is no precedent for unit tests on \`_execute_one_stage\` (it's exercised through the orchestration end-to-end tests, not direct mocks). Adding mock-heavy tests just for this comment-posting helper would set a new precedent disproportionate to the change. Verification is via the rebuild + re-trigger above.