### PR TITLE
fix(builders): read '## Files' section from issue body to drive impl phase (PR-Q8)

### DIFF
--- a/src/stronghold/builders/pipeline.py
+++ b/src/stronghold/builders/pipeline.py
@@ -655,6 +655,27 @@ class RuntimePipeline:
             prompt, self._frank_model, extract_json, "issue analysis",
         )
 
+        # Source-of-truth merge: if the issue body has an explicit
+        # '## Files' section (Quartermaster decompositions and well-
+        # formed human sub-issues do), trust those over Frank's LLM
+        # guess. The LLM tends to hallucinate plausible-but-wrong
+        # paths for "create new module" issues, picking an existing
+        # file that *sounds* related instead of the actual new module
+        # the issue body asks for. Files declared in the body are
+        # preferred; LLM-suggested files are appended if they don't
+        # collide.
+        body_files = self._extract_files_from_issue_body(issue_content)
+        if body_files:
+            llm_files = analysis.get("affected_files", []) or []
+            merged: list[str] = list(body_files)
+            for f in llm_files:
+                if f and f not in merged:
+                    merged.append(f)
+            analysis["affected_files"] = merged
+            analysis["affected_files_source"] = "issue_body" if not llm_files else "issue_body+llm"
+        else:
+            analysis.setdefault("affected_files_source", "llm")
+
         # Post to issue
         summary = (
             f"## Issue Analysis\n\n"
@@ -663,7 +684,8 @@ class RuntimePipeline:
             + "\n".join(f"- {r}" for r in analysis.get("requirements", []))
             + "\n\n**Edge Cases:**\n"
             + "\n".join(f"- {e}" for e in analysis.get("edge_cases", []))
-            + f"\n\n**Affected Files:** {', '.join(analysis.get('affected_files', []))}\n\n"
+            + f"\n\n**Affected Files** (source: {analysis.get('affected_files_source', 'llm')}):"
+            f" {', '.join(analysis.get('affected_files', []))}\n\n"
             f"**Approach:** {analysis.get('approach', '')}\n"
         )
 
@@ -792,11 +814,20 @@ class RuntimePipeline:
         criteria = getattr(run, "_criteria", [])
         locked_criteria: set[int] = getattr(run, "_locked_criteria", set())
         analysis = getattr(run, "_analysis", {})
-        affected_files = analysis.get("affected_files", [])
+        affected_files = list(analysis.get("affected_files", []) or [])
         issue_content = getattr(run, "_issue_content", "")
 
         if not criteria:
             return StageResult(success=False, summary="No acceptance criteria found")
+
+        # Belt-and-suspenders: even if Frank's analysis didn't carry
+        # the files forward, parse the issue body's '## Files' section
+        # directly. This catches issues where analyze_issue ran on an
+        # older code path or the analysis dict was lost across stages.
+        body_files = self._extract_files_from_issue_body(issue_content)
+        for bf in body_files:
+            if bf and bf not in affected_files:
+                affected_files.append(bf)
 
         # Resolve affected source file
         if not affected_files:
@@ -2811,4 +2842,57 @@ class RuntimePipeline:
             path = match.group(1)
             if path not in paths:
                 paths.append(path)
+        return paths
+
+    @staticmethod
+    def _extract_files_from_issue_body(issue_body: str) -> list[str]:
+        """Extract file paths from a Quartermaster-style '## Files' section.
+
+        Quartermaster decompositions and other well-formed sub-issues
+        include an explicit list of files that should be created or
+        modified, as a markdown bullet list under a '## Files' header
+        (sometimes '## Files to create' or '## Files to modify').
+
+        Example issue body fragment::
+
+            ## Files
+            - src/stronghold/analytics/suggestions.py
+            - src/stronghold/api/routes/optimization.py
+            - tests/api/test_optimization.py
+
+        Returns the list of paths in document order, deduplicated.
+        Returns [] if no '## Files' section is present.
+
+        This is the source of truth for the implementation pipeline:
+        if Quartermaster (or a human author) said the issue requires
+        these files, the impl phase must create them. Frank's LLM
+        guess at affected_files is secondary and may hallucinate
+        existing-but-wrong paths.
+        """
+        import re
+
+        match = re.search(
+            r"^##\s+Files(?:\s+to\s+(?:create|modify|change))?\s*\n"
+            r"((?:[ \t]*[-*][ \t]+\S.*\n?)+)",
+            issue_body,
+            re.MULTILINE | re.IGNORECASE,
+        )
+        if not match:
+            return []
+
+        block = match.group(1)
+        paths: list[str] = []
+        for line in block.splitlines():
+            line = line.strip()
+            if not line.startswith(("-", "*")):
+                continue
+            # Strip the bullet marker, surrounding backticks, and any
+            # trailing inline annotation like " (new)" or " — desc".
+            entry = line.lstrip("-*").strip().strip("`").strip()
+            # Stop at the first whitespace so trailing prose doesn't
+            # get glued to the path.
+            entry = entry.split()[0] if entry else ""
+            entry = entry.strip("`,;")
+            if entry and entry not in paths:
+                paths.append(entry)
         return paths

