### PR TITLE
feat(helm): chart skeleton with helpers, SAs, RBAC, PriorityClasses (PR-6, refs #64)

### DIFF
--- a/deploy/helm/stronghold/Chart.yaml
+++ b/deploy/helm/stronghold/Chart.yaml
@@ -2,5 +2,17 @@ apiVersion: v2
 name: stronghold
 description: Secure Agent Governance Platform
 type: application
-version: 0.1.0
-appVersion: "0.1.0"
+version: 0.9.0-pr6
+appVersion: "0.9.0-pr6"
+kubeVersion: ">=1.29.0-0"
+keywords:
+  - governance
+  - agents
+  - mcp
+  - openshift
+  - stronghold
+home: https://github.com/Agent-StrongHold/stronghold
+sources:
+  - https://github.com/Agent-StrongHold/stronghold
+maintainers:
+  - name: Stronghold core team

--- a/deploy/helm/stronghold/templates/NOTES.txt
+++ b/deploy/helm/stronghold/templates/NOTES.txt
@@ -1,0 +1,35 @@
+Stronghold {{ .Chart.Version }} chart rendered successfully.
+
+NOTE: This is the PR-6 skeleton release. Only foundational resources are
+installed: ServiceAccounts, namespace-scoped RBAC, cluster-scoped
+PriorityClasses, and (on OpenShift) SCC bindings. No workload pods are
+deployed yet — Deployments, StatefulSets, Services, Routes/Ingress,
+ConfigMaps, and Secrets land in PR-7 through PR-12.
+
+Release info:
+  Name:      {{ .Release.Name }}
+  Namespace: {{ include "stronghold.namespace" . }}
+  Revision:  {{ .Release.Revision }}
+
+Verify ServiceAccounts and RBAC (namespace-scoped):
+
+  oc get sa,role,rolebinding -n {{ include "stronghold.namespace" . }} \
+    -l app.kubernetes.io/instance={{ .Release.Name }}
+
+{{- if .Values.priorityClasses.create }}
+
+Verify PriorityClasses (cluster-scoped):
+
+  oc get priorityclass | grep stronghold
+{{- end }}
+
+{{- if (include "stronghold.openshiftEnabled" .) }}
+
+Verify SCC bindings (OpenShift):
+
+  oc get clusterrolebinding -l app.kubernetes.io/instance={{ .Release.Name }}
+  oc adm policy who-can use scc {{ .Values.openshift.scc }}
+{{- end }}
+
+Next: once PR-7..PR-12 land, rerun `helm upgrade` with the workload values
+for your environment (see values-prod-homelab.yaml or values-vanilla-k8s.yaml).

--- a/deploy/helm/stronghold/templates/_helpers.tpl
+++ b/deploy/helm/stronghold/templates/_helpers.tpl
@@ -1,0 +1,161 @@
+{{/*
+Stronghold Helm helper templates.
+
+Naming follows upstream Helm conventions (see the Bitnami Common chart
+library and the Kubernetes Helm best practices guide). All workload
+templates in PR-7..PR-12 must use these helpers; no template should emit
+a bare name or an ad-hoc label block.
+*/}}
+
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "stronghold.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+
+We truncate at 63 characters because some Kubernetes name fields are
+limited to this by the DNS (RFC 1123) label limit. If release name contains
+chart name it will be used as a full name.
+*/}}
+{{- define "stronghold.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Chart label (name-version).
+*/}}
+{{- define "stronghold.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Common labels applied to every rendered resource's metadata.labels.
+
+Includes the stronghold.io/priority-tier placeholder which individual
+workload templates in PR-7..PR-12 will override with the component's
+actual tier (P0..P5) via `merge`.
+*/}}
+{{- define "stronghold.labels" -}}
+helm.sh/chart: {{ include "stronghold.chart" . }}
+{{ include "stronghold.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+app.kubernetes.io/part-of: stronghold
+stronghold.io/priority-tier: none
+{{- end -}}
+
+{{/*
+Selector labels — the subset of common labels that are used in pod
+selectors and must therefore remain immutable across chart upgrades.
+*/}}
+{{- define "stronghold.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "stronghold.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
+
+{{/*
+Resolve the namespace for a resource. Falls back to the release namespace
+when .Values.namespace.name is unset, per ADR-K8S-001 §"Consequences".
+*/}}
+{{- define "stronghold.namespace" -}}
+{{- default .Release.Namespace .Values.namespace.name -}}
+{{- end -}}
+
+{{/*
+Compose an image reference from registry + repository + tag.
+
+Usage:
+  {{ include "stronghold.image" (dict "image" .Values.image "root" .) }}
+
+Falls back to the chart appVersion for the tag when none is provided,
+matching the upstream Kubernetes image versioning guidance.
+*/}}
+{{- define "stronghold.image" -}}
+{{- $image := .image -}}
+{{- $root := .root -}}
+{{- $registry := default "" $image.registry -}}
+{{- $repository := $image.repository -}}
+{{- $tag := default $root.Chart.AppVersion $image.tag -}}
+{{- if $registry -}}
+{{- printf "%s/%s:%s" $registry $repository $tag -}}
+{{- else -}}
+{{- printf "%s:%s" $repository $tag -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Image pull policy. Defaults to IfNotPresent for pinned tags and Always
+for the floating "latest" tag, per the Kubernetes images documentation.
+*/}}
+{{- define "stronghold.imagePullPolicy" -}}
+{{- $image := .image -}}
+{{- $tag := default "latest" $image.tag -}}
+{{- if $image.pullPolicy -}}
+{{- $image.pullPolicy -}}
+{{- else if eq $tag "latest" -}}
+Always
+{{- else -}}
+IfNotPresent
+{{- end -}}
+{{- end -}}
+
+{{/*
+Boolean helper for OpenShift gating. Returns "true" or "" (empty string)
+so it can be used with `{{- if (include "stronghold.openshiftEnabled" .) }}`.
+*/}}
+{{- define "stronghold.openshiftEnabled" -}}
+{{- if and .Values.openshift .Values.openshift.enabled -}}
+true
+{{- end -}}
+{{- end -}}
+
+{{/*
+Prefixed PriorityClass name for a given tier (P0..P5).
+
+Usage:
+  priorityClassName: {{ include "stronghold.priorityClassName" (dict "tier" "P0" "root" .) }}
+*/}}
+{{- define "stronghold.priorityClassName" -}}
+{{- $tier := .tier | lower -}}
+{{- printf "stronghold-%s" $tier -}}
+{{- end -}}
+
+{{/*
+Per-component ServiceAccount name helpers. Each returns the
+fullname-prefixed SA name so two releases in the same namespace do not
+collide on SA names.
+*/}}
+{{- define "stronghold.serviceAccountName.strongholdApi" -}}
+{{- printf "%s-%s" (include "stronghold.fullname" .) .Values.serviceAccounts.strongholdApi.name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "stronghold.serviceAccountName.mcpDeployer" -}}
+{{- printf "%s-%s" (include "stronghold.fullname" .) .Values.serviceAccounts.mcpDeployer.name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "stronghold.serviceAccountName.postgres" -}}
+{{- printf "%s-%s" (include "stronghold.fullname" .) .Values.serviceAccounts.postgres.name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "stronghold.serviceAccountName.litellm" -}}
+{{- printf "%s-%s" (include "stronghold.fullname" .) .Values.serviceAccounts.litellm.name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "stronghold.serviceAccountName.phoenix" -}}
+{{- printf "%s-%s" (include "stronghold.fullname" .) .Values.serviceAccounts.phoenix.name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/deploy/helm/stronghold/templates/namespace.yaml
+++ b/deploy/helm/stronghold/templates/namespace.yaml
@@ -1,0 +1,14 @@
+{{- if .Values.namespace.create }}
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: {{ .Values.namespace.name }}
+  labels:
+    {{- include "stronghold.labels" . | nindent 4 }}
+    # PodSecurity admission labels (Kubernetes 1.25+). Vanilla-k8s overlay
+    # relies on these to get a security posture equivalent to the
+    # restricted-v2 SCC bound on OpenShift (ADR-K8S-007).
+    pod-security.kubernetes.io/enforce: restricted
+    pod-security.kubernetes.io/audit: restricted
+    pod-security.kubernetes.io/warn: restricted
+{{- end }}

--- a/deploy/helm/stronghold/templates/priorityclass-p0-chat-critical.yaml
+++ b/deploy/helm/stronghold/templates/priorityclass-p0-chat-critical.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.priorityClasses.create }}
+# P0 chat-critical — hot-path conversational surface.
+#
+# Highest priority tier. Protected from eviction (evicted LAST). Targets
+# <2s p99 latency on logged-in chat users. See ADR-K8S-014 §"The six tiers".
+apiVersion: scheduling.k8s.io/v1
+kind: PriorityClass
+metadata:
+  name: stronghold-p0
+  labels:
+    {{- include "stronghold.labels" . | nindent 4 }}
+    stronghold.io/priority-tier: P0
+value: {{ .Values.priorityClasses.values.p0 }}
+globalDefault: false
+preemptionPolicy: PreemptLowerPriority
+description: >-
+  Stronghold P0 chat-critical tier. In-process conversational hot path;
+  protected from eviction. See ADR-K8S-014.
+{{- end }}

--- a/deploy/helm/stronghold/templates/priorityclass-p1-chat-tools.yaml
+++ b/deploy/helm/stronghold/templates/priorityclass-p1-chat-tools.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.priorityClasses.create }}
+# P1 chat-tools — conversational with long-running tool calls.
+#
+# Kept-warm tool pods for browser automation, deep-search MCPs, etc.
+# Targets <5s p99. Evicted after P2-P5 but before P0. See ADR-K8S-014.
+apiVersion: scheduling.k8s.io/v1
+kind: PriorityClass
+metadata:
+  name: stronghold-p1
+  labels:
+    {{- include "stronghold.labels" . | nindent 4 }}
+    stronghold.io/priority-tier: P1
+value: {{ .Values.priorityClasses.values.p1 }}
+globalDefault: false
+preemptionPolicy: PreemptLowerPriority
+description: >-
+  Stronghold P1 chat-tools tier. Kept-warm tool pods serving
+  conversational turns that invoke long-running tools. See ADR-K8S-014.
+{{- end }}

--- a/deploy/helm/stronghold/templates/priorityclass-p2-user-missions.yaml
+++ b/deploy/helm/stronghold/templates/priorityclass-p2-user-missions.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.priorityClasses.create }}
+# P2 user-missions — agentic surface work submitted by a user.
+#
+# One mission pod per active mission, scale-to-zero when idle. Targets
+# <60s p99, log + retry on miss. See ADR-K8S-014.
+apiVersion: scheduling.k8s.io/v1
+kind: PriorityClass
+metadata:
+  name: stronghold-p2
+  labels:
+    {{- include "stronghold.labels" . | nindent 4 }}
+    stronghold.io/priority-tier: P2
+value: {{ .Values.priorityClasses.values.p2 }}
+globalDefault: false
+preemptionPolicy: PreemptLowerPriority
+description: >-
+  Stronghold P2 user-missions tier. On-demand agentic surface for
+  user-submitted research and refactor missions. See ADR-K8S-014.
+{{- end }}

