### PR TITLE
fix: persist sentinel strikes to postgres (PR-4, refs #64, closes R22)

### DIFF
--- a/migrations/012_sentinel_strikes.sql
+++ b/migrations/012_sentinel_strikes.sql
@@ -1,0 +1,61 @@
+-- Stronghold 012: Persistent strike tracker (PR-4, BACKLOG R22)
+-- Replaces InMemoryStrikeTracker state with postgres-backed tables so strike
+-- state survives process restart and stays consistent across multi-replica
+-- Stronghold-API deployments.
+--
+-- Two tables:
+--   sentinel_strikes            -- per-user strike record (1 row per user_id)
+--   sentinel_strike_violations  -- append-only per-violation history
+--
+-- The schema mirrors the dataclass fields in
+-- src/stronghold/security/strikes.py (StrikeRecord + ViolationRecord) so the
+-- PostgresStrikeTracker and InMemoryStrikeTracker share an identical contract.
+
+-- ============================================================================
+-- sentinel_strikes: per-user strike state
+-- ============================================================================
+
+CREATE TABLE IF NOT EXISTS sentinel_strikes (
+    user_id            TEXT PRIMARY KEY,
+    org_id             TEXT NOT NULL,
+    strike_count       INTEGER NOT NULL DEFAULT 0,
+    scrutiny_level     TEXT NOT NULL DEFAULT 'normal',
+    locked_until       TIMESTAMPTZ,
+    disabled           BOOLEAN NOT NULL DEFAULT FALSE,
+    last_violation_at  TIMESTAMPTZ,
+    last_appeal        TEXT NOT NULL DEFAULT '',
+    last_appeal_at     TIMESTAMPTZ,
+    created_at         TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at         TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_sentinel_strikes_org
+    ON sentinel_strikes (org_id);
+
+CREATE INDEX IF NOT EXISTS idx_sentinel_strikes_disabled
+    ON sentinel_strikes (org_id, disabled)
+    WHERE disabled = TRUE;
+
+-- ============================================================================
+-- sentinel_strike_violations: append-only violation history
+-- ============================================================================
+
+CREATE TABLE IF NOT EXISTS sentinel_strike_violations (
+    id          BIGSERIAL PRIMARY KEY,
+    user_id     TEXT NOT NULL,
+    org_id      TEXT NOT NULL,
+    timestamp   TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    flags       TEXT[] NOT NULL DEFAULT '{}',
+    boundary    TEXT NOT NULL DEFAULT 'user_input',
+    detail      TEXT NOT NULL DEFAULT '',
+    CONSTRAINT fk_sentinel_strike_violations_user
+        FOREIGN KEY (user_id)
+        REFERENCES sentinel_strikes (user_id)
+        ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_sentinel_strike_violations_user
+    ON sentinel_strike_violations (user_id, timestamp DESC);
+
+CREATE INDEX IF NOT EXISTS idx_sentinel_strike_violations_org
+    ON sentinel_strike_violations (org_id, timestamp DESC);

--- a/src/stronghold/container.py
+++ b/src/stronghold/container.py
@@ -296,7 +296,15 @@ async def create_container(config: StrongholdConfig) -> Container:
     router = RouterEngine(quota_tracker)
     classifier = ClassifierEngine()
     warden = Warden()
-    strike_tracker = InMemoryStrikeTracker()
+    strike_tracker: Any
+    if db_pool is not None:
+        from stronghold.persistence.pg_strikes import PostgresStrikeTracker  # noqa: PLC0415
+
+        strike_tracker = PostgresStrikeTracker(db_pool)
+        logger.info("Strike tracker: PostgreSQL (persistent, multi-replica safe)")
+    else:
+        strike_tracker = InMemoryStrikeTracker()
+        logger.info("Strike tracker: InMemory (no DATABASE_URL set)")
     gate = Gate(warden=warden, strike_tracker=strike_tracker)
     sentinel = Sentinel(
         warden=warden,

--- a/src/stronghold/persistence/pg_strikes.py
+++ b/src/stronghold/persistence/pg_strikes.py
@@ -1,0 +1,417 @@
+"""PostgreSQL-backed strike tracker.
+
+Replaces :class:`stronghold.security.strikes.InMemoryStrikeTracker` for
+production deployments so strike state survives process restart and stays
+consistent across multiple Stronghold-API replicas.
+
+The contract (return types, escalation ladder, admin semantics) mirrors
+:class:`InMemoryStrikeTracker` exactly -- the same test cases cover both
+implementations.  Concurrency-safety across replicas is guaranteed by a
+``SELECT ... FOR UPDATE`` row lock inside every mutation transaction.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING
+
+from stronghold.security.strikes import (
+    DISABLED,
+    ELEVATED,
+    LOCKED,
+    LOCKOUT_DURATION,
+    NORMAL,
+    StrikeRecord,
+    ViolationRecord,
+)
+
+if TYPE_CHECKING:
+    import asyncpg
+
+logger = logging.getLogger("stronghold.persistence.pg_strikes")
+
+
+class PostgresStrikeTracker:
+    """PostgreSQL-backed strike tracker.
+
+    Implements the same protocol as :class:`InMemoryStrikeTracker`:
+    ``get``, ``record_violation``, ``submit_appeal``, ``remove_strikes``,
+    ``unlock``, ``enable``, ``get_all_for_org``.
+
+    Two tables back this class (see migration 012):
+
+    * ``sentinel_strikes``           -- one row per user with the current
+      strike state (count, scrutiny level, lockout, disabled flag, appeal).
+    * ``sentinel_strike_violations`` -- append-only log of individual
+      violation events, joined back to ``sentinel_strikes`` on ``user_id``.
+
+    Mutations that escalate strike state acquire a row-level lock via
+    ``SELECT ... FOR UPDATE`` so concurrent ``record_violation`` calls from
+    different API replicas serialize correctly and no strikes are lost.
+    """
+
+    def __init__(self, pool: asyncpg.Pool) -> None:
+        self._pool = pool
+
+    # ------------------------------------------------------------------ read
+
+    async def get(self, user_id: str) -> StrikeRecord | None:
+        """Get strike record for a user (``None`` if no record exists)."""
+        async with self._pool.acquire() as conn:
+            row = await conn.fetchrow(
+                "SELECT * FROM sentinel_strikes WHERE user_id = $1",
+                user_id,
+            )
+            if row is None:
+                return None
+            violations = await conn.fetch(
+                """SELECT timestamp, flags, boundary, detail
+                   FROM sentinel_strike_violations
+                   WHERE user_id = $1
+                   ORDER BY id ASC""",
+                user_id,
+            )
+        return _row_to_record(row, violations)
+
+    async def get_all_for_org(self, org_id: str) -> list[StrikeRecord]:
+        """Get all strike records for an org (admin view)."""
+        async with self._pool.acquire() as conn:
+            rows = await conn.fetch(
+                "SELECT * FROM sentinel_strikes WHERE org_id = $1",
+                org_id,
+            )
+            records: list[StrikeRecord] = []
+            for row in rows:
+                violations = await conn.fetch(
+                    """SELECT timestamp, flags, boundary, detail
+                       FROM sentinel_strike_violations
+                       WHERE user_id = $1
+                       ORDER BY id ASC""",
+                    row["user_id"],
+                )
+                records.append(_row_to_record(row, violations))
+        return records
+
+    # ------------------------------------------------------------------ write
+
+    async def record_violation(
+        self,
+        *,
+        user_id: str,
+        org_id: str,
+        flags: tuple[str, ...],
+        boundary: str = "user_input",
+        detail: str = "",
+    ) -> StrikeRecord:
+        """Record a violation and escalate strike level.
+
+        Atomic under concurrent writers: the transaction upserts the
+        ``sentinel_strikes`` row, acquires a row lock via
+        ``SELECT ... FOR UPDATE``, increments ``strike_count``, applies
+        the escalation ladder, appends the violation row, and commits.
+        """
+        now = datetime.now(UTC)
+        async with self._pool.acquire() as conn, conn.transaction():
+            # Ensure a row exists, then lock it.  The INSERT ... ON CONFLICT
+            # DO NOTHING + SELECT FOR UPDATE pattern avoids lost updates
+            # when two replicas race on the first violation for a user.
+            await conn.execute(
+                """INSERT INTO sentinel_strikes (user_id, org_id)
+                   VALUES ($1, $2)
+                   ON CONFLICT (user_id) DO NOTHING""",
+                user_id,
+                org_id,
+            )
+            row = await conn.fetchrow(
+                "SELECT * FROM sentinel_strikes WHERE user_id = $1 FOR UPDATE",
+                user_id,
+            )
+            assert row is not None  # just inserted or already existed
+
+            new_count: int = int(row["strike_count"]) + 1
+            scrutiny = str(row["scrutiny_level"])
+            locked_until = row["locked_until"]
+            disabled = bool(row["disabled"])
+
+            if new_count >= 3:
+                scrutiny = DISABLED
+                disabled = True
+                logger.warning(
+                    "ACCOUNT DISABLED: user=%s org=%s strikes=%d",
+                    user_id,
+                    org_id,
+                    new_count,
+                )
+            elif new_count == 2:
+                scrutiny = LOCKED
+                locked_until = now + LOCKOUT_DURATION
+                logger.warning(
+                    "ACCOUNT LOCKED: user=%s org=%s until=%s",
+                    user_id,
+                    org_id,
+                    locked_until.isoformat(),
+                )
+            elif new_count == 1:
+                scrutiny = ELEVATED
+                logger.warning(
+                    "STRIKE 1: user=%s org=%s -- elevated scrutiny enabled",
+                    user_id,
+                    org_id,
+                )
+
+            updated = await conn.fetchrow(
+                """UPDATE sentinel_strikes SET
+                     strike_count = $2,
+                     scrutiny_level = $3,
+                     locked_until = $4,
+                     disabled = $5,
+                     last_violation_at = $6,
+                     updated_at = NOW()
+                   WHERE user_id = $1
+                   RETURNING *""",
+                user_id,
+                new_count,
+                scrutiny,
+                locked_until,
+                disabled,
+                now,
+            )
+            await conn.execute(
+                """INSERT INTO sentinel_strike_violations
+                     (user_id, org_id, timestamp, flags, boundary, detail)
+                   VALUES ($1, $2, $3, $4, $5, $6)""",
+                user_id,
+                org_id,
+                now,
+                list(flags),
+                boundary,
+                detail,
+            )
+            violations = await conn.fetch(
+                """SELECT timestamp, flags, boundary, detail
+                   FROM sentinel_strike_violations
+                   WHERE user_id = $1
+                   ORDER BY id ASC""",
+                user_id,
+            )
+
+        assert updated is not None
+        return _row_to_record(updated, violations)
+
+    async def submit_appeal(self, user_id: str, appeal_text: str) -> bool:
+        """Submit an appeal for a strike.  Returns True if recorded."""
+        async with self._pool.acquire() as conn, conn.transaction():
+            row = await conn.fetchrow(
+                "SELECT strike_count FROM sentinel_strikes WHERE user_id = $1 FOR UPDATE",
+                user_id,
+            )
+            if row is None or int(row["strike_count"]) == 0:
+                return False
+            await conn.execute(
+                """UPDATE sentinel_strikes SET
+                     last_appeal = $2,
+                     last_appeal_at = NOW(),
+                     updated_at = NOW()
+                   WHERE user_id = $1""",
+                user_id,
+                appeal_text,
+            )
+        logger.info("Appeal submitted: user=%s text=%s", user_id, appeal_text[:100])
+        return True
+
+    async def remove_strikes(
+        self,
+        user_id: str,
+        count: int | None = None,
+    ) -> StrikeRecord | None:
+        """Remove strikes from a user.  ``count=None`` clears all.
+
+        Called by admins.  Recalculates scrutiny level from the new count
+        using the same rules as :meth:`InMemoryStrikeTracker._recalculate_level`.
+        """
+        async with self._pool.acquire() as conn, conn.transaction():
+            row = await conn.fetchrow(
+                "SELECT * FROM sentinel_strikes WHERE user_id = $1 FOR UPDATE",
+                user_id,
+            )
+            if row is None:
+                return None
+
+            current = int(row["strike_count"])
+            new_count = 0 if count is None else max(0, current - count)
+            scrutiny, disabled, locked_until = _recalculate_level(
+                new_count,
+                current_locked_until=row["locked_until"],
+            )
+
+            updated = await conn.fetchrow(
+                """UPDATE sentinel_strikes SET
+                     strike_count = $2,
+                     scrutiny_level = $3,
+                     locked_until = $4,
+                     disabled = $5,
+                     updated_at = NOW()
+                   WHERE user_id = $1
+                   RETURNING *""",
+                user_id,
+                new_count,
+                scrutiny,
+                locked_until,
+                disabled,
+            )
+            violations = await conn.fetch(
+                """SELECT timestamp, flags, boundary, detail
+                   FROM sentinel_strike_violations
+                   WHERE user_id = $1
+                   ORDER BY id ASC""",
+                user_id,
+            )
+
+        assert updated is not None
+        logger.info(
+            "Strikes removed: user=%s new_count=%d level=%s",
+            user_id,
+            new_count,
+            scrutiny,
+        )
+        return _row_to_record(updated, violations)
+
+    async def unlock(self, user_id: str) -> StrikeRecord | None:
+        """Unlock a locked account (team_admin+ action).
+
+        Clears ``locked_until`` but does NOT remove strikes.  If the account
+        is still disabled, scrutiny stays at DISABLED (admin must call
+        :meth:`enable` to re-enable).
+        """
+        async with self._pool.acquire() as conn, conn.transaction():
+            row = await conn.fetchrow(
+                "SELECT * FROM sentinel_strikes WHERE user_id = $1 FOR UPDATE",
+                user_id,
+            )
+            if row is None:
+                return None
+
+            disabled = bool(row["disabled"])
+            strike_count = int(row["strike_count"])
+            scrutiny = str(row["scrutiny_level"])
+            if not disabled:
+                scrutiny = ELEVATED if strike_count >= 1 else NORMAL
+
+            updated = await conn.fetchrow(
+                """UPDATE sentinel_strikes SET
+                     locked_until = NULL,
+                     scrutiny_level = $2,
+                     updated_at = NOW()
+                   WHERE user_id = $1
+                   RETURNING *""",
+                user_id,
+                scrutiny,
+            )
+            violations = await conn.fetch(
+                """SELECT timestamp, flags, boundary, detail
+                   FROM sentinel_strike_violations
+                   WHERE user_id = $1
+                   ORDER BY id ASC""",
+                user_id,
+            )
+
+        assert updated is not None
+        logger.info("Account unlocked: user=%s", user_id)
+        return _row_to_record(updated, violations)
+
+    async def enable(self, user_id: str) -> StrikeRecord | None:
+        """Re-enable a disabled account (org_admin+ action).
+
+        Clears ``disabled`` and ``locked_until`` but does NOT remove strikes.
+        Scrutiny falls back to ELEVATED if any strikes remain, else NORMAL.
+        """
+        async with self._pool.acquire() as conn, conn.transaction():
+            row = await conn.fetchrow(
+                "SELECT * FROM sentinel_strikes WHERE user_id = $1 FOR UPDATE",
+                user_id,
+            )
+            if row is None:
+                return None
+
+            strike_count = int(row["strike_count"])
+            scrutiny = ELEVATED if strike_count >= 1 else NORMAL
+
+            updated = await conn.fetchrow(
+                """UPDATE sentinel_strikes SET
+                     disabled = FALSE,
+                     locked_until = NULL,
+                     scrutiny_level = $2,
+                     updated_at = NOW()
+                   WHERE user_id = $1
+                   RETURNING *""",
+                user_id,
+                scrutiny,
+            )
+            violations = await conn.fetch(
+                """SELECT timestamp, flags, boundary, detail
+                   FROM sentinel_strike_violations
+                   WHERE user_id = $1
+                   ORDER BY id ASC""",
+                user_id,
+            )
+
+        assert updated is not None
+        logger.info("Account re-enabled: user=%s", user_id)
+        return _row_to_record(updated, violations)
+
+
+# ---------------------------------------------------------------------- helpers
+
+
+def _recalculate_level(
+    new_count: int,
+    *,
+    current_locked_until: datetime | None,
+) -> tuple[str, bool, datetime | None]:
+    """Recalculate (scrutiny_level, disabled, locked_until) from strike count.
+
+    Mirrors :meth:`InMemoryStrikeTracker._recalculate_level` exactly:
+
+    * 3+  -> DISABLED, disabled=True, locked_until preserved
+    * 2   -> LOCKED, disabled unchanged, locked_until preserved
+            (admin may have unlocked; we never re-lock here)
+    * 1   -> ELEVATED, disabled=False, locked_until=None
+    * 0   -> NORMAL,   disabled=False, locked_until=None
+    """
+    if new_count >= 3:
+        return DISABLED, True, current_locked_until
+    if new_count == 2:
+        # Do not re-lock if admin already unlocked -- preserve current value.
+        return LOCKED, False, current_locked_until
+    if new_count >= 1:
+        return ELEVATED, False, None
+    return NORMAL, False, None
+
+
+def _row_to_record(
+    row: asyncpg.Record,
+    violation_rows: list[asyncpg.Record],
+) -> StrikeRecord:
+    """Convert a ``sentinel_strikes`` row (+ its violations) to StrikeRecord."""
+    record = StrikeRecord(
+        user_id=str(row["user_id"]),
+        org_id=str(row["org_id"]),
+        strike_count=int(row["strike_count"]),
+        scrutiny_level=str(row["scrutiny_level"]),
+        locked_until=row["locked_until"],
+        disabled=bool(row["disabled"]),
+        last_violation_at=row["last_violation_at"],
+        last_appeal=str(row["last_appeal"]),
+        last_appeal_at=row["last_appeal_at"],
+    )
+    record.violations = [
+        ViolationRecord(
+            timestamp=vrow["timestamp"],
+            flags=tuple(vrow["flags"]),
+            boundary=str(vrow["boundary"]),
+            detail=str(vrow["detail"]),
+        )
+        for vrow in violation_rows
+    ]
+    return record

--- a/tests/fakes.py
+++ b/tests/fakes.py
@@ -273,6 +273,56 @@ class FakeViolationStore:
         return []
 
 
+class FakeStrikeTracker:
+    """Fake strike tracker for tests that don't want a real Postgres connection.
+
+    Thin wrapper around :class:`InMemoryStrikeTracker` so test code that
+    imports ``FakeStrikeTracker`` from ``tests.fakes`` stays independent of
+    the production module's import path.  Semantics are identical to the
+    in-memory implementation; no DB calls, no async lock contention, no I/O.
+    """
+
+    def __init__(self) -> None:
+        from stronghold.security.strikes import InMemoryStrikeTracker  # noqa: PLC0415
+
+        self._impl = InMemoryStrikeTracker()
+
+    async def get(self, user_id: str) -> Any:
+        return await self._impl.get(user_id)
+
+    async def record_violation(
+        self,
+        *,
+        user_id: str,
+        org_id: str,
+        flags: tuple[str, ...],
+        boundary: str = "user_input",
+        detail: str = "",
+    ) -> Any:
+        return await self._impl.record_violation(
+            user_id=user_id,
+            org_id=org_id,
+            flags=flags,
+            boundary=boundary,
+            detail=detail,
+        )
+
+    async def submit_appeal(self, user_id: str, appeal_text: str) -> bool:
+        return await self._impl.submit_appeal(user_id, appeal_text)
+
+    async def remove_strikes(self, user_id: str, count: int | None = None) -> Any:
+        return await self._impl.remove_strikes(user_id, count)
+
+    async def unlock(self, user_id: str) -> Any:
+        return await self._impl.unlock(user_id)
+
+    async def enable(self, user_id: str) -> Any:
+        return await self._impl.enable(user_id)
+
+    async def get_all_for_org(self, org_id: str) -> list[Any]:
+        return await self._impl.get_all_for_org(org_id)
+
+
 # ── Test container factory ───────────────────────────────────────────
 # Use these instead of constructing Container manually.
 

--- a/tests/security/test_postgres_strike_tracker.py
+++ b/tests/security/test_postgres_strike_tracker.py
@@ -1,0 +1,453 @@
+"""Integration tests for PostgresStrikeTracker (PR-4, BACKLOG R22).
+
+These tests run against a real PostgreSQL instance so we can verify:
+
+* strikes persist across a fresh tracker instance (process restart)
+* concurrent ``record_violation`` calls from two tracker instances
+  serialize correctly and no strikes are lost
+* strike counts, scrutiny levels, lockout, disabled flag, appeals, and the
+  violations history all round-trip through the DB
+* the 012 migration applies cleanly on an empty database
+
+The tests skip if ``STRONGHOLD_TEST_DATABASE_URL`` is not set, so they are
+safe to run in CI environments without a Postgres fixture.  To run locally::
+
+    docker run --rm -d -p 5555:5432 \\
+        -e POSTGRES_PASSWORD=stronghold -e POSTGRES_DB=stronghold_test \\
+        --name pg-sh-test postgres:16
+    export STRONGHOLD_TEST_DATABASE_URL=postgresql://postgres:stronghold@localhost:5555/stronghold_test
+    pytest tests/security/test_postgres_strike_tracker.py -v
+
+No mocks are used -- only real asyncpg connections against a real database.
+The in-memory tracker's unit tests (test_strikes_coverage.py) continue to
+validate the InMemoryStrikeTracker variant which is still used as the
+dev/test fallback when DATABASE_URL is unset.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import pytest
+
+from stronghold.security.strikes import (
+    DISABLED,
+    ELEVATED,
+    LOCKED,
+    LOCKOUT_DURATION,
+    NORMAL,
+)
+
+if TYPE_CHECKING:
+    import asyncpg
+
+# Skip the whole module when no test DB is configured.
+_DB_URL = os.environ.get("STRONGHOLD_TEST_DATABASE_URL")
+pytestmark = pytest.mark.skipif(
+    _DB_URL is None,
+    reason="STRONGHOLD_TEST_DATABASE_URL not set -- skipping pg integration tests",
+)
+
+
+# ── Migration helpers ───────────────────────────────────────────────────
+
+_MIGRATION_FILENAME = "012_sentinel_strikes.sql"
+
+
+def _find_migration() -> Path:
+    """Locate the 012 migration file relative to the repo root."""
+    here = Path(__file__).resolve()
+    for parent in here.parents:
+        candidate = parent / "migrations" / _MIGRATION_FILENAME
+        if candidate.exists():
+            return candidate
+    msg = f"Could not locate {_MIGRATION_FILENAME} above {here}"
+    raise RuntimeError(msg)
+
+
+async def _apply_migration(pool: asyncpg.Pool) -> None:
+    """Drop and re-create the sentinel strikes tables on each test run."""
+    migration_sql = _find_migration().read_text()
+    async with pool.acquire() as conn:
+        await conn.execute(
+            "DROP TABLE IF EXISTS sentinel_strike_violations CASCADE;"
+            "DROP TABLE IF EXISTS sentinel_strikes CASCADE;"
+        )
+        await conn.execute(migration_sql)
+
+
+# ── Fixtures ────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+async def pg_pool() -> asyncpg.Pool:
+    """Connection pool against the test Postgres instance."""
+    import asyncpg  # noqa: PLC0415
+
+    assert _DB_URL is not None
+    pool = await asyncpg.create_pool(_DB_URL, min_size=1, max_size=5)
+    assert pool is not None
+    try:
+        await _apply_migration(pool)
+        yield pool
+    finally:
+        async with pool.acquire() as conn:
+            await conn.execute(
+                "DROP TABLE IF EXISTS sentinel_strike_violations CASCADE;"
+                "DROP TABLE IF EXISTS sentinel_strikes CASCADE;"
+            )
+        await pool.close()
+
+
+@pytest.fixture
+def tracker(pg_pool: asyncpg.Pool) -> PostgresStrikeTracker:  # noqa: F821
+    from stronghold.persistence.pg_strikes import PostgresStrikeTracker  # noqa: PLC0415
+
+    return PostgresStrikeTracker(pg_pool)
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# Migration
+# ═══════════════════════════════════════════════════════════════════════
+
+
+class TestMigration:
+    """012 migration applies cleanly and creates the expected schema."""
+
+    async def test_tables_exist(self, pg_pool: asyncpg.Pool) -> None:
+        async with pg_pool.acquire() as conn:
+            strikes = await conn.fetchval(
+                "SELECT EXISTS(SELECT 1 FROM information_schema.tables "
+                "WHERE table_name = 'sentinel_strikes')"
+            )
+            violations = await conn.fetchval(
+                "SELECT EXISTS(SELECT 1 FROM information_schema.tables "
+                "WHERE table_name = 'sentinel_strike_violations')"
+            )
+        assert strikes is True
+        assert violations is True
+
+    async def test_sentinel_strikes_columns(self, pg_pool: asyncpg.Pool) -> None:
+        async with pg_pool.acquire() as conn:
+            rows = await conn.fetch(
+                "SELECT column_name FROM information_schema.columns "
+                "WHERE table_name = 'sentinel_strikes'"
+            )
+        cols = {r["column_name"] for r in rows}
+        # Every dataclass field on StrikeRecord is represented in the table.
+        expected = {
+            "user_id",
+            "org_id",
+            "strike_count",
+            "scrutiny_level",
+            "locked_until",
+            "disabled",
+            "last_violation_at",
+            "last_appeal",
+            "last_appeal_at",
+        }
+        missing = expected - cols
+        assert not missing, f"missing columns: {missing}"
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# Persistence across tracker instances (simulates process restart)
+# ═══════════════════════════════════════════════════════════════════════
+
+
+class TestPersistence:
+    """Strike state survives across tracker instances sharing a pool."""
+
+    async def test_strike_persists_across_instances(
+        self,
+        pg_pool: asyncpg.Pool,
+    ) -> None:
+        from stronghold.persistence.pg_strikes import PostgresStrikeTracker  # noqa: PLC0415
+
+        t1 = PostgresStrikeTracker(pg_pool)
+        await t1.record_violation(
+            user_id="persist_user",
+            org_id="acme",
+            flags=("injection",),
+            boundary="user_input",
+            detail="first violation",
+        )
+
+        # New tracker instance == simulated process restart.
+        t2 = PostgresStrikeTracker(pg_pool)
+        record = await t2.get("persist_user")
+
+        assert record is not None
+        assert record.strike_count == 1
+        assert record.scrutiny_level == ELEVATED
+        assert record.org_id == "acme"
+        assert len(record.violations) == 1
+        assert record.violations[0].flags == ("injection",)
+        assert record.violations[0].detail == "first violation"
+
+    async def test_unknown_user_returns_none(
+        self,
+        tracker: PostgresStrikeTracker,  # noqa: F821
+    ) -> None:
+        assert await tracker.get("no_such_user") is None
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# Escalation ladder (mirrors test_strikes_coverage.py)
+# ═══════════════════════════════════════════════════════════════════════
+
+
+class TestEscalation:
+    """Warn -> lock -> disable escalation, identical to InMemoryStrikeTracker."""
+
+    async def test_strike_1_elevated(
+        self,
+        tracker: PostgresStrikeTracker,  # noqa: F821
+    ) -> None:
+        r = await tracker.record_violation(
+            user_id="u1",
+            org_id="acme",
+            flags=("f",),
+        )
+        assert r.strike_count == 1
+        assert r.scrutiny_level == ELEVATED
+        assert r.disabled is False
+        assert r.locked_until is None
+
+    async def test_strike_2_locked(
+        self,
+        tracker: PostgresStrikeTracker,  # noqa: F821
+    ) -> None:
+        for _ in range(2):
+            r = await tracker.record_violation(user_id="u1", org_id="acme", flags=("f",))
+        assert r.strike_count == 2
+        assert r.scrutiny_level == LOCKED
+        assert r.locked_until is not None
+        assert r.disabled is False
+        expected_min = datetime.now(UTC) + LOCKOUT_DURATION - timedelta(seconds=10)
+        assert r.locked_until >= expected_min
+        assert r.is_locked is True
+
+    async def test_strike_3_disabled(
+        self,
+        tracker: PostgresStrikeTracker,  # noqa: F821
+    ) -> None:
+        for _ in range(3):
+            r = await tracker.record_violation(user_id="u1", org_id="acme", flags=("f",))
+        assert r.strike_count == 3
+        assert r.scrutiny_level == DISABLED
+        assert r.disabled is True
+        assert r.is_locked is True
+
+    async def test_violations_accumulate_ordered(
+        self,
+        tracker: PostgresStrikeTracker,  # noqa: F821
+    ) -> None:
+        await tracker.record_violation(
+            user_id="u1", org_id="acme", flags=("first",), boundary="user_input"
+        )
+        await tracker.record_violation(
+            user_id="u1", org_id="acme", flags=("second",), boundary="tool_result"
+        )
+        record = await tracker.get("u1")
+        assert record is not None
+        assert len(record.violations) == 2
+        assert record.violations[0].flags == ("first",)
+        assert record.violations[0].boundary == "user_input"
+        assert record.violations[1].flags == ("second",)
+        assert record.violations[1].boundary == "tool_result"
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# Concurrency: no lost updates under multi-replica writers
+# ═══════════════════════════════════════════════════════════════════════
+
+
+class TestConcurrency:
+    """Two trackers on the same pool must not lose strikes under concurrency."""
+
+    async def test_concurrent_violations_no_lost_updates(
+        self,
+        pg_pool: asyncpg.Pool,
+    ) -> None:
+        from stronghold.persistence.pg_strikes import PostgresStrikeTracker  # noqa: PLC0415
+
+        t1 = PostgresStrikeTracker(pg_pool)
+        t2 = PostgresStrikeTracker(pg_pool)
+
+        async def hit(tracker: PostgresStrikeTracker) -> None:
+            await tracker.record_violation(
+                user_id="race_user",
+                org_id="acme",
+                flags=("race",),
+            )
+
+        # 10 concurrent violations split across two "replicas".
+        tasks = [hit(t1 if i % 2 == 0 else t2) for i in range(10)]
+        await asyncio.gather(*tasks)
+
+        record = await t1.get("race_user")
+        assert record is not None
+        # Every single violation must have landed.  If SELECT FOR UPDATE
+        # were missing, this would typically be less than 10.
+        assert record.strike_count == 10
+        assert len(record.violations) == 10
+        # count >= 3 so the user ends up DISABLED.
+        assert record.disabled is True
+        assert record.scrutiny_level == DISABLED
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# Admin actions: remove_strikes / unlock / enable / submit_appeal
+# ═══════════════════════════════════════════════════════════════════════
+
+
+class TestAdminActions:
+    async def test_remove_strikes_clear_all(
+        self,
+        tracker: PostgresStrikeTracker,  # noqa: F821
+    ) -> None:
+        for _ in range(3):
+            await tracker.record_violation(user_id="u1", org_id="acme", flags=("f",))
+        r = await tracker.remove_strikes("u1", count=None)
+        assert r is not None
+        assert r.strike_count == 0
+        assert r.scrutiny_level == NORMAL
+        assert r.disabled is False
+        assert r.locked_until is None
+
+    async def test_remove_strikes_partial(
+        self,
+        tracker: PostgresStrikeTracker,  # noqa: F821
+    ) -> None:
+        for _ in range(3):
+            await tracker.record_violation(user_id="u1", org_id="acme", flags=("f",))
+        r = await tracker.remove_strikes("u1", count=2)
+        assert r is not None
+        assert r.strike_count == 1
+        assert r.scrutiny_level == ELEVATED
+        assert r.disabled is False
+        assert r.locked_until is None
+
+    async def test_remove_strikes_clamps_at_zero(
+        self,
+        tracker: PostgresStrikeTracker,  # noqa: F821
+    ) -> None:
+        await tracker.record_violation(user_id="u1", org_id="acme", flags=("f",))
+        r = await tracker.remove_strikes("u1", count=10)
+        assert r is not None
+        assert r.strike_count == 0
+        assert r.scrutiny_level == NORMAL
+
+    async def test_remove_strikes_unknown_user(
+        self,
+        tracker: PostgresStrikeTracker,  # noqa: F821
+    ) -> None:
+        assert await tracker.remove_strikes("ghost") is None
+
+    async def test_unlock_clears_lockout_keeps_strikes(
+        self,
+        tracker: PostgresStrikeTracker,  # noqa: F821
+    ) -> None:
+        for _ in range(2):
+            await tracker.record_violation(user_id="u1", org_id="acme", flags=("f",))
+        r = await tracker.unlock("u1")
+        assert r is not None
+        assert r.locked_until is None
+        assert r.strike_count == 2
+        assert r.scrutiny_level == ELEVATED
+        assert r.is_locked is False
+
+    async def test_unlock_disabled_stays_disabled(
+        self,
+        tracker: PostgresStrikeTracker,  # noqa: F821
+    ) -> None:
+        for _ in range(3):
+            await tracker.record_violation(user_id="u1", org_id="acme", flags=("f",))
+        r = await tracker.unlock("u1")
+        assert r is not None
+        assert r.disabled is True
+        assert r.is_locked is True
+
+    async def test_unlock_unknown_user(
+        self,
+        tracker: PostgresStrikeTracker,  # noqa: F821
+    ) -> None:
+        assert await tracker.unlock("ghost") is None
+
+    async def test_enable_clears_disabled(
+        self,
+        tracker: PostgresStrikeTracker,  # noqa: F821
+    ) -> None:
+        for _ in range(3):
+            await tracker.record_violation(user_id="u1", org_id="acme", flags=("f",))
+        r = await tracker.enable("u1")
+        assert r is not None
+        assert r.disabled is False
+        assert r.locked_until is None
+        assert r.scrutiny_level == ELEVATED
+        assert r.strike_count == 3
+        assert r.is_locked is False
+
+    async def test_enable_unknown_user(
+        self,
+        tracker: PostgresStrikeTracker,  # noqa: F821
+    ) -> None:
+        assert await tracker.enable("ghost") is None
+
+    async def test_submit_appeal_success(
+        self,
+        tracker: PostgresStrikeTracker,  # noqa: F821
+    ) -> None:
+        await tracker.record_violation(user_id="u1", org_id="acme", flags=("f",))
+        ok = await tracker.submit_appeal("u1", "please reconsider")
+        assert ok is True
+        r = await tracker.get("u1")
+        assert r is not None
+        assert r.last_appeal == "please reconsider"
+        assert r.last_appeal_at is not None
+
+    async def test_submit_appeal_unknown_user(
+        self,
+        tracker: PostgresStrikeTracker,  # noqa: F821
+    ) -> None:
+        assert await tracker.submit_appeal("ghost", "please") is False
+
+    async def test_submit_appeal_zero_strikes(
+        self,
+        tracker: PostgresStrikeTracker,  # noqa: F821
+    ) -> None:
+        await tracker.record_violation(user_id="u1", org_id="acme", flags=("f",))
+        await tracker.remove_strikes("u1", count=None)
+        assert await tracker.submit_appeal("u1", "please") is False
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# get_all_for_org
+# ═══════════════════════════════════════════════════════════════════════
+
+
+class TestGetAllForOrg:
+    async def test_returns_org_users_only(
+        self,
+        tracker: PostgresStrikeTracker,  # noqa: F821
+    ) -> None:
+        await tracker.record_violation(user_id="u1", org_id="acme", flags=("f",))
+        await tracker.record_violation(user_id="u2", org_id="acme", flags=("f",))
+        await tracker.record_violation(user_id="u3", org_id="other", flags=("f",))
+
+        acme = await tracker.get_all_for_org("acme")
+        assert {r.user_id for r in acme} == {"u1", "u2"}
+
+        other = await tracker.get_all_for_org("other")
+        assert {r.user_id for r in other} == {"u3"}
+
+    async def test_empty_org(
+        self,
+        tracker: PostgresStrikeTracker,  # noqa: F821
+    ) -> None:
+        assert await tracker.get_all_for_org("nonexistent") == []


### PR DESCRIPTION
## Summary

PR-4 of the v0.9 K8s hardening sequence (parent epic #64). Closes BACKLOG R22.

Replaces ``InMemoryStrikeTracker`` with a postgres-backed implementation so sentinel strikes survive process restart and multiple API replicas don't lose strike counts under concurrent writes.

## What's in this PR

| File | Lines | Purpose |
|---|---|---|
| ``migrations/012_sentinel_strikes.sql`` | 61 | New ``sentinel_strikes`` (1 row per user) + ``sentinel_strike_violations`` (append-only history) tables |
| ``src/stronghold/persistence/pg_strikes.py`` | 417 | ``PostgresStrikeTracker`` class — same public surface as ``InMemoryStrikeTracker`` |
| ``src/stronghold/container.py`` | +9/-1 | Wires ``PostgresStrikeTracker`` when a ``db_pool`` is present, falls back to in-memory otherwise |
| ``tests/security/test_postgres_strike_tracker.py`` | 427 | Real-postgres integration test (gated by ``STRONGHOLD_TEST_DATABASE_URL``) |
| ``tests/fakes.py`` | +50 | New ``FakeStrikeTracker`` (thin wrapper around in-memory for tests that don't want a real DB) |

## Schema

``sentinel_strikes``: ``user_id`` (PK text), ``org_id``, ``strike_count``, ``scrutiny_level``, ``locked_until``, ``disabled``, ``last_violation_at``, ``last_appeal``, ``last_appeal_at``, ``created_at``, ``updated_at``. Indexed on ``org_id`` plus a partial index on ``(org_id) WHERE disabled=TRUE``.

``sentinel_strike_violations``: ``id`` (BIGSERIAL), ``user_id``, ``org_id``, ``timestamp``, ``flags`` (TEXT[]), ``boundary``, ``detail``. ``ON DELETE CASCADE`` from ``sentinel_strikes``. Indexed on ``(user_id, timestamp DESC)`` and ``(org_id, timestamp DESC)``.

## Concurrency model

Every mutation runs inside a transaction that does ``INSERT ... ON CONFLICT DO NOTHING`` followed by ``SELECT ... FOR UPDATE`` on the strike row. The row lock serializes concurrent writes from any number of API replicas.

The test ``TestConcurrency::test_concurrent_violations_no_lost_updates`` fires 10 simultaneous violations across two tracker instances and asserts the final strike count is exactly 10.

## What's deliberately NOT changed

- The escalation rules in ``_recalculate_level`` are byte-for-byte equivalent to the in-memory tracker (3+→DISABLED preserving ``locked_until``, 2→LOCKED preserving ``locked_until``, 1→ELEVATED, 0→NORMAL). No semantics change.
- No decay/expiry mechanism added — the existing tracker has none, so this PR preserves that contract. ``locked_until`` is the only timestamp with semantic meaning and is preserved verbatim.
- No new ``protocols/strikes.py`` — Stronghold doesn't have one; the in-memory class is the de-facto interface and ``PostgresStrikeTracker`` matches its public surface exactly.
- ``tests/security/test_strikes_coverage.py`` (in-memory tests) untouched.
- Pre-existing format drift in ``tests/fakes.py`` line 219 (``FakeRateLimiter``) left alone — verified identical in upstream, out of scope.

## Verification

- ``ruff check`` on new/modified files: **clean**
- ``ruff format --check`` on new files: **clean**
- ``mypy src/stronghold/persistence/pg_strikes.py --strict``: **Success**
- ``mypy src/stronghold/security/ --strict``: **Success: no issues in 23 source files**
- ``mypy src/stronghold/container.py --strict``: **Success**

Full pytest run requires a live postgres; the new suite skips cleanly without ``STRONGHOLD_TEST_DATABASE_URL``. CI needs to provision a postgres (or mark these tests integration-tier) for full coverage.

## Test plan

- [ ] CI passes with a postgres available (the new tests must run, not skip)
- [ ] ``InMemoryStrikeTracker`` tests still pass unchanged
- [ ] Manual smoke test: trigger N strikes, restart Stronghold-API, verify strike state preserved