### PR TITLE
fix: drop privileged: true from stronghold + postgres (PR-5, refs #64, closes R1+R2)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,6 @@
 services:
   stronghold:
     build: .
-    privileged: true  # Required for Kind K8s cluster access (MCP deployer)
     restart: unless-stopped
     ports:
       - "0.0.0.0:8100:8100"
@@ -36,7 +35,6 @@ services:
 
   postgres:
     image: pgvector/pgvector:pg17
-    privileged: true  # Required for pgvector extension setup
     restart: unless-stopped
     environment:
       - POSTGRES_USER=stronghold


### PR DESCRIPTION
## Summary

PR-5 of the v0.9 K8s hardening sequence (parent epic #64). Removes `privileged: true` from the `stronghold` and `postgres` containers in `docker-compose.yml`. Closes BACKLOG R1 and R2.

## Diff

```diff
   stronghold:
-    privileged: true  # Required for Kind K8s cluster access (MCP deployer)
   postgres:
-    privileged: true  # Required for pgvector extension setup
```

## Why both flags were unnecessary

**stronghold (R1)**: the comment claimed privileged was needed for Kind K8s cluster access via the MCP deployer. Kind actually runs as a sibling container on the shared `kind` Docker network, so kubectl talks to it over standard TCP/443. No kernel capabilities needed.

**postgres (R2)**: the comment claimed privileged was needed for pgvector extension setup. The image in use (`pgvector/pgvector:pg17`) installs the extension at build time via the initdb hook (`CREATE EXTENSION vector`); the running container needs no special privileges.

## Verification

- `docker compose config --quiet` clean
- `grep -rn 'privileged.*true' --include='*.yml' --include='*.yaml' .` returns empty for production deployment files
- `deploy/k8s/*.yaml` already had no privileged flags

## Follow-up risk

The stronghold container's MCP deployer flow uses kubectl against a Kind API server over Docker networking. The change is non-breaking by design (no capabilities or syscalls were actually used by either container at runtime), but worth smoke-testing the MCP deployment paths in CI before merge to confirm.

## Test plan

- [ ] CI passes (unit + integration)
- [ ] `docker compose up -d` brings up stronghold + postgres successfully
- [ ] MCP deployer flow exercised end-to-end against the Kind cluster
- [ ] pgvector `CREATE EXTENSION vector` succeeds inside postgres container