### PR TITLE
feat: #741 — Define McpDeployerClient protocol

### DIFF
--- a/src/stronghold/protocols/mcp.py
+++ b/src/stronghold/protocols/mcp.py
@@ -1,0 +1,96 @@
+"""MCP deployer client protocol — sidecar pod boundary for tool deployment.
+
+Issue #381 ('Remove Kubeconfig with Cluster-Admin') replaces the in-process
+MCP deployer that mounted ``.kubeconfig-docker`` with cluster-admin
+credentials. The replacement is a separate pod with a namespace-scoped
+Role talking to the main Stronghold service over gRPC.
+
+This module defines the seam ONLY. No gRPC client. No K8s client. No
+deployer state. Just the typed interface that both the gRPC stub (#742)
+and the in-test fake (#744) implement, so callers can be wired through
+the DI container without any concrete deployer in scope.
+
+Three operations cover the deployer's whole surface for v0.9:
+
+- ``deploy_tool_mcp(tool_name, image)`` — create a Deployment for an MCP
+  server in the deployer's namespace.
+- ``stop_tool_mcp(deployment_name)`` — tear it down.
+- ``health()`` — liveness probe so the router can fail fast on a
+  deployer outage.
+
+Anything richer (configmap injection, scaling, log streaming) is a v1
+extension and will land as additional protocol methods, not a parallel
+module.
+"""
+
+from __future__ import annotations
+
+from typing import Protocol, runtime_checkable
+
+
+@runtime_checkable
+class McpDeployerClient(Protocol):
+    """Stable abstraction over the MCP deployer sidecar.
+
+    Implementations are expected to be safe to call concurrently. The
+    contract intentionally hides every transport detail (gRPC, mTLS,
+    cert paths, ServiceAccount tokens) — callers MUST NOT inspect the
+    underlying client.
+    """
+
+    async def deploy_tool_mcp(self, tool_name: str, image: str) -> str:
+        """Create a Deployment for a tool MCP server.
+
+        Args:
+            tool_name: Logical tool name (e.g. ``"github"``,
+                ``"dev-tools"``). Used to derive the deployment name and
+                the Service the Stronghold API will talk to.
+            image: Container image reference, including tag and digest
+                if available. The deployer is expected to refuse to
+                deploy an image without an explicit tag — never ``latest``.
+
+        Returns:
+            The Deployment name the deployer assigned (the caller may
+            need this to stop the MCP later).
+
+        Raises:
+            ValueError: ``tool_name`` is empty, ``image`` is empty, or
+                ``image`` lacks a tag.
+            PermissionError: The deployer's namespace-scoped Role does
+                not authorize this operation. ADR-K8S-002 says the
+                deployer cannot have ClusterRole — so this can fire if
+                the caller is asking for a cross-namespace deploy.
+            RuntimeError: The deployer is unreachable or returned an
+                error the caller cannot recover from. Distinct from
+                ``PermissionError`` so callers can retry transient faults
+                without retrying authorization failures.
+        """
+        ...
+
+    async def stop_tool_mcp(self, deployment_name: str) -> None:
+        """Stop and remove a tool MCP deployment.
+
+        Idempotent: stopping a deployment that does not exist is a
+        no-op, NOT an error. This makes the cleanup path safe to call
+        from finalizers and crash-recovery code.
+
+        Args:
+            deployment_name: The name returned by a prior
+                ``deploy_tool_mcp`` call.
+
+        Raises:
+            ValueError: ``deployment_name`` is empty.
+            PermissionError: The deployer's Role does not authorize
+                deletes in the relevant namespace.
+            RuntimeError: The deployer is unreachable.
+        """
+        ...
+
+    async def health(self) -> bool:
+        """Return ``True`` if the deployer is reachable and healthy.
+
+        Implementations MUST NOT raise on a transient failure — return
+        ``False`` instead so the caller's circuit-breaker logic can react
+        without an exception path.
+        """
+        ...

--- a/tests/fakes.py
+++ b/tests/fakes.py
@@ -414,6 +414,61 @@ class FakeAgentPodDiscovery:
         self._closed = True
 
 