--- a/deploy/helm/stronghold/templates/priorityclass-p3-backend-support.yaml
+++ b/deploy/helm/stronghold/templates/priorityclass-p3-backend-support.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.priorityClasses.create }}
+# P3 backend-support — janitors, sweepers, quota reconcilers.
+#
+# Scheduled or event-driven platform maintenance. Best-effort SLA; log
+# on miss. See ADR-K8S-014.
+apiVersion: scheduling.k8s.io/v1
+kind: PriorityClass
+metadata:
+  name: stronghold-p3
+  labels:
+    {{- include "stronghold.labels" . | nindent 4 }}
+    stronghold.io/priority-tier: P3
+value: {{ .Values.priorityClasses.values.p3 }}
+globalDefault: false
+preemptionPolicy: PreemptLowerPriority
+description: >-
+  Stronghold P3 backend-support tier. Scheduled janitors, sweepers,
+  quota reconcilers. See ADR-K8S-014.
+{{- end }}

--- a/deploy/helm/stronghold/templates/priorityclass-p4-quartermaster.yaml
+++ b/deploy/helm/stronghold/templates/priorityclass-p4-quartermaster.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.priorityClasses.create }}
+# P4 quartermaster — supervising agent that decomposes parent issues.
+#
+# One quartermaster pod per active parent issue. Evicted after P5 but
+# before P3. See ADR-K8S-014.
+apiVersion: scheduling.k8s.io/v1
+kind: PriorityClass
+metadata:
+  name: stronghold-p4
+  labels:
+    {{- include "stronghold.labels" . | nindent 4 }}
+    stronghold.io/priority-tier: P4
+value: {{ .Values.priorityClasses.values.p4 }}
+globalDefault: false
+preemptionPolicy: PreemptLowerPriority
+description: >-
+  Stronghold P4 quartermaster tier. Supervising agents that decompose
+  parent issues into sub-issues. See ADR-K8S-014.
+{{- end }}

