### PR TITLE
feat: #770 — Define AgentPodProtocol interface

### DIFF
--- a/src/stronghold/protocols/agent_pod.py
+++ b/src/stronghold/protocols/agent_pod.py
@@ -1,0 +1,128 @@
+"""Agent pod discovery, registration, and spawning protocol.
+
+The per-tenant per-user agent pod model is described in ARCHITECTURE.md §9
+and in the operator notes for issue #371. This module defines the seam
+between callers (the routing layer, the arbiter, the spawner client) and
+the concrete K8s-backed discovery service that lives at
+``stronghold.agent_pod.discovery.AgentPodDiscovery``.
+
+Two protocols live here:
+
+- ``AgentPodDiscovery`` — find / register / unregister pods. Issue #373.
+- ``AgentPodSpawner`` — extend later in #374 to add ``spawn_user_pod`` and
+  cleanup methods. Defined in this file (rather than its own) per the
+  operator notes on #774, which call out that the spawner extends the
+  same protocol surface so callers don't have to import two modules.
+
+The K8s label selector is the source of truth. Redis is a cache. Pod
+identity is ``(tenant_id, user_id, agent_type)``; ``pod_name`` is included
+in registration/unregistration calls so the discovery service can detect
+generation skew when a pod is recreated under the same identity.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Protocol, runtime_checkable
+
+
+@dataclass(frozen=True)
+class AgentPodInfo:
+    """Snapshot of a discovered agent pod.
+
+    Returned by ``AgentPodDiscovery.get_user_pod``. ``ip`` is the pod IP
+    suitable for direct addressing (Stronghold uses pod IPs from
+    discovery, not service-level load balancing). ``generation`` is a
+    monotonic counter the discovery service bumps every time a pod is
+    re-registered for the same identity, so callers can detect that the
+    pod they were addressing has been recreated.
+    """
+
+    ip: str
+    generation: int
+    pod_name: str
+
+
+@runtime_checkable
+class AgentPodDiscovery(Protocol):
+    """Discover and track per-tenant per-user agent pods.
+
+    Implementations are expected to be safe to call concurrently. The
+    contract intentionally does NOT promise persistence beyond the
+    process — the K8s label selector is the source of truth. Caches
+    (Redis, in-memory) are the implementation's business.
+    """
+
+    async def get_user_pod(
+        self,
+        tenant_id: str,
+        user_id: str,
+        agent_type: str,
+    ) -> AgentPodInfo | None:
+        """Find the pod currently serving this (tenant, user, agent_type).
+
+        Returns ``None`` if no pod is registered. The discovery service
+        SHOULD attempt a K8s label query on cache miss before returning
+        ``None``, so callers can treat ``None`` as authoritative.
+
+        Args:
+            tenant_id: Tenant slug per the namespace naming in
+                ADR-K8S-001 (``stronghold-tenant-{slug}``).
+            user_id: Stable user identifier.
+            agent_type: Agent role (e.g. ``"mason"``, ``"davinci"``).
+
+        Returns:
+            ``AgentPodInfo`` if a pod is registered, ``None`` otherwise.
+
+        Raises:
+            PermissionError: Cedar PDP (#700) denied tenant-scoped
+                discovery — i.e. a caller in tenant A asked about a pod
+                in tenant B. Tenant-isolation invariant.
+        """
+        ...
+
+    async def register_pod(
+        self,
+        tenant_id: str,
+        user_id: str,
+        agent_type: str,
+        pod_name: str,
+        ip: str,
+        generation: int,
+    ) -> None:
+        """Record a freshly-spawned pod in the discovery service.
+
+        Idempotent within a single ``generation``. Re-registering the
+        same identity with a *higher* generation replaces the prior
+        entry; a *lower* generation is a no-op so out-of-order callbacks
+        from the spawner can't roll back the live mapping.
+
+        Raises:
+            PermissionError: Cedar denied write access for this tenant.
+        """
+        ...
+
+    async def unregister_pod(
+        self,
+        tenant_id: str,
+        user_id: str,
+        agent_type: str,
+        pod_name: str,
+    ) -> None:
+        """Drop the discovery entry for this pod.
+
+        ``pod_name`` is required so the watcher's pod-deletion callback
+        can avoid evicting an entry that has already been replaced by a
+        re-registration with the same identity but a different pod_name.
+
+        Raises:
+            PermissionError: Cedar denied write access for this tenant.
+        """
+        ...
+
+    async def close(self) -> None:
+        """Release any background watchers, sockets, or pooled connections.
+
+        Idempotent. Safe to call multiple times.
+        """
+        ...

--- a/tests/agent_pod/test_protocol.py
+++ b/tests/agent_pod/test_protocol.py
@@ -1,0 +1,173 @@
+"""Tests for the AgentPodDiscovery protocol contract via FakeAgentPodDiscovery.
+
+These tests pin the contract every concrete discovery implementation must
+satisfy, including the tenant-isolation invariants and the
+generation-skew rules that protect against out-of-order spawner callbacks.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from stronghold.protocols.agent_pod import AgentPodDiscovery, AgentPodInfo
+from tests.fakes import FakeAgentPodDiscovery
+
+
+class TestAgentPodInfo:
+    def test_fields(self) -> None:
+        info = AgentPodInfo(ip="10.0.0.1", generation=3, pod_name="mason-abc")
+        assert info.ip == "10.0.0.1"
+        assert info.generation == 3
+        assert info.pod_name == "mason-abc"
+
+    def test_frozen(self) -> None:
+        info = AgentPodInfo(ip="10.0.0.1", generation=1, pod_name="mason-abc")
+        with pytest.raises(AttributeError):
+            info.ip = "10.0.0.2"  # type: ignore[misc]
+
+
+class TestProtocolCompliance:
+    def test_fake_implements_protocol(self) -> None:
+        fake = FakeAgentPodDiscovery()
+        assert isinstance(fake, AgentPodDiscovery)
+
+
+class TestGetUserPod:
+    @pytest.mark.asyncio
+    async def test_returns_none_when_unregistered(self) -> None:
+        fake = FakeAgentPodDiscovery()
+        result = await fake.get_user_pod("acme", "alice", "mason")
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_returns_registered_pod(self) -> None:
+        fake = FakeAgentPodDiscovery()
+        await fake.register_pod("acme", "alice", "mason", "mason-1", "10.0.0.1", 1)
+        result = await fake.get_user_pod("acme", "alice", "mason")
+        assert result == AgentPodInfo(ip="10.0.0.1", generation=1, pod_name="mason-1")
+
+    @pytest.mark.asyncio
+    async def test_records_calls(self) -> None:
+        fake = FakeAgentPodDiscovery()
+        await fake.get_user_pod("acme", "alice", "mason")
+        assert fake.get_calls == [("acme", "alice", "mason")]
+
+    @pytest.mark.asyncio
+    async def test_isolation_per_tenant(self) -> None:
+        fake = FakeAgentPodDiscovery()
+        await fake.register_pod("acme", "alice", "mason", "mason-1", "10.0.0.1", 1)
+        # Same user_id + agent_type, different tenant — must not leak.
+        result = await fake.get_user_pod("globex", "alice", "mason")
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_isolation_per_user(self) -> None:
+        fake = FakeAgentPodDiscovery()
+        await fake.register_pod("acme", "alice", "mason", "mason-1", "10.0.0.1", 1)
+        result = await fake.get_user_pod("acme", "bob", "mason")
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_isolation_per_agent_type(self) -> None:
+        fake = FakeAgentPodDiscovery()
+        await fake.register_pod("acme", "alice", "mason", "mason-1", "10.0.0.1", 1)
+        result = await fake.get_user_pod("acme", "alice", "davinci")
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_permission_error_for_denied_tenant(self) -> None:
+        fake = FakeAgentPodDiscovery()
+        fake.set_permission_denied_for_tenant("globex")
+        with pytest.raises(PermissionError, match="globex"):
+            await fake.get_user_pod("globex", "alice", "mason")
+
+
+class TestRegisterPod:
+    @pytest.mark.asyncio
+    async def test_register_persists(self) -> None:
+        fake = FakeAgentPodDiscovery()
+        await fake.register_pod("acme", "alice", "mason", "mason-1", "10.0.0.1", 1)
+        result = await fake.get_user_pod("acme", "alice", "mason")
+        assert result is not None
+        assert result.generation == 1
+
+    @pytest.mark.asyncio
+    async def test_register_records_calls(self) -> None:
+        fake = FakeAgentPodDiscovery()
+        await fake.register_pod("acme", "alice", "mason", "mason-1", "10.0.0.1", 1)
+        assert fake.register_calls == [("acme", "alice", "mason", "mason-1", "10.0.0.1", 1)]
+
+    @pytest.mark.asyncio
+    async def test_higher_generation_replaces_existing(self) -> None:
+        fake = FakeAgentPodDiscovery()
+        await fake.register_pod("acme", "alice", "mason", "mason-1", "10.0.0.1", 1)
+        await fake.register_pod("acme", "alice", "mason", "mason-2", "10.0.0.2", 2)
+        result = await fake.get_user_pod("acme", "alice", "mason")
+        assert result is not None
+        assert result.generation == 2
+        assert result.ip == "10.0.0.2"
+        assert result.pod_name == "mason-2"
+
+    @pytest.mark.asyncio
+    async def test_lower_generation_is_ignored(self) -> None:
+        """Out-of-order spawner callbacks must not roll back the live mapping."""
+        fake = FakeAgentPodDiscovery()
+        await fake.register_pod("acme", "alice", "mason", "mason-2", "10.0.0.2", 2)
+        await fake.register_pod("acme", "alice", "mason", "mason-1", "10.0.0.1", 1)
+        result = await fake.get_user_pod("acme", "alice", "mason")
+        assert result is not None
+        assert result.generation == 2  # Did not regress.
+
+    @pytest.mark.asyncio
+    async def test_permission_error_for_denied_tenant(self) -> None:
+        fake = FakeAgentPodDiscovery()
+        fake.set_permission_denied_for_tenant("globex")
+        with pytest.raises(PermissionError):
+            await fake.register_pod("globex", "alice", "mason", "p", "10.0.0.1", 1)
+
+
+class TestUnregisterPod:
+    @pytest.mark.asyncio
+    async def test_unregister_removes_entry(self) -> None:
+        fake = FakeAgentPodDiscovery()
+        await fake.register_pod("acme", "alice", "mason", "mason-1", "10.0.0.1", 1)
+        await fake.unregister_pod("acme", "alice", "mason", "mason-1")
+        result = await fake.get_user_pod("acme", "alice", "mason")
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_unregister_does_not_evict_replacement_pod(self) -> None:
+        """The delete-then-respawn race: deletion of the OLD pod_name must
+        not wipe the entry held by a NEW pod_name registered for the same
+        identity in between."""
+        fake = FakeAgentPodDiscovery()
+        await fake.register_pod("acme", "alice", "mason", "mason-1", "10.0.0.1", 1)
+        await fake.register_pod("acme", "alice", "mason", "mason-2", "10.0.0.2", 2)
+        # Late-arriving DELETE event for the old pod.
+        await fake.unregister_pod("acme", "alice", "mason", "mason-1")
+        result = await fake.get_user_pod("acme", "alice", "mason")
+        assert result is not None
+        assert result.pod_name == "mason-2"
+
+    @pytest.mark.asyncio
+    async def test_unregister_unknown_is_noop(self) -> None:
+        fake = FakeAgentPodDiscovery()
+        await fake.unregister_pod("acme", "alice", "mason", "mason-ghost")
+        # No raise; nothing in state.
+        assert await fake.get_user_pod("acme", "alice", "mason") is None
+
+    @pytest.mark.asyncio
+    async def test_permission_error_for_denied_tenant(self) -> None:
+        fake = FakeAgentPodDiscovery()
+        fake.set_permission_denied_for_tenant("globex")
+        with pytest.raises(PermissionError):
+            await fake.unregister_pod("globex", "alice", "mason", "p")
+
+
+class TestClose:
+    @pytest.mark.asyncio
+    async def test_close_idempotent(self) -> None:
+        fake = FakeAgentPodDiscovery()
+        await fake.close()
+        await fake.close()
+        assert fake.close_calls == 2

--- a/tests/fakes.py
+++ b/tests/fakes.py
@@ -286,7 +286,6 @@ class FakeSecretBackend:
     def __init__(self) -> None:
         from collections import defaultdict
 
-
         self._values: dict[str, SecretResult] = {}
         self._denied: set[str] = set()
         self._closed = False
@@ -333,6 +332,82 @@ class FakeSecretBackend:
         # Then drain any explicitly-pushed changes.
         for result in self._pending_changes.pop(ref, []):
             yield result
+
+    async def close(self) -> None:
+        self.close_calls += 1
+        self._closed = True
+
+
+class FakeAgentPodDiscovery:
+    """In-memory `AgentPodDiscovery` for tests.
+
+    State is keyed by ``(tenant_id, user_id, agent_type)``. Use
+    ``set_permission_denied_for_tenant`` to assert tenant isolation.
+    """
+
+    def __init__(self) -> None:
+        from stronghold.protocols.agent_pod import AgentPodInfo
+
+        self._pods: dict[tuple[str, str, str], AgentPodInfo] = {}
+        self._denied_tenants: set[str] = set()
+        self._closed = False
+        self.get_calls: list[tuple[str, str, str]] = []
+        self.register_calls: list[tuple[str, str, str, str, str, int]] = []
+        self.unregister_calls: list[tuple[str, str, str, str]] = []
+        self.close_calls = 0
+
+    def set_permission_denied_for_tenant(self, tenant_id: str) -> None:
+        self._denied_tenants.add(tenant_id)
+
+    async def get_user_pod(
+        self,
+        tenant_id: str,
+        user_id: str,
+        agent_type: str,
+    ) -> Any:
+        self.get_calls.append((tenant_id, user_id, agent_type))
+        if tenant_id in self._denied_tenants:
+            raise PermissionError(f"Cedar denied discovery for tenant {tenant_id!r}")
+        return self._pods.get((tenant_id, user_id, agent_type))
+
+    async def register_pod(
+        self,
+        tenant_id: str,
+        user_id: str,
+        agent_type: str,
+        pod_name: str,
+        ip: str,
+        generation: int,
+    ) -> None:
+        from stronghold.protocols.agent_pod import AgentPodInfo
+
+        self.register_calls.append(
+            (tenant_id, user_id, agent_type, pod_name, ip, generation),
+        )
+        if tenant_id in self._denied_tenants:
+            raise PermissionError(f"Cedar denied register for tenant {tenant_id!r}")
+        key = (tenant_id, user_id, agent_type)
+        existing = self._pods.get(key)
+        if existing is not None and existing.generation > generation:
+            return  # Out-of-order callback — keep the newer generation.
+        self._pods[key] = AgentPodInfo(ip=ip, generation=generation, pod_name=pod_name)
+
+    async def unregister_pod(
+        self,
+        tenant_id: str,
+        user_id: str,
+        agent_type: str,
+        pod_name: str,
+    ) -> None:
+        self.unregister_calls.append((tenant_id, user_id, agent_type, pod_name))
+        if tenant_id in self._denied_tenants:
+            raise PermissionError(f"Cedar denied unregister for tenant {tenant_id!r}")
+        key = (tenant_id, user_id, agent_type)
+        existing = self._pods.get(key)
+        # Only evict if the pod_name matches — protects against the
+        # delete-then-respawn race documented on #770.
+        if existing is not None and existing.pod_name == pod_name:
+            self._pods.pop(key, None)
 
     async def close(self) -> None:
         self.close_calls += 1


### PR DESCRIPTION
Closes #770. Unblocks #771-#777 (the rest of #373) plus everything in #374 and #378 that depends on the spawner extension landing on this protocol module.

## What this lands

- `src/stronghold/protocols/agent_pod.py` — `AgentPodDiscovery` runtime-checkable Protocol with `get_user_pod`, `register_pod`, `unregister_pod`, `close`, plus an `AgentPodInfo` frozen dataclass for snapshots.
- `tests/fakes.py` — `FakeAgentPodDiscovery` in-memory implementation. Used by every downstream sub-issue test.
- `tests/agent_pod/test_protocol.py` — 20 contract tests pinning the protocol semantics.

## Three load-bearing rules

1. **Identity is `(tenant_id, user_id, agent_type)`.** `pod_name` is a separate field threaded through register/unregister so the discovery service can detect generation skew.
2. **Generation is monotonic.** `register_pod` with a *lower* generation than the existing entry is a no-op. Without this, a slow callback for an old pod could overwrite the entry for a freshly-spawned new pod — a real failure mode of the K8s watcher loop.
3. **`unregister_pod` requires `pod_name`.** The K8s watcher's late-arriving DELETE event for an old pod_name must NOT wipe the entry held by a NEW pod_name registered for the same identity in between. This is the delete-then-respawn race called out in the #770 operator notes; the test `test_unregister_does_not_evict_replacement_pod` pins it.

## Tenant isolation

`PermissionError` is the canonical signal that Cedar PDP (#700) denied tenant-scoped discovery — a caller in tenant A asking about a pod in tenant B. Tested across all three identity dimensions (`tenant_id`, `user_id`, `agent_type`) with explicit cross-tenant leak assertions.

## Quality gates

- ✅ `ruff check` — clean
- ✅ `ruff format --check` — clean
- ✅ `mypy --strict` — clean
- ✅ `pytest tests/agent_pod/test_protocol.py` — **20 passed in 0.09s**

## Scope discipline

Protocol seam ONLY. The K8s discovery service is #774; the Redis cache is #771; the K8s label query is #772; the watcher is #773. The future `AgentPodSpawner` (issue #778) will extend this same module rather than living in a separate file.

## ADR alignment

- [ADR-K8S-001 — Namespace topology](https://github.com/Agent-StrongHold/stronghold/blob/feat/k8s-phase0-adrs/docs/adr/ADR-K8S-001-namespace-topology.md)
- [ADR-K8S-002 — RBAC boundary](https://github.com/Agent-StrongHold/stronghold/blob/feat/k8s-phase0-adrs/docs/adr/ADR-K8S-002-rbac-boundary.md)