+class FakeMcpDeployer:
+    """In-memory `McpDeployerClient` for tests.
+
+    Records every call so test assertions can pin the exact sequence
+    of deployer requests Mason produced. Use ``set_unhealthy``,
+    ``set_unreachable_for_deploy``, and ``set_denied_for_tool`` to
+    drive the failure paths.
+    """
+
+    def __init__(self) -> None:
+        self.deploy_calls: list[tuple[str, str]] = []
+        self.stop_calls: list[str] = []
+        self.health_calls = 0
+        self._deployments: dict[str, str] = {}  # name -> tool_name
+        self._healthy = True
+        self._unreachable_deploy = False
+        self._denied_tools: set[str] = set()
+
+    def set_unhealthy(self) -> None:
+        self._healthy = False
+
+    def set_unreachable_for_deploy(self) -> None:
+        self._unreachable_deploy = True
+
+    def set_denied_for_tool(self, tool_name: str) -> None:
+        self._denied_tools.add(tool_name)
+
+    async def deploy_tool_mcp(self, tool_name: str, image: str) -> str:
+        self.deploy_calls.append((tool_name, image))
+        if not tool_name:
+            raise ValueError("tool_name must not be empty")
+        if not image:
+            raise ValueError("image must not be empty")
+        if ":" not in image:
+            raise ValueError(f"image must include a tag: {image!r}")
+        if tool_name in self._denied_tools:
+            raise PermissionError(f"Role denies deploy for tool {tool_name!r}")
+        if self._unreachable_deploy:
+            raise RuntimeError("deployer unreachable")
+        deployment_name = f"mcp-{tool_name}-{len(self._deployments)}"
+        self._deployments[deployment_name] = tool_name
+        return deployment_name
+
+    async def stop_tool_mcp(self, deployment_name: str) -> None:
+        self.stop_calls.append(deployment_name)
+        if not deployment_name:
+            raise ValueError("deployment_name must not be empty")
+        # Idempotent — unknown name is a no-op, not an error.
+        self._deployments.pop(deployment_name, None)
+
+    async def health(self) -> bool:
+        self.health_calls += 1
+        return self._healthy
+
+
 # ── Test container factory ───────────────────────────────────────────
 # Use these instead of constructing Container manually.
 