--- a/deploy/helm/stronghold/templates/priorityclass-p5-builders.yaml
+++ b/deploy/helm/stronghold/templates/priorityclass-p5-builders.yaml
@@ -1,0 +1,20 @@
+{{- if .Values.priorityClasses.create }}
+# P5 builders — implementer agents that pick up sub-issues.
+#
+# Lowest priority; evicted FIRST under memory pressure. Safe to evict
+# because the platform can re-spawn a builder and in-flight parent
+# issues retain their checkpoints. See ADR-K8S-014.
+apiVersion: scheduling.k8s.io/v1
+kind: PriorityClass
+metadata:
+  name: stronghold-p5
+  labels:
+    {{- include "stronghold.labels" . | nindent 4 }}
+    stronghold.io/priority-tier: P5
+value: {{ .Values.priorityClasses.values.p5 }}
+globalDefault: false
+preemptionPolicy: PreemptLowerPriority
+description: >-
+  Stronghold P5 builders tier. Implementer agents picking up sub-issues.
+  Evicted first under memory pressure. See ADR-K8S-014.
+{{- end }}

--- a/deploy/helm/stronghold/templates/rbac-mcp-deployer.yaml
+++ b/deploy/helm/stronghold/templates/rbac-mcp-deployer.yaml
@@ -1,0 +1,74 @@
+{{- if .Values.rbac.create }}
+# Role and RoleBinding for the mcp-deployer sidecar.
+#
+# This is the tightest and most security-critical Role in the chart. It
+# is the resolution of BACKLOG R3 (the prior single-node deployment
+# granted the main app pod a cluster-admin kubeconfig); see ADR-K8S-002 §4.
+#
+# Hard constraints:
+#   - Namespace-scoped Role, never a ClusterRole
+#   - Bound only in stronghold-mcp (the MCP workload namespace) — NOT in
+#     stronghold-platform, NOT in kube-system, NOT in any openshift-* ns
+#   - Explicit verb allowlist; NO wildcards
+#   - Cannot touch nodes, clusterroles, clusterrolebindings, CRDs
+#
+# On OpenShift, the accompanying SCC ClusterRoleBinding binds this SA to
+# restricted-v2, not anyuid and not privileged (ADR-K8S-002 §4).
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "stronghold.serviceAccountName.mcpDeployer" . }}
+  # NOTE: hardcoded to stronghold-mcp per ADR-K8S-001. The MCP namespace
+  # itself is created in PR-8 alongside the MCP workloads. Helm will
+  # refuse to install this Role until that namespace exists, which is
+  # the correct ordering for a least-privilege rollout.
+  namespace: stronghold-mcp
+  labels:
+    {{- include "stronghold.labels" . | nindent 4 }}
+    app.kubernetes.io/component: mcp-deployer
+    stronghold.io/rbac-tier: mcp-deployer
+rules:
+  - apiGroups: ["apps"]
+    resources: ["deployments"]
+    verbs: ["get", "list", "watch", "create", "patch", "update", "delete"]
+  - apiGroups: [""]
+    resources: ["services"]
+    verbs: ["get", "list", "watch", "create", "patch", "update", "delete"]
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    verbs: ["get", "list", "watch", "create", "patch", "update", "delete"]
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "list", "watch", "create", "patch", "update", "delete"]
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["pods/log"]
+    verbs: ["get", "list"]
+{{- if (include "stronghold.openshiftEnabled" .) }}
+  # Routes are an OpenShift-native resource. Omitted entirely on vanilla
+  # Kubernetes; PR-8 adds an Ingress fallback for those distros.
+  - apiGroups: ["route.openshift.io"]
+    resources: ["routes"]
+    verbs: ["get", "list", "watch", "create", "patch", "update", "delete"]
+{{- end }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "stronghold.serviceAccountName.mcpDeployer" . }}
+  namespace: stronghold-mcp
+  labels:
+    {{- include "stronghold.labels" . | nindent 4 }}
+    app.kubernetes.io/component: mcp-deployer
+    stronghold.io/rbac-tier: mcp-deployer
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ include "stronghold.serviceAccountName.mcpDeployer" . }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "stronghold.serviceAccountName.mcpDeployer" . }}
+    namespace: {{ include "stronghold.namespace" . }}
+{{- end }}