--- a/tests/builders/core/test_extract_files_from_issue_body.py
+++ b/tests/builders/core/test_extract_files_from_issue_body.py
@@ -1,0 +1,113 @@
+from __future__ import annotations
+
+import pytest
+
+from stronghold.builders.pipeline import RuntimePipeline
+
+
+def test_quartermaster_single_file_section() -> None:
+    body = (
+        "## Description\n"
+        "Create the optimization suggestions system.\n"
+        "\n"
+        "## Acceptance Criteria\n"
+        "- [ ] Class CostOptimizer\n"
+        "\n"
+        "## Files\n"
+        "- src/stronghold/analytics/suggestions.py\n"
+        "\n"
+        "---\n"
+        "_Sub-issue of #136, step 7 of 10_\n"
+    )
+    assert RuntimePipeline._extract_files_from_issue_body(body) == [
+        "src/stronghold/analytics/suggestions.py",
+    ]
+
+
+def test_multiple_files_in_order() -> None:
+    body = (
+        "## Files\n"
+        "- src/stronghold/agents/warden_at_arms/agent.yaml\n"
+        "- tests/agents/test_warden_at_arms.py\n"
+    )
+    assert RuntimePipeline._extract_files_from_issue_body(body) == [
+        "src/stronghold/agents/warden_at_arms/agent.yaml",
+        "tests/agents/test_warden_at_arms.py",
+    ]
+
+
+def test_returns_empty_list_when_no_files_section() -> None:
+    body = "## Description\nrandom prose.\n\n## Acceptance Criteria\n- thing\n"
+    assert RuntimePipeline._extract_files_from_issue_body(body) == []
+
+
+def test_alternate_header_files_to_create() -> None:
+    body = "## Files to create\n- src/stronghold/foo.py\n- src/stronghold/bar.py\n"
+    assert RuntimePipeline._extract_files_from_issue_body(body) == [
+        "src/stronghold/foo.py",
+        "src/stronghold/bar.py",
+    ]
+
+
+def test_alternate_header_files_to_modify() -> None:
+    body = "## Files to modify\n- src/stronghold/api/routes/status.py\n"
+    assert RuntimePipeline._extract_files_from_issue_body(body) == [
+        "src/stronghold/api/routes/status.py",
+    ]
+
+
+def test_strips_backticks_and_trailing_prose() -> None:
+    body = (
+        "## Files\n"
+        "- `src/stronghold/baz.py`  (new module)\n"
+        "- src/stronghold/qux.py — adds helper\n"
+    )
+    assert RuntimePipeline._extract_files_from_issue_body(body) == [
+        "src/stronghold/baz.py",
+        "src/stronghold/qux.py",
+    ]
+
+
+def test_supports_mixed_bullet_styles() -> None:
+    body = (
+        "## Files\n"
+        "* src/stronghold/api/routes/optimization.py\n"
+        "- src/stronghold/api/routes/status.py\n"
+    )
+    assert RuntimePipeline._extract_files_from_issue_body(body) == [
+        "src/stronghold/api/routes/optimization.py",
+        "src/stronghold/api/routes/status.py",
+    ]
+
+
+def test_deduplicates_repeated_paths() -> None:
+    body = (
+        "## Files\n"
+        "- src/stronghold/foo.py\n"
+        "- src/stronghold/bar.py\n"
+        "- src/stronghold/foo.py\n"
+    )
+    assert RuntimePipeline._extract_files_from_issue_body(body) == [
+        "src/stronghold/foo.py",
+        "src/stronghold/bar.py",
+    ]
+
+
+def test_case_insensitive_header() -> None:
+    body = "## FILES\n- src/stronghold/foo.py\n"
+    assert RuntimePipeline._extract_files_from_issue_body(body) == [
+        "src/stronghold/foo.py",
+    ]
+
+
+def test_ignores_files_section_buried_inside_prose() -> None:
+    """A '## Files' header that has no bullet list immediately under it
+    should not match — we only care about Quartermaster-style structured
+    file lists, not casual prose mentions of files.
+    """
+    body = (
+        "## Files\n"
+        "\n"
+        "We'll figure out the file structure later.\n"
+    )
+    assert RuntimePipeline._extract_files_from_issue_body(body) == []