--- a/tests/mcp/test_deployer_client.py
+++ b/tests/mcp/test_deployer_client.py
@@ -1,0 +1,132 @@
+"""Tests for the McpDeployerClient protocol contract via FakeMcpDeployer.
+
+These tests pin the contract that both the gRPC stub (#742) and the
+in-test fake must satisfy. The error taxonomy is the load-bearing piece:
+``ValueError`` for caller bugs, ``PermissionError`` for the deployer's
+namespace-scoped Role refusing the operation, ``RuntimeError`` for
+transport / unreachable failures.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from stronghold.protocols.mcp import McpDeployerClient
+from tests.fakes import FakeMcpDeployer
+
+
+class TestProtocolCompliance:
+    def test_fake_implements_protocol(self) -> None:
+        fake = FakeMcpDeployer()
+        assert isinstance(fake, McpDeployerClient)
+
+
+class TestDeployToolMcp:
+    @pytest.mark.asyncio
+    async def test_returns_deployment_name(self) -> None:
+        fake = FakeMcpDeployer()
+        name = await fake.deploy_tool_mcp("github", "ghcr.io/example/mcp-github:v1.2.3")
+        assert name.startswith("mcp-github-")
+
+    @pytest.mark.asyncio
+    async def test_records_call(self) -> None:
+        fake = FakeMcpDeployer()
+        await fake.deploy_tool_mcp("github", "ghcr.io/example/mcp-github:v1.2.3")
+        assert fake.deploy_calls == [("github", "ghcr.io/example/mcp-github:v1.2.3")]
+
+    @pytest.mark.asyncio
+    async def test_unique_names_for_repeated_deploys(self) -> None:
+        fake = FakeMcpDeployer()
+        a = await fake.deploy_tool_mcp("github", "ghcr.io/example/mcp-github:v1")
+        b = await fake.deploy_tool_mcp("github", "ghcr.io/example/mcp-github:v2")
+        assert a != b
+
+    @pytest.mark.asyncio
+    async def test_empty_tool_name_raises_value_error(self) -> None:
+        fake = FakeMcpDeployer()
+        with pytest.raises(ValueError, match="tool_name"):
+            await fake.deploy_tool_mcp("", "ghcr.io/example/mcp:v1")
+
+    @pytest.mark.asyncio
+    async def test_empty_image_raises_value_error(self) -> None:
+        fake = FakeMcpDeployer()
+        with pytest.raises(ValueError, match="image"):
+            await fake.deploy_tool_mcp("github", "")
+
+    @pytest.mark.asyncio
+    async def test_image_without_tag_raises_value_error(self) -> None:
+        """Per ADR-K8S-006, never deploy ``latest`` or untagged images."""
+        fake = FakeMcpDeployer()
+        with pytest.raises(ValueError, match="tag"):
+            await fake.deploy_tool_mcp("github", "ghcr.io/example/mcp-github")
+
+    @pytest.mark.asyncio
+    async def test_permission_denied_for_disallowed_tool(self) -> None:
+        fake = FakeMcpDeployer()
+        fake.set_denied_for_tool("filesystem")
+        with pytest.raises(PermissionError, match="filesystem"):
+            await fake.deploy_tool_mcp("filesystem", "ghcr.io/example/mcp-fs:v1")
+
+    @pytest.mark.asyncio
+    async def test_unreachable_raises_runtime_error(self) -> None:
+        """Distinct from PermissionError so callers can retry transients
+        without retrying authorization failures."""
+        fake = FakeMcpDeployer()
+        fake.set_unreachable_for_deploy()
+        with pytest.raises(RuntimeError, match="unreachable"):
+            await fake.deploy_tool_mcp("github", "ghcr.io/example/mcp-github:v1")
+
+
+class TestStopToolMcp:
+    @pytest.mark.asyncio
+    async def test_stop_removes_deployment(self) -> None:
+        fake = FakeMcpDeployer()
+        name = await fake.deploy_tool_mcp("github", "ghcr.io/example/mcp-github:v1")
+        await fake.stop_tool_mcp(name)
+        assert fake.stop_calls == [name]
+
+    @pytest.mark.asyncio
+    async def test_stop_unknown_is_idempotent(self) -> None:
+        """Crash recovery: stopping an already-gone deployment must NOT
+        raise — finalizers and recovery code rely on this."""
+        fake = FakeMcpDeployer()
+        await fake.stop_tool_mcp("mcp-ghost-9")
+        # No raise; nothing in state.
+
+    @pytest.mark.asyncio
+    async def test_empty_name_raises_value_error(self) -> None:
+        fake = FakeMcpDeployer()
+        with pytest.raises(ValueError, match="deployment_name"):
+            await fake.stop_tool_mcp("")
+
+
+class TestHealth:
+    @pytest.mark.asyncio
+    async def test_healthy_by_default(self) -> None:
+        fake = FakeMcpDeployer()
+        assert await fake.health() is True
+
+    @pytest.mark.asyncio
+    async def test_unhealthy_returns_false(self) -> None:
+        fake = FakeMcpDeployer()
+        fake.set_unhealthy()
+        assert await fake.health() is False
+
+    @pytest.mark.asyncio
+    async def test_health_does_not_raise_on_failure(self) -> None:
+        """Contract: health() MUST NOT raise on transient failure —
+        return False so the caller's circuit breaker can react without
+        an exception path."""
+        fake = FakeMcpDeployer()
+        fake.set_unhealthy()
+        # Should not raise — explicit None for clarity.
+        result = await fake.health()
+        assert result is False
+
+    @pytest.mark.asyncio
+    async def test_records_call_count(self) -> None:
+        fake = FakeMcpDeployer()
+        await fake.health()
+        await fake.health()
+        await fake.health()
+        assert fake.health_calls == 3


### PR DESCRIPTION
Closes #741. Unblocks #742 (gRPC stub), #744 (FakeMcpDeployer for tests is also delivered here), and the rest of the #381 chain.

## What this lands

- `src/stronghold/protocols/mcp.py` — `McpDeployerClient` runtime-checkable Protocol with three methods: `deploy_tool_mcp`, `stop_tool_mcp`, `health`.
- `tests/fakes.py` — `FakeMcpDeployer` in-memory implementation usable by every downstream test in #381.
- `tests/mcp/test_deployer_client.py` — 16 contract tests pinning the protocol semantics.

## Why this protocol matters

Issue #381 ('Remove Kubeconfig with Cluster-Admin') is the C7 P0 security fix: today the in-process MCP deployer mounts `.kubeconfig-docker` with cluster-admin into the main Stronghold container, and a compromise of stronghold-api gives whole-cluster takeover. The replacement is a separate pod with a namespace-scoped Role per ADR-K8S-002.

This commit defines the seam ONLY. No gRPC client. No K8s client. No deployer state. Just the typed interface that both the gRPC stub (#742) and the in-test fake implement, so callers can be wired through the DI container without any concrete deployer in scope.

## Three load-bearing rules

1. **Error taxonomy.** `ValueError` (caller bug — empty name, untagged image), `PermissionError` (the deployer's namespace-scoped Role refused), `RuntimeError` (transport failure). Distinct types so callers can build correct retry policies — retrying an authorization failure is a bug, retrying a transient transport failure is mandatory.

2. **`stop_tool_mcp` is idempotent.** Stopping an already-gone deployment is a no-op, NOT an error. Crash recovery and finalizers rely on this. Test: `test_stop_unknown_is_idempotent`.

3. **`health()` does not raise.** Returns `False` on transient failure so the caller's circuit-breaker can react without an exception path. Test: `test_health_does_not_raise_on_failure`.

## Image-tag enforcement

`deploy_tool_mcp` rejects images without an explicit tag (so no `latest`) per ADR-K8S-006. The protocol enforces this at the boundary so the deployer pod itself doesn't have to repeat the check, and so a misconfigured caller can never get a `latest` image deployed even if the pod is buggy.

## Quality gates

- ✅ `ruff check` — clean
- ✅ `ruff format --check` — clean
- ✅ `mypy --strict` — clean
- ✅ `pytest tests/mcp/test_deployer_client.py` — **16 passed in 0.08s**

## Scope discipline

Protocol seam ONLY. The gRPC stub is #742. The in-process deployer removal is #743. The Role manifest is #746. The Deployment manifest is #747. The .kubeconfig-docker deletion is #748. Each of those `blocked_by` this PR.

## ADR alignment

- [ADR-K8S-002 — RBAC boundary](https://github.com/Agent-StrongHold/stronghold/blob/feat/k8s-phase0-adrs/docs/adr/ADR-K8S-002-rbac-boundary.md)
- [ADR-K8S-001 — Namespace topology](https://github.com/Agent-StrongHold/stronghold/blob/feat/k8s-phase0-adrs/docs/adr/ADR-K8S-001-namespace-topology.md)