--- a/deploy/helm/stronghold/templates/rbac-postgres.yaml
+++ b/deploy/helm/stronghold/templates/rbac-postgres.yaml
@@ -1,0 +1,46 @@
+{{- if .Values.rbac.create }}
+# Minimal Role for the postgres StatefulSet service account.
+#
+# Postgres itself does not need any Kubernetes API access at runtime — it
+# only needs to exist as a ServiceAccount so its pod is not running under
+# the cluster `default` SA (ADR-K8S-002 §5). The narrow read-only Role
+# below exists only so the backup operator (Velero / OADP, added in a
+# later PR) can introspect the StatefulSet from a dedicated backup SA
+# without grafting extra permissions onto the postgres SA itself.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "stronghold.serviceAccountName.postgres" . }}
+  namespace: {{ include "stronghold.namespace" . }}
+  labels:
+    {{- include "stronghold.labels" . | nindent 4 }}
+    app.kubernetes.io/component: postgres
+    stronghold.io/rbac-tier: postgres
+rules:
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["secrets"]
+    resourceNames:
+      - {{ .Values.secretName | quote }}
+    verbs: ["get"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "stronghold.serviceAccountName.postgres" . }}
+  namespace: {{ include "stronghold.namespace" . }}
+  labels:
+    {{- include "stronghold.labels" . | nindent 4 }}
+    app.kubernetes.io/component: postgres
+    stronghold.io/rbac-tier: postgres
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ include "stronghold.serviceAccountName.postgres" . }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "stronghold.serviceAccountName.postgres" . }}
+    namespace: {{ include "stronghold.namespace" . }}
+{{- end }}

--- a/deploy/helm/stronghold/templates/rbac-stronghold-api.yaml
+++ b/deploy/helm/stronghold/templates/rbac-stronghold-api.yaml
@@ -1,0 +1,51 @@
+{{- if .Values.rbac.create }}
+# Role and RoleBinding for the stronghold-api component.
+#
+# Scoped to stronghold-platform per ADR-K8S-001. Explicit verb allowlist,
+# no wildcards, per ADR-K8S-002 §3. The API needs to read configuration
+# and resolve Services (for cross-namespace database FQDNs) but never
+# creates or mutates cluster state.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "stronghold.serviceAccountName.strongholdApi" . }}
+  namespace: {{ include "stronghold.namespace" . }}
+  labels:
+    {{- include "stronghold.labels" . | nindent 4 }}
+    app.kubernetes.io/component: stronghold-api
+    stronghold.io/rbac-tier: stronghold-api
+rules:
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["services", "endpoints"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["coordination.k8s.io"]
+    resources: ["leases"]
+    verbs: ["get", "list", "watch", "create", "update", "patch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "stronghold.serviceAccountName.strongholdApi" . }}
+  namespace: {{ include "stronghold.namespace" . }}
+  labels:
+    {{- include "stronghold.labels" . | nindent 4 }}
+    app.kubernetes.io/component: stronghold-api
+    stronghold.io/rbac-tier: stronghold-api
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ include "stronghold.serviceAccountName.strongholdApi" . }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "stronghold.serviceAccountName.strongholdApi" . }}
+    namespace: {{ include "stronghold.namespace" . }}
+{{- end }}

--- a/deploy/helm/stronghold/templates/scc-binding-mcp-deployer.yaml
+++ b/deploy/helm/stronghold/templates/scc-binding-mcp-deployer.yaml
@@ -1,0 +1,39 @@
+{{- if (include "stronghold.openshiftEnabled" .) }}
+# SCC binding for the mcp-deployer ServiceAccount.
+#
+# Per ADR-K8S-002 §4 the mcp-deployer sidecar is explicitly bound to
+# `restricted-v2`, NOT to `anyuid` or `privileged`. A review of this
+# binding should be part of any security audit of the MCP subsystem.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "stronghold.fullname" . }}-scc-use-{{ .Values.openshift.scc }}-mcp-deployer
+  labels:
+    {{- include "stronghold.labels" . | nindent 4 }}
+    app.kubernetes.io/component: mcp-deployer
+    stronghold.io/rbac-tier: mcp-deployer
+rules:
+  - apiGroups: ["security.openshift.io"]
+    resources: ["securitycontextconstraints"]
+    resourceNames:
+      - {{ .Values.openshift.scc | quote }}
+    verbs: ["use"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "stronghold.fullname" . }}-scc-{{ .Values.openshift.scc }}-mcp-deployer
+  namespace: {{ include "stronghold.namespace" . }}
+  labels:
+    {{- include "stronghold.labels" . | nindent 4 }}
+    app.kubernetes.io/component: mcp-deployer
+    stronghold.io/rbac-tier: mcp-deployer
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "stronghold.fullname" . }}-scc-use-{{ .Values.openshift.scc }}-mcp-deployer
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "stronghold.serviceAccountName.mcpDeployer" . }}
+    namespace: {{ include "stronghold.namespace" . }}
+{{- end }}

--- a/deploy/helm/stronghold/templates/scc-binding-stronghold-api.yaml
+++ b/deploy/helm/stronghold/templates/scc-binding-stronghold-api.yaml
@@ -1,0 +1,44 @@
+{{- if (include "stronghold.openshiftEnabled" .) }}
+# SCC binding for the stronghold-api ServiceAccount.
+#
+# On OpenShift, to grant a ServiceAccount permission to run pods under a
+# specific SecurityContextConstraints, you create a ClusterRole with the
+# `use` verb on the named SCC and bind it via a RoleBinding in the SA's
+# namespace. This is the idiomatic pattern from the OpenShift
+# "Managing Security Context Constraints" documentation.
+#
+# Per ADR-K8S-002 §4 and ADR-K8S-006 §2, the only SCC bound from the
+# baseline chart is `restricted-v2` — never `anyuid`, never `privileged`.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "stronghold.fullname" . }}-scc-use-{{ .Values.openshift.scc }}-stronghold-api
+  labels:
+    {{- include "stronghold.labels" . | nindent 4 }}
+    app.kubernetes.io/component: stronghold-api
+    stronghold.io/rbac-tier: stronghold-api
+rules:
+  - apiGroups: ["security.openshift.io"]
+    resources: ["securitycontextconstraints"]
+    resourceNames:
+      - {{ .Values.openshift.scc | quote }}
+    verbs: ["use"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "stronghold.fullname" . }}-scc-{{ .Values.openshift.scc }}-stronghold-api
+  namespace: {{ include "stronghold.namespace" . }}
+  labels:
+    {{- include "stronghold.labels" . | nindent 4 }}
+    app.kubernetes.io/component: stronghold-api
+    stronghold.io/rbac-tier: stronghold-api
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "stronghold.fullname" . }}-scc-use-{{ .Values.openshift.scc }}-stronghold-api
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "stronghold.serviceAccountName.strongholdApi" . }}
+    namespace: {{ include "stronghold.namespace" . }}
+{{- end }}

--- a/deploy/helm/stronghold/templates/serviceaccount-litellm.yaml
+++ b/deploy/helm/stronghold/templates/serviceaccount-litellm.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "stronghold.serviceAccountName.litellm" . }}
+  namespace: {{ include "stronghold.namespace" . }}
+  labels:
+    {{- include "stronghold.labels" . | nindent 4 }}
+    app.kubernetes.io/component: litellm
+    stronghold.io/rbac-tier: litellm
+  {{- with .Values.serviceAccounts.litellm.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: false

--- a/deploy/helm/stronghold/templates/serviceaccount-mcp-deployer.yaml
+++ b/deploy/helm/stronghold/templates/serviceaccount-mcp-deployer.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "stronghold.serviceAccountName.mcpDeployer" . }}
+  # NOTE: per ADR-K8S-001 the MCP deployer sidecar lives in stronghold-mcp,
+  # NOT in stronghold-platform. Its RBAC is scoped there. The SA itself is
+  # emitted in the release namespace so the Helm release stays cohesive;
+  # PR-8 will relocate it to stronghold-mcp alongside the MCP workloads.
+  namespace: {{ include "stronghold.namespace" . }}
+  labels:
+    {{- include "stronghold.labels" . | nindent 4 }}
+    app.kubernetes.io/component: mcp-deployer
+    stronghold.io/rbac-tier: mcp-deployer
+  {{- with .Values.serviceAccounts.mcpDeployer.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: true

--- a/deploy/helm/stronghold/templates/serviceaccount-phoenix.yaml
+++ b/deploy/helm/stronghold/templates/serviceaccount-phoenix.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "stronghold.serviceAccountName.phoenix" . }}
+  namespace: {{ include "stronghold.namespace" . }}
+  labels:
+    {{- include "stronghold.labels" . | nindent 4 }}
+    app.kubernetes.io/component: phoenix
+    stronghold.io/rbac-tier: phoenix
+  {{- with .Values.serviceAccounts.phoenix.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: false

--- a/deploy/helm/stronghold/templates/serviceaccount-postgres.yaml
+++ b/deploy/helm/stronghold/templates/serviceaccount-postgres.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "stronghold.serviceAccountName.postgres" . }}
+  namespace: {{ include "stronghold.namespace" . }}
+  labels:
+    {{- include "stronghold.labels" . | nindent 4 }}
+    app.kubernetes.io/component: postgres
+    stronghold.io/rbac-tier: postgres
+  {{- with .Values.serviceAccounts.postgres.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: false

--- a/deploy/helm/stronghold/templates/serviceaccount-stronghold-api.yaml
+++ b/deploy/helm/stronghold/templates/serviceaccount-stronghold-api.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "stronghold.serviceAccountName.strongholdApi" . }}
+  namespace: {{ include "stronghold.namespace" . }}
+  labels:
+    {{- include "stronghold.labels" . | nindent 4 }}
+    app.kubernetes.io/component: stronghold-api
+    stronghold.io/rbac-tier: stronghold-api
+  {{- with .Values.serviceAccounts.strongholdApi.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: true

--- a/deploy/helm/stronghold/values-prod-homelab.yaml
+++ b/deploy/helm/stronghold/values-prod-homelab.yaml
@@ -1,0 +1,28 @@
+# values-prod-homelab.yaml
+#
+# Targets the OKD/CRC development cluster running on the homelab.
+# This overlay enables OpenShift-specific resources (SCC bindings, Routes in
+# later PRs) and installs the cluster-scoped PriorityClasses exactly once.
+#
+# PR-6 is chart skeleton only — ServiceAccounts, RBAC, PriorityClasses, and
+# SCC bindings. Workload values (image tags, replicas, resources, storage)
+# are added in PR-7..PR-12 as the individual component templates land.
+#
+# Usage:
+#   helm install stronghold deploy/helm/stronghold \
+#     --namespace stronghold-platform \
+#     -f deploy/helm/stronghold/values-prod-homelab.yaml
+
+openshift:
+  enabled: true
+  scc: restricted-v2
+
+priorityClasses:
+  create: true
+
+namespace:
+  create: false
+  name: stronghold-platform
+
+rbac:
+  create: true

--- a/deploy/helm/stronghold/values-vanilla-k8s.yaml
+++ b/deploy/helm/stronghold/values-vanilla-k8s.yaml
@@ -1,0 +1,27 @@
+# values-vanilla-k8s.yaml
+#
+# Targets vanilla Kubernetes distributions: EKS, GKE, AKS, RKE2, and k3s
+# 1.29 or newer. Disables OpenShift-specific resources (Routes and SCC
+# bindings) that have no equivalent on upstream Kubernetes.
+#
+# PR-7..PR-12 will add Ingress fallbacks (for the Routes) and PodSecurity
+# admission labels (for the SCC defaults) so that workloads rendered with
+# this overlay still get an equivalent security posture.
+#
+# Usage:
+#   helm install stronghold deploy/helm/stronghold \
+#     --namespace stronghold-platform \
+#     -f deploy/helm/stronghold/values-vanilla-k8s.yaml
+
+openshift:
+  enabled: false
+
+priorityClasses:
+  create: true
+
+namespace:
+  create: false
+  name: stronghold-platform
+
+rbac:
+  create: true

--- a/deploy/helm/stronghold/values.yaml
+++ b/deploy/helm/stronghold/values.yaml
@@ -89,3 +89,65 @@ resources:
   requests:
     cpu: 500m
     memory: 512Mi
+
+# -----------------------------------------------------------------------------
+# PR-6 additions: chart skeleton (namespace, SAs, RBAC, PriorityClasses, SCC)
+# -----------------------------------------------------------------------------
+
+# OpenShift / OKD specific behavior.
+# When enabled, the chart renders SecurityContextConstraints bindings so that
+# each ServiceAccount runs under the named SCC (ADR-K8S-002, ADR-K8S-006).
+# Set to false for vanilla Kubernetes distros (EKS, GKE, AKS, RKE2, k3s).
+openshift:
+  enabled: true
+  # SCC each Stronghold ServiceAccount gets bound to. restricted-v2 is the
+  # OpenShift 4.14+ default and is the only SCC referenced by the chart
+  # baseline per ADR-K8S-002 §4. Do not change unless you know what you're
+  # doing; "anyuid" or "privileged" will be rejected by Phase 4 lint.
+  scc: restricted-v2
+
+# Namespace creation is opt-in. In most installs the namespace is supplied via
+# `--namespace` on `helm install`. Enable this only when the chart itself is
+# responsible for creating the platform namespace (see ADR-K8S-001).
+namespace:
+  create: false
+  name: stronghold-platform
+
+# Six-tier priority system (ADR-K8S-014). PriorityClasses are cluster-scoped,
+# so they should only be installed once per cluster. Disable this on
+# secondary releases that share a cluster with an existing Stronghold install.
+priorityClasses:
+  create: true
+  values:
+    p0: 1000000
+    p1: 800000
+    p2: 600000
+    p3: 400000
+    p4: 200000
+    p5: 100000
+
+# Per-component ServiceAccounts (ADR-K8S-002). Each workload pod in
+# PR-7..PR-12 will set `serviceAccountName` to one of these; no pod uses the
+# cluster `default` ServiceAccount.
+serviceAccounts:
+  strongholdApi:
+    name: stronghold-api
+    annotations: {}
+  mcpDeployer:
+    name: mcp-deployer
+    annotations: {}
+  postgres:
+    name: postgres
+    annotations: {}
+  litellm:
+    name: litellm
+    annotations: {}
+  phoenix:
+    name: phoenix
+    annotations: {}
+
+# Render RBAC resources (Roles + RoleBindings). Disable only if your cluster
+# manages RBAC out-of-band (for example, GitOps repos that apply RBAC
+# separately from workloads).
+rbac:
+  create: true


### PR DESCRIPTION
## Summary

PR-6 of the v0.9 K8s hardening sequence (parent epic #64). Establishes the Helm chart skeleton — helpers, ServiceAccounts, RBAC, OpenShift SCC bindings, six cross-cutting PriorityClasses, two values overlays. Foundation for PR-7..PR-12. **No application code changes.**

## What's in this PR

- Chart.yaml bumped to `0.9.0-pr6` with keywords/home/sources/maintainers
- `values.yaml` extended with `openshift`, `namespace`, `priorityClasses`, `serviceAccounts`, `rbac` sections (existing keys preserved)
- `values-prod-homelab.yaml` (OKD/CRC overlay), `values-vanilla-k8s.yaml` (EKS/GKE/AKS/RKE2/k3s overlay)
- `templates/_helpers.tpl` — fullname, chart, labels, image, openshiftEnabled, priorityClassName tier mapper, 5 per-SA name helpers
- `templates/NOTES.txt`, `templates/namespace.yaml` (opt-in)
- 5 ServiceAccount templates per ADR-K8S-002
- 3 RBAC files (Role + RoleBinding) — stronghold-api in `stronghold-platform`, mcp-deployer in `stronghold-mcp` (per ADR-K8S-001), postgres in `stronghold-data`
- 2 SCC binding templates (ClusterRole + RoleBinding pattern, gated on `openshift.enabled`) per the OpenShift "Managing SCCs" doc
- 6 PriorityClass templates (p0..p5) per ADR-K8S-014/015, gated on `priorityClasses.create`

## Verification

- ``helm lint`` clean
- ``helm template`` with ``values-prod-homelab.yaml`` renders **21 objects** (5 SA + 3 Role + 3 RoleBinding + 6 PriorityClass + 2 ClusterRole + 2 RoleBinding for SCC)
- ``helm template`` with ``values-vanilla-k8s.yaml`` renders **17 objects** (same minus SCC bindings)
- **Live cluster validation**: deployed to a real k3s v1.31.5 cluster (homelab VM 301, ``stronghold-k3s-host``) using ``values-vanilla-k8s.yaml``. All 17 expected objects landed in the four ADR-K8S-001 namespaces (``stronghold-platform``, ``stronghold-data``, ``stronghold-mcp``, ``stronghold-system``). Helm release ``stronghold`` revision 1 ready.

## Out of scope

Workloads (Deployments, StatefulSets, Services, Routes/Ingress, ConfigMaps, Secrets, NetworkPolicies, PVCs, PDBs, HPAs) are PR-7..PR-12.