### PR DESCRIPTION
## Summary
Bug 2 from the orchestrator investigation. The TDD impl phase iterates over `analysis['affected_files']` which is populated by Frank's LLM guess at *which existing file* should be modified. For issues that require **creating** a new module — most v0.9 sub-issues, plus the 4+ already-stuck issues #490/#491/#492/#498 — the LLM hallucinates an existing file that sounds related instead of the actual new module the issue body asks for.

This PR makes the impl phase read the explicit `## Files` markdown section from the issue body and use it as the source of truth, with the LLM's guess as a secondary input.

## Concrete evidence

Issue **#498 (\"Implement optimization suggestions engine\")** literally contains:

\`\`\`markdown
## Files
- src/stronghold/analytics/suggestions.py
\`\`\`

But the pipeline never read it. Frank's LLM guessed \`src/stronghold/api/routes/optimization.py\`, the impl phase rewrote that wrong file forever, the test imported a third wrong module, every test errored with \`ModuleNotFoundError: No module named 'stronghold.api.routes.optimization'\`, \`final_passing == 0\`, the handler returned \`success=False\`, the outer loop reset to \`acceptance_defined\` and retried — for hours.

PR-Q7 (#930) made this failure visible on the issue. PR-Q8 (this PR) fixes the actual root cause.

## What changed

**1. New helper `RuntimePipeline._extract_files_from_issue_body`**

Static method, regex-parses \`## Files\` / \`## Files to create\` / \`## Files to modify\` markdown sections from the issue body and returns the list of paths in document order, deduplicated, with backticks and trailing prose stripped. Pure function, easy to unit test.

**2. \`analyze_issue()\` merges body files into the analysis**

After the LLM produces its analysis JSON, body-declared files are prepended to \`analysis['affected_files']\` (LLM-suggested files are appended only if they don't collide). The summary comment posted to the issue now includes a \`source\` tag (\`issue_body\` / \`issue_body+llm\` / \`llm\`) so reviewers can see where the file list came from.

**3. \`write_tests_and_implement()\` does belt-and-suspenders parsing**

In case Frank's analysis dict was somehow lost across stages (older runs, retries, restart races), the impl phase parses the issue body directly and appends any new files to \`affected_files\`. Defense in depth: if either Frank's pass OR the impl pass reads the body, the right files get created.

**4. New unit test file: \`tests/builders/core/test_extract_files_from_issue_body.py\`**

10 cases, all pass (verified locally):

- Single file (Quartermaster format)
- Multiple files preserved in order
- Returns \`[]\` when no \`## Files\` section
- Alternate header \`## Files to create\`
- Alternate header \`## Files to modify\`
- Strips backticks and trailing prose ('— adds helper', '(new module)')
- Mixed bullet styles (\`*\` and \`-\`)
- Deduplicates repeated paths
- Case-insensitive header (\`## FILES\`)
- Negative case: \`## Files\` followed by prose instead of bullets is correctly skipped

## Test plan

- [x] 10 new unit tests pass: \`PYTHONPATH=src pytest tests/builders/core/test_extract_files_from_issue_body.py -v\`
- [x] \`pipeline.py\` syntax-checks clean
- [x] Local helper invocation against #498's actual issue body returns the correct path (\`src/stronghold/analytics/suggestions.py\`)
- [ ] Container rebuilt with this change
- [ ] Re-trigger #498 (or any of #490, #491, #492, the new #812..#925 sub-issues) and verify the impl phase now creates the expected file instead of hallucinating an existing one
- [ ] Verify #498's issue analysis comment shows \`Affected Files (source: issue_body): src/stronghold/analytics/suggestions.py\`

## Why this is the highest-leverage fix in the queue

Every one of the 100+ new v0.9 sub-issues I queued tonight (#812..#925) has a Quartermaster-generated \`## Files\` section. **Without this fix, all 100+ would dispatch into Mason and fail with the same Bug 2 pattern.** With this fix, they should dispatch and succeed (modulo Bug 3 transient timeouts which are independent).

## Out of scope (filed as follow-ups)

- **Bug 3**: per-call retry-with-backoff on transient \`httpcore.ReadTimeout\` inside \`_llm_call\`. Real evidence from #606's first attempt today, but independent of Bug 2.
- **Bug 4**: outer-loop retry strategy (resetting to \`acceptance_defined\` on every failure) is wrong for both modes. Q8 removes the dominant trigger so the outer loop becomes meaningfully less wasteful even without changing its logic.
- **Q7.5 polish**: \`handler_exception\` failure comment summary should include \`str(exception)\` (currently it's just \"Stage X failed\"; the traceback IS captured below it).