### PR TITLE
feat(helm): workload templates — postgres + stronghold + sidecar + litellm + phoenix + mcp + routes/ingress (PR-7..PR-10, refs #64, closes R3)

### DIFF
--- a/deploy/helm/stronghold/files/litellm-proxy-config.yaml
+++ b/deploy/helm/stronghold/files/litellm-proxy-config.yaml
@@ -1,0 +1,1501 @@
+model_list:
+- model_name: mistral-large
+  litellm_params:
+    model: mistral/mistral-large-latest
+    api_key: os.environ/MISTRAL_API_KEY
+    max_budget: 400.0
+    budget_duration: 30d
+    rpm: 60
+    tpm: 500000
+  model_info:
+    input_cost_per_token: 1.0e-06
+    output_cost_per_token: 1.0e-06
+- model_name: mistral-codestral
+  litellm_params:
+    model: mistral/codestral-latest
+    api_key: os.environ/MISTRAL_API_KEY
+    max_budget: 83.333333
+    budget_duration: 30d
+    rpm: 60
+    tpm: 100000
+  model_info:
+    input_cost_per_token: 1.0e-06
+    output_cost_per_token: 1.0e-06
+- model_name: mistral-devstral
+  litellm_params:
+    model: mistral/devstral-latest
+    api_key: os.environ/MISTRAL_API_KEY
+    max_budget: 200.0
+    budget_duration: 30d
+    rpm: 60
+    tpm: 500000
+  model_info:
+    input_cost_per_token: 1.0e-06
+    output_cost_per_token: 1.0e-06
+- model_name: mistral-small
+  litellm_params:
+    model: mistral/mistral-small-latest
+    api_key: os.environ/MISTRAL_API_KEY
+    max_budget: 100.0
+    budget_duration: 30d
+    rpm: 60
+    tpm: 500000
+  model_info:
+    input_cost_per_token: 1.0e-06
+    output_cost_per_token: 1.0e-06
+- model_name: cerebras-llama8b
+  litellm_params:
+    model: cerebras/llama3.1-8b
+    api_key: os.environ/CEREBRAS_API_KEY
+    max_budget: 1.0
+    budget_duration: 1d
+    rpm: 30
+    tpm: 100000
+  model_info:
+    input_cost_per_token: 1.0e-06
+    output_cost_per_token: 1.0e-06
+- model_name: gemini-flash
+  litellm_params:
+    model: gemini/gemini-2.5-flash
+    api_key: os.environ/GEMINI_API_KEY
+    max_budget: 0.04
+    budget_duration: 1d
+    rpm: 5
+    tpm: 250000
+  model_info:
+    input_cost_per_token: 1.0e-06
+    output_cost_per_token: 1.0e-06
+- model_name: gemini-3-flash
+  litellm_params:
+    model: gemini/gemini-3-flash-preview
+    api_key: os.environ/GEMINI_API_KEY
+    max_budget: 0.04
+    budget_duration: 1d
+    rpm: 5
+    tpm: 250000
+  model_info:
+    input_cost_per_token: 1.0e-06
+    output_cost_per_token: 1.0e-06
+- model_name: gemini-flash-lite
+  litellm_params:
+    model: gemini/gemini-2.5-flash-lite
+    api_key: os.environ/GEMINI_API_KEY
+    max_budget: 0.04
+    budget_duration: 1d
+    rpm: 10
+    tpm: 250000
+  model_info:
+    input_cost_per_token: 1.0e-06
+    output_cost_per_token: 1.0e-06
+- model_name: gemma-27b
+  litellm_params:
+    model: gemini/gemma-3-27b-it
+    api_key: os.environ/GEMINI_API_KEY
+    max_budget: 28.8
+    budget_duration: 1d
+    rpm: 30
+    tpm: 15000
+  model_info:
+    input_cost_per_token: 1.0e-06
+    output_cost_per_token: 1.0e-06
+- model_name: gemma-12b
+  litellm_params:
+    model: gemini/gemma-3-12b-it
+    api_key: os.environ/GEMINI_API_KEY
+    max_budget: 28.8
+    budget_duration: 1d
+    rpm: 30
+    tpm: 15000
+  model_info:
+    input_cost_per_token: 1.0e-06
+    output_cost_per_token: 1.0e-06
+- model_name: gemma-4b
+  litellm_params:
+    model: gemini/gemma-3-4b-it
+    api_key: os.environ/GEMINI_API_KEY
+    max_budget: 28.8
+    budget_duration: 1d
+    rpm: 30
+    tpm: 15000
+  model_info:
+    input_cost_per_token: 1.0e-06
+    output_cost_per_token: 1.0e-06
+- model_name: imagen-4
+  litellm_params:
+    model: gemini/imagen-4-generate
+    api_key: os.environ/GEMINI_API_KEY
+    max_budget: 0.25
+    budget_duration: 1d
+  model_info:
+    input_cost_per_token: 0.01
+    output_cost_per_token: 0.0
+- model_name: imagen-4-fast
+  litellm_params:
+    model: gemini/imagen-4-fast-generate
+    api_key: os.environ/GEMINI_API_KEY
+    max_budget: 0.25
+    budget_duration: 1d
+  model_info:
+    input_cost_per_token: 0.01
+    output_cost_per_token: 0.0
+- model_name: imagen-4-ultra
+  litellm_params:
+    model: gemini/imagen-4-ultra-generate
+    api_key: os.environ/GEMINI_API_KEY
+    max_budget: 0.25
+    budget_duration: 1d
+  model_info:
+    input_cost_per_token: 0.01
+    output_cost_per_token: 0.0
+- model_name: gemini-embedding
+  litellm_params:
+    model: gemini/gemini-embedding-1
+    api_key: os.environ/GEMINI_API_KEY
+    max_budget: 0.1
+    budget_duration: 1d
+    rpm: 100
+    tpm: 30000
+  model_info:
+    input_cost_per_token: 1.0e-06
+    output_cost_per_token: 1.0e-06
+- model_name: openrouter-google/gemini-3.1-pro
+  litellm_params:
+    model: openrouter/google/gemini-3.1-pro-preview
+    api_key: os.environ/OPENROUTER_API_KEY
+    max_budget: 0.666666
+    budget_duration: 30d
+    rpm: 60
+    tpm: 100000
+  model_info:
+    input_cost_per_token: 1.0e-06
+    output_cost_per_token: 1.0e-06
+- model_name: openrouter-anthropic/claude-opus-4.6
+  litellm_params:
+    model: openrouter/anthropic/claude-opus-4.6
+    api_key: os.environ/OPENROUTER_API_KEY
+    max_budget: 0.666666
+    budget_duration: 30d
+    rpm: 60
+    tpm: 100000
+  model_info:
+    input_cost_per_token: 1.0e-06
+    output_cost_per_token: 1.0e-06
+- model_name: openrouter-upstage/solar-pro-3:free
+  litellm_params:
+    model: openrouter/upstage/solar-pro-3:free
+    api_key: os.environ/OPENROUTER_API_KEY
+    max_budget: 0.666666
+    budget_duration: 30d
+    rpm: 60
+    tpm: 100000
+  model_info:
+    input_cost_per_token: 1.0e-06
+    output_cost_per_token: 1.0e-06
+- model_name: openrouter-openai/gpt-5.2-pro
+  litellm_params:
+    model: openrouter/openai/gpt-5.2-pro
+    api_key: os.environ/OPENROUTER_API_KEY
+    max_budget: 0.666666
+    budget_duration: 30d
+    rpm: 60
+    tpm: 100000
+  model_info:
+    input_cost_per_token: 1.0e-06
+    output_cost_per_token: 1.0e-06
+- model_name: openrouter-anthropic/claude-opus-4.5
+  litellm_params:
+    model: openrouter/anthropic/claude-opus-4.5
+    api_key: os.environ/OPENROUTER_API_KEY
+    max_budget: 0.666666
+    budget_duration: 30d
+    rpm: 60
+    tpm: 100000
+  model_info:
+    input_cost_per_token: 1.0e-06
+    output_cost_per_token: 1.0e-06
+- model_name: openrouter-google/gemini-3-pro-image
+  litellm_params:
+    model: openrouter/google/gemini-3-pro-image-preview
+    api_key: os.environ/OPENROUTER_API_KEY
+    max_budget: 0.666666
+    budget_duration: 30d
+    rpm: 60
+    tpm: 100000
+  model_info:
+    input_cost_per_token: 1.0e-06
+    output_cost_per_token: 1.0e-06
+- model_name: openrouter-google/gemini-3-pro
+  litellm_params:
+    model: openrouter/google/gemini-3-pro-preview
+    api_key: os.environ/OPENROUTER_API_KEY
+    max_budget: 0.666666
+    budget_duration: 30d
+    rpm: 60
+    tpm: 100000
+  model_info:
+    input_cost_per_token: 1.0e-06
+    output_cost_per_token: 1.0e-06
+- model_name: openrouter-kwaipilot/kat-coder-pro
+  litellm_params:
+    model: openrouter/kwaipilot/kat-coder-pro
+    api_key: os.environ/OPENROUTER_API_KEY
+    max_budget: 0.666666
+    budget_duration: 30d
+    rpm: 60
+    tpm: 100000
+  model_info:
+    input_cost_per_token: 1.0e-06
+    output_cost_per_token: 1.0e-06
+- model_name: openrouter-perplexity/sonar-pro-search
+  litellm_params:
+    model: openrouter/perplexity/sonar-pro-search
+    api_key: os.environ/OPENROUTER_API_KEY
+    max_budget: 0.666666
+    budget_duration: 30d
+    rpm: 60
+    tpm: 100000
+  model_info:
+    input_cost_per_token: 1.0e-06
+    output_cost_per_token: 1.0e-06
+- model_name: openrouter-openai/gpt-5-pro
+  litellm_params:
+    model: openrouter/openai/gpt-5-pro
+    api_key: os.environ/OPENROUTER_API_KEY
+    max_budget: 0.666666
+    budget_duration: 30d
+    rpm: 60
+    tpm: 100000
+  model_info:
+    input_cost_per_token: 1.0e-06
+    output_cost_per_token: 1.0e-06
+- model_name: openrouter-nousresearch/hermes-4-405b
+  litellm_params:
+    model: openrouter/nousresearch/hermes-4-405b
+    api_key: os.environ/OPENROUTER_API_KEY
+    max_budget: 0.666666
+    budget_duration: 30d
+    rpm: 60
+    tpm: 100000
+  model_info:
+    input_cost_per_token: 1.0e-06
+    output_cost_per_token: 1.0e-06
+- model_name: openrouter-anthropic/claude-opus-4.1
+  litellm_params:
+    model: openrouter/anthropic/claude-opus-4.1
+    api_key: os.environ/OPENROUTER_API_KEY
+    max_budget: 0.666666
+    budget_duration: 30d
+    rpm: 60
+    tpm: 100000
+  model_info:
+    input_cost_per_token: 1.0e-06
+    output_cost_per_token: 1.0e-06
+- model_name: openrouter-google/gemini-2.5-pro
+  litellm_params:
+    model: openrouter/google/gemini-2.5-pro
+    api_key: os.environ/OPENROUTER_API_KEY
+    max_budget: 0.666666
+    budget_duration: 30d
+    rpm: 60
+    tpm: 100000
+  model_info:
+    input_cost_per_token: 1.0e-06
+    output_cost_per_token: 1.0e-06
+- model_name: openrouter-openai/o3-pro
+  litellm_params:
+    model: openrouter/openai/o3-pro
+    api_key: os.environ/OPENROUTER_API_KEY
+    max_budget: 0.666666
+    budget_duration: 30d
+    rpm: 60
+    tpm: 100000
+  model_info:
+    input_cost_per_token: 1.0e-06
+    output_cost_per_token: 1.0e-06
+- model_name: cohere-command-a-vision-07-2025
+  litellm_params:
+    model: cohere/command-a-vision-07-2025
+    api_key: os.environ/COHERE_API_KEY
+    max_budget: 0.1875
+    budget_duration: 30d
+    rpm: 60
+    tpm: 100000
+  model_info:
+    input_cost_per_token: 1.0e-06
+    output_cost_per_token: 1.0e-06
+- model_name: cohere-c4ai-aya-vision-8b
+  litellm_params:
+    model: cohere/c4ai-aya-vision-8b
+    api_key: os.environ/COHERE_API_KEY
+    max_budget: 0.0625
+    budget_duration: 30d
+    rpm: 60
+    tpm: 100000
+  model_info:
+    input_cost_per_token: 1.0e-06
+    output_cost_per_token: 1.0e-06
+- model_name: cohere-command-a-reasoning-08-2025
+  litellm_params:
+    model: cohere/command-a-reasoning-08-2025
+    api_key: os.environ/COHERE_API_KEY
+    max_budget: 0.1875
+    budget_duration: 30d
+    rpm: 60
+    tpm: 100000
+  model_info:
+    input_cost_per_token: 1.0e-06
+    output_cost_per_token: 1.0e-06
+- model_name: cohere-c4ai-aya-expanse-8b
+  litellm_params:
+    model: cohere/c4ai-aya-expanse-8b
+    api_key: os.environ/COHERE_API_KEY
+    max_budget: 0.0625
+    budget_duration: 30d
+    rpm: 60
+    tpm: 100000
+  model_info:
+    input_cost_per_token: 1.0e-06
+    output_cost_per_token: 1.0e-06
+- model_name: cohere-command-r-08-2024
+  litellm_params:
+    model: cohere/command-r-08-2024
+    api_key: os.environ/COHERE_API_KEY
+    max_budget: 0.125
+    budget_duration: 30d
+    rpm: 60
+    tpm: 100000
+  model_info:
+    input_cost_per_token: 1.0e-06
+    output_cost_per_token: 1.0e-06
+- model_name: cohere-command-r7b-arabic-02-2025
+  litellm_params:
+    model: cohere/command-r7b-arabic-02-2025
+    api_key: os.environ/COHERE_API_KEY
+    max_budget: 0.0625
+    budget_duration: 30d
+    rpm: 60
+    tpm: 100000
+  model_info:
+    input_cost_per_token: 1.0e-06
+    output_cost_per_token: 1.0e-06
+- model_name: cohere-c4ai-aya-expanse-32b
+  litellm_params:
+    model: cohere/c4ai-aya-expanse-32b
+    api_key: os.environ/COHERE_API_KEY
+    max_budget: 0.125
+    budget_duration: 30d
+    rpm: 60
+    tpm: 100000
+  model_info:
+    input_cost_per_token: 1.0e-06
+    output_cost_per_token: 1.0e-06
+- model_name: cohere-command-r7b-12-2024
+  litellm_params:
+    model: cohere/command-r7b-12-2024
+    api_key: os.environ/COHERE_API_KEY
+    max_budget: 0.0625
+    budget_duration: 30d
+    rpm: 60
+    tpm: 100000
+  model_info:
+    input_cost_per_token: 1.0e-06
+    output_cost_per_token: 1.0e-06
+- model_name: cohere-c4ai-aya-vision-32b
+  litellm_params:
+    model: cohere/c4ai-aya-vision-32b
+    api_key: os.environ/COHERE_API_KEY
+    max_budget: 0.125
+    budget_duration: 30d
+    rpm: 60
+    tpm: 100000
+  model_info:
+    input_cost_per_token: 1.0e-06
+    output_cost_per_token: 1.0e-06
+- model_name: cloudflare-@hf/nousresearch/hermes-2-pro-mistral-7b
+  litellm_params:
+    model: cloudflare/@hf/nousresearch/hermes-2-pro-mistral-7b
+    api_key: os.environ/CLOUDFLARE_API_KEY
+    max_budget: 1.290322
+    budget_duration: 1d
+    rpm: 60
+    tpm: 100000
+  model_info:
+    input_cost_per_token: 1.0e-06
+    output_cost_per_token: 1.0e-06
+- model_name: cloudflare-@cf/meta/llama33-70b-fp8-fast
+  litellm_params:
+    model: cloudflare/@cf/meta/llama-3.3-70b-instruct-fp8-fast
+    api_key: os.environ/CLOUDFLARE_API_KEY
+    max_budget: 0.967741
+    budget_duration: 1d
+    rpm: 60
+    tpm: 100000
+  model_info:
+    input_cost_per_token: 1.0e-06
+    output_cost_per_token: 1.0e-06
+- model_name: cloudflare-@cf/deepseek-ai/deepseek-r1-distill-qwen-32b
+  litellm_params:
+    model: cloudflare/@cf/deepseek-ai/deepseek-r1-distill-qwen-32b
+    api_key: os.environ/CLOUDFLARE_API_KEY
+    max_budget: 0.645161
+    budget_duration: 1d
+    rpm: 60
+    tpm: 100000
+  model_info:
+    input_cost_per_token: 1.0e-06
+    output_cost_per_token: 1.0e-06
+- model_name: cloudflare-@cf/qwen/qwen2.5-coder-32b
+  litellm_params:
+    model: cloudflare/@cf/qwen/qwen2.5-coder-32b-instruct
+    api_key: os.environ/CLOUDFLARE_API_KEY
+    max_budget: 0.645161
+    budget_duration: 1d
+    rpm: 60
+    tpm: 100000
+  model_info:
+    input_cost_per_token: 1.0e-06
+    output_cost_per_token: 1.0e-06
+- model_name: cloudflare-@cf/aisingapore/gemma-sea-lion-v4-27b
+  litellm_params:
+    model: cloudflare/@cf/aisingapore/gemma-sea-lion-v4-27b-it
+    api_key: os.environ/CLOUDFLARE_API_KEY
+    max_budget: 0.645161
+    budget_duration: 1d
+    rpm: 60
+    tpm: 100000
+  model_info:
+    input_cost_per_token: 1.0e-06
+    output_cost_per_token: 1.0e-06
+- model_name: cloudflare-@cf/qwen/qwq-32b
+  litellm_params:
+    model: cloudflare/@cf/qwen/qwq-32b
+    api_key: os.environ/CLOUDFLARE_API_KEY
+    max_budget: 0.645161
+    budget_duration: 1d
+    rpm: 60
+    tpm: 100000
+  model_info:
+    input_cost_per_token: 1.0e-06
+    output_cost_per_token: 1.0e-06
+- model_name: cloudflare-@cf/openai/gpt-oss-120b
+  litellm_params:
+    model: cloudflare/@cf/openai/gpt-oss-120b
+    api_key: os.environ/CLOUDFLARE_API_KEY
+    max_budget: 0.645161
+    budget_duration: 1d
+    rpm: 60
+    tpm: 100000
+  model_info:
+    input_cost_per_token: 1.0e-06
+    output_cost_per_token: 1.0e-06
+- model_name: cloudflare-@cf/qwen/qwen1.5-0.5b
+  litellm_params:
+    model: cloudflare/@cf/qwen/qwen1.5-0.5b-chat
+    api_key: os.environ/CLOUDFLARE_API_KEY
+    max_budget: 0.645161
+    budget_duration: 1d
+    rpm: 60
+    tpm: 100000
+  model_info:
+    input_cost_per_token: 1.0e-06
+    output_cost_per_token: 1.0e-06
+- model_name: cloudflare-@cf/zai-org/glm-4.7-flash
+  litellm_params:
+    model: cloudflare/@cf/zai-org/glm-4.7-flash
+    api_key: os.environ/CLOUDFLARE_API_KEY
+    max_budget: 0.645161
+    budget_duration: 1d
+    rpm: 60
+    tpm: 100000
+  model_info:
+    input_cost_per_token: 1.0e-06
+    output_cost_per_token: 1.0e-06
+- model_name: cloudflare-@cf/ibm-granite/granite-4.0-h-micro
+  litellm_params:
+    model: cloudflare/@cf/ibm-granite/granite-4.0-h-micro
+    api_key: os.environ/CLOUDFLARE_API_KEY
+    max_budget: 0.645161
+    budget_duration: 1d
+    rpm: 60
+    tpm: 100000
+  model_info:
+    input_cost_per_token: 1.0e-06
+    output_cost_per_token: 1.0e-06
+- model_name: cloudflare-@cf/microsoft/phi-2
+  litellm_params:
+    model: cloudflare/@cf/microsoft/phi-2
+    api_key: os.environ/CLOUDFLARE_API_KEY
+    max_budget: 0.645161
+    budget_duration: 1d
+    rpm: 60
+    tpm: 100000
+  model_info:
+    input_cost_per_token: 1.0e-06
+    output_cost_per_token: 1.0e-06
+- model_name: cloudflare-@cf/openai/gpt-oss-20b
+  litellm_params:
+    model: cloudflare/@cf/openai/gpt-oss-20b
+    api_key: os.environ/CLOUDFLARE_API_KEY
+    max_budget: 0.645161
+    budget_duration: 1d
+    rpm: 60
+    tpm: 100000
+  model_info:
+    input_cost_per_token: 1.0e-06
+    output_cost_per_token: 1.0e-06
+- model_name: cloudflare-@cf/openchat/openchat-3.5-0106
+  litellm_params:
+    model: cloudflare/@cf/openchat/openchat-3.5-0106
+    api_key: os.environ/CLOUDFLARE_API_KEY
+    max_budget: 0.645161
+    budget_duration: 1d
+    rpm: 60
+    tpm: 100000
+  model_info:
+    input_cost_per_token: 1.0e-06
+    output_cost_per_token: 1.0e-06
+- model_name: cloudflare-@cf/meta/llama-3-8b
+  litellm_params:
+    model: cloudflare/@cf/meta/llama-3-8b-instruct
+    api_key: os.environ/CLOUDFLARE_API_KEY
+    max_budget: 0.32258
+    budget_duration: 1d
+    rpm: 60
+    tpm: 100000
+  model_info:
+    input_cost_per_token: 1.0e-06
+    output_cost_per_token: 1.0e-06
+- model_name: cloudflare-@cf/meta/llama31-8b-fp8
+  litellm_params:
+    model: cloudflare/@cf/meta/llama-3.1-8b-instruct-fp8
+    api_key: os.environ/CLOUDFLARE_API_KEY
+    max_budget: 0.32258
+    budget_duration: 1d
+    rpm: 60
+    tpm: 100000
+  model_info:
+    input_cost_per_token: 1.0e-06
+    output_cost_per_token: 1.0e-06
+- model_name: cerebras-gpt-oss-120b
+  litellm_params:
+    model: cerebras/gpt-oss-120b
+    api_key: os.environ/CEREBRAS_API_KEY
+    max_budget: 0.333333
+    budget_duration: 1d
+    rpm: 60
+    tpm: 100000
+  model_info:
+    input_cost_per_token: 1.0e-06
+    output_cost_per_token: 1.0e-06
+- model_name: cerebras-zai-glm-4.7
+  litellm_params:
+    model: cerebras/zai-glm-4.7
+    api_key: os.environ/CEREBRAS_API_KEY
+    max_budget: 0.333333
+    budget_duration: 1d
+    rpm: 60
+    tpm: 100000
+  model_info:
+    input_cost_per_token: 1.0e-06
+    output_cost_per_token: 1.0e-06
+- model_name: cerebras-qwen-3-235b-a22b-2507
+  litellm_params:
+    model: cerebras/qwen-3-235b-a22b-instruct-2507
+    api_key: os.environ/CEREBRAS_API_KEY
+    max_budget: 0.166666
+    budget_duration: 1d
+    rpm: 60
+    tpm: 100000
+  model_info:
+    input_cost_per_token: 1.0e-06
+    output_cost_per_token: 1.0e-06
+- model_name: cerebras-llama3.1-8b
+  litellm_params:
+    model: cerebras/llama3.1-8b
+    api_key: os.environ/CEREBRAS_API_KEY
+    max_budget: 0.166666
+    budget_duration: 1d
+    rpm: 60
+    tpm: 100000
+  model_info:
+    input_cost_per_token: 1.0e-06
+    output_cost_per_token: 1.0e-06
+- model_name: mistral-mistral-large-2411
+  litellm_params:
+    model: mistral/mistral-large-2411
+    api_key: os.environ/MISTRAL_API_KEY
+    max_budget: 83.333333
+    budget_duration: 30d
+    rpm: 60
+    tpm: 100000
+  model_info:
+    input_cost_per_token: 1.0e-06
+    output_cost_per_token: 1.0e-06
+- model_name: mistral-pixtral-large-2411
+  litellm_params:
+    model: mistral/pixtral-large-2411
+    api_key: os.environ/MISTRAL_API_KEY
+    max_budget: 83.333333
+    budget_duration: 30d
+    rpm: 60
+    tpm: 100000
+  model_info:
+    input_cost_per_token: 1.0e-06
+    output_cost_per_token: 1.0e-06
+- model_name: mistral-pixtral-large
+  litellm_params:
+    model: mistral/pixtral-large-latest
+    api_key: os.environ/MISTRAL_API_KEY
+    max_budget: 83.333333
+    budget_duration: 30d
+    rpm: 60
+    tpm: 100000
+  model_info:
+    input_cost_per_token: 1.0e-06
+    output_cost_per_token: 1.0e-06
+- model_name: mistral-mistral-large-pixtral-2411
+  litellm_params:
+    model: mistral/mistral-large-pixtral-2411
+    api_key: os.environ/MISTRAL_API_KEY
+    max_budget: 83.333333
+    budget_duration: 30d
+    rpm: 60
+    tpm: 100000
+  model_info:
+    input_cost_per_token: 1.0e-06
+    output_cost_per_token: 1.0e-06
+- model_name: mistral-codestral-2508
+  litellm_params:
+    model: mistral/codestral-2508
+    api_key: os.environ/MISTRAL_API_KEY
+    max_budget: 83.333333
+    budget_duration: 30d
+    rpm: 60
+    tpm: 100000
+  model_info:
+    input_cost_per_token: 1.0e-06
+    output_cost_per_token: 1.0e-06
+- model_name: mistral-mistral-large-2512
+  litellm_params:
+    model: mistral/mistral-large-2512
+    api_key: os.environ/MISTRAL_API_KEY
+    max_budget: 83.333333
+    budget_duration: 30d
+    rpm: 60
+    tpm: 100000
+  model_info:
+    input_cost_per_token: 1.0e-06
+    output_cost_per_token: 1.0e-06
+- model_name: mistral-mistral-large
+  litellm_params:
+    model: mistral/mistral-large-latest
+    api_key: os.environ/MISTRAL_API_KEY
+    max_budget: 83.333333
+    budget_duration: 30d
+    rpm: 60
+    tpm: 100000
+  model_info:
+    input_cost_per_token: 1.0e-06
+    output_cost_per_token: 1.0e-06
+- model_name: mistral-codestral-embed
+  litellm_params:
+    model: mistral/codestral-embed
+    api_key: os.environ/MISTRAL_API_KEY
+    max_budget: 0.09999999999999999
+    budget_duration: 30d
+    rpm: 100
+    tpm: 30000
+  model_info:
+    input_cost_per_token: 1.0e-06
+    output_cost_per_token: 1.0e-06
+- model_name: mistral-mistral-medium-2505
+  litellm_params:
+    model: mistral/mistral-medium-2505
+    api_key: os.environ/MISTRAL_API_KEY
+    max_budget: 55.555555
+    budget_duration: 30d
+    rpm: 60
+    tpm: 100000
+  model_info:
+    input_cost_per_token: 1.0e-06
+    output_cost_per_token: 1.0e-06
+- model_name: mistral-mistral-medium-2508
+  litellm_params:
+    model: mistral/mistral-medium-2508
+    api_key: os.environ/MISTRAL_API_KEY
+    max_budget: 55.555555
+    budget_duration: 30d
+    rpm: 60
+    tpm: 100000
+  model_info:
+    input_cost_per_token: 1.0e-06
+    output_cost_per_token: 1.0e-06
+- model_name: mistral-mistral-medium
+  litellm_params:
+    model: mistral/mistral-medium-latest
+    api_key: os.environ/MISTRAL_API_KEY
+    max_budget: 55.555555
+    budget_duration: 30d
+    rpm: 60
+    tpm: 100000
+  model_info:
+    input_cost_per_token: 1.0e-06
+    output_cost_per_token: 1.0e-06
+- model_name: mistral-devstral-small-2507
+  litellm_params:
+    model: mistral/devstral-small-2507
+    api_key: os.environ/MISTRAL_API_KEY
+    max_budget: 55.555555
+    budget_duration: 30d
+    rpm: 60
+    tpm: 100000
+  model_info:
+    input_cost_per_token: 1.0e-06
+    output_cost_per_token: 1.0e-06
+- model_name: mistral-devstral-medium-2507
+  litellm_params:
+    model: mistral/devstral-medium-2507
+    api_key: os.environ/MISTRAL_API_KEY
+    max_budget: 55.555555
+    budget_duration: 30d
+    rpm: 60
+    tpm: 100000
+  model_info:
+    input_cost_per_token: 1.0e-06
+    output_cost_per_token: 1.0e-06
+- model_name: google-gemini-2.5-pro
+  litellm_params:
+    model: gemini/gemini-2.5-pro
+    api_key: os.environ/GEMINI_API_KEY
+    max_budget: 0.444444
+    budget_duration: 1d
+    rpm: 60
+    tpm: 100000
+  model_info:
+    input_cost_per_token: 1.0e-06
+    output_cost_per_token: 1.0e-06
+- model_name: google-gemini-pro
+  litellm_params:
+    model: gemini/gemini-pro-latest
+    api_key: os.environ/GEMINI_API_KEY
+    max_budget: 0.444444
+    budget_duration: 1d
+    rpm: 60
+    tpm: 100000
+  model_info:
+    input_cost_per_token: 1.0e-06
+    output_cost_per_token: 1.0e-06
+- model_name: google-gemini-3-pro
+  litellm_params:
+    model: gemini/gemini-3-pro-preview
+    api_key: os.environ/GEMINI_API_KEY
+    max_budget: 0.444444
+    budget_duration: 1d
+    rpm: 60
+    tpm: 100000
+  model_info:
+    input_cost_per_token: 1.0e-06
+    output_cost_per_token: 1.0e-06
+- model_name: google-gemini-3.1-pro
+  litellm_params:
+    model: gemini/gemini-3.1-pro-preview
+    api_key: os.environ/GEMINI_API_KEY
+    max_budget: 0.444444
+    budget_duration: 1d
+    rpm: 60
+    tpm: 100000
+  model_info:
+    input_cost_per_token: 1.0e-06
+    output_cost_per_token: 1.0e-06
+- model_name: google-gemini-3.1-pro-customtools
+  litellm_params:
+    model: gemini/gemini-3.1-pro-preview-customtools
+    api_key: os.environ/GEMINI_API_KEY
+    max_budget: 0.444444
+    budget_duration: 1d
+    rpm: 60
+    tpm: 100000
+  model_info:
+    input_cost_per_token: 1.0e-06
+    output_cost_per_token: 1.0e-06
+- model_name: google-gemini-3-pro-image
+  litellm_params:
+    model: gemini/gemini-3-pro-image-preview
+    api_key: os.environ/GEMINI_API_KEY
+    max_budget: 0.444444
+    budget_duration: 1d
+    rpm: 60
+    tpm: 100000
+  model_info:
+    input_cost_per_token: 1.0e-06
+    output_cost_per_token: 1.0e-06
+- model_name: google-imagen-4.0-ultra-generate-001
+  litellm_params:
+    model: gemini/imagen-4.0-ultra-generate-001
+    api_key: os.environ/GEMINI_API_KEY
+    max_budget: 0.25
+    budget_duration: 1d
+    rpm: 5
+  model_info:
+    input_cost_per_token: 1.0e-06
+    output_cost_per_token: 1.0e-06
+- model_name: google-gemini-2.5-flash
+  litellm_params:
+    model: gemini/gemini-2.5-flash
+    api_key: os.environ/GEMINI_API_KEY
+    max_budget: 0.04
+    budget_duration: 1d
+    rpm: 5
+    tpm: 250000
+  model_info:
+    input_cost_per_token: 1.0e-06
+    output_cost_per_token: 1.0e-06
+- model_name: google-gemini-2.5-flash-lite
+  litellm_params:
+    model: gemini/gemini-2.5-flash-lite
+    api_key: os.environ/GEMINI_API_KEY
+    max_budget: 0.04
+    budget_duration: 1d
+    rpm: 10
+    tpm: 250000
+  model_info:
+    input_cost_per_token: 1.0e-06
+    output_cost_per_token: 1.0e-06
+- model_name: google-gemini-2.5-flash-image
+  litellm_params:
+    model: gemini/gemini-2.5-flash-image
+    api_key: os.environ/GEMINI_API_KEY
+    max_budget: 0.333333
+    budget_duration: 1d
+    rpm: 60
+    tpm: 100000
+  model_info:
+    input_cost_per_token: 1.0e-06
+    output_cost_per_token: 1.0e-06
+- model_name: google-gemini-2.5-flash-lite-09-2025
+  litellm_params:
+    model: gemini/gemini-2.5-flash-lite-preview-09-2025
+    api_key: os.environ/GEMINI_API_KEY
+    max_budget: 0.333333
+    budget_duration: 1d
+    rpm: 60
+    tpm: 100000
+  model_info:
+    input_cost_per_token: 1.0e-06
+    output_cost_per_token: 1.0e-06
+- model_name: google-gemini-3-flash
+  litellm_params:
+    model: gemini/gemini-3-flash-preview
+    api_key: os.environ/GEMINI_API_KEY
+    max_budget: 0.04
+    budget_duration: 1d
+    rpm: 5
+    tpm: 250000
+  model_info:
+    input_cost_per_token: 1.0e-06
+    output_cost_per_token: 1.0e-06
+- model_name: google-gemini-2.0-flash-lite-001
+  litellm_params:
+    model: gemini/gemini-2.0-flash-lite-001
+    api_key: os.environ/GEMINI_API_KEY
+    max_budget: 0.222222
+    budget_duration: 1d
+    rpm: 60
+    tpm: 100000
+  model_info:
+    input_cost_per_token: 1.0e-06
+    output_cost_per_token: 1.0e-06
+- model_name: google-gemini-2.0-flash-lite
+  litellm_params:
+    model: gemini/gemini-2.0-flash-lite
+    api_key: os.environ/GEMINI_API_KEY
+    max_budget: 0.222222
+    budget_duration: 1d
+    rpm: 60
+    tpm: 100000
+  model_info:
+    input_cost_per_token: 1.0e-06
+    output_cost_per_token: 1.0e-06
+- model_name: google-gemma-3-27b
+  litellm_params:
+    model: gemini/gemma-3-27b-it
+    api_key: os.environ/GEMINI_API_KEY
+    max_budget: 0.222222
+    budget_duration: 1d
+    rpm: 30
+    tpm: 15000
+  model_info:
+    input_cost_per_token: 1.0e-06
+    output_cost_per_token: 1.0e-06
+- model_name: groq-moonshotai/kimi-k2-0905
+  litellm_params:
+    model: groq/moonshotai/kimi-k2-instruct-0905
+    api_key: os.environ/GROQ_API_KEY
+    max_budget: 0.043478
+    budget_duration: 1d
+    rpm: 60
+    tpm: 100000
+  model_info:
+    input_cost_per_token: 1.0e-06
+    output_cost_per_token: 1.0e-06
+- model_name: groq-canopylabs/orpheus-v1-english
+  litellm_params:
+    model: groq/canopylabs/orpheus-v1-english
+    api_key: os.environ/GROQ_API_KEY
+    max_budget: 0.043478
+    budget_duration: 1d
+    rpm: 60
+    tpm: 100000
+  model_info:
+    input_cost_per_token: 1.0e-06
+    output_cost_per_token: 1.0e-06
+- model_name: groq-groq/compound
+  litellm_params:
+    model: groq/groq/compound
+    api_key: os.environ/GROQ_API_KEY
+    max_budget: 0.043478
+    budget_duration: 1d
+    rpm: 60
+    tpm: 100000
+  model_info:
+    input_cost_per_token: 1.0e-06
+    output_cost_per_token: 1.0e-06
+- model_name: groq-canopylabs/orpheus-arabic-saudi
+  litellm_params:
+    model: groq/canopylabs/orpheus-arabic-saudi
+    api_key: os.environ/GROQ_API_KEY
+    max_budget: 0.043478
+    budget_duration: 1d
+    rpm: 60
+    tpm: 100000
+  model_info:
+    input_cost_per_token: 1.0e-06
+    output_cost_per_token: 1.0e-06
+- model_name: groq-llama33-70b
+  litellm_params:
+    model: groq/llama-3.3-70b-versatile
+    api_key: os.environ/GROQ_API_KEY
+    max_budget: 0.065217
+    budget_duration: 1d
+    rpm: 30
+    tpm: 131072
+  model_info:
+    input_cost_per_token: 1.0e-06
+    output_cost_per_token: 1.0e-06
+- model_name: groq-moonshotai/kimi-k2
+  litellm_params:
+    model: groq/moonshotai/kimi-k2-instruct
+    api_key: os.environ/GROQ_API_KEY
+    max_budget: 0.043478
+    budget_duration: 1d
+    rpm: 60
+    tpm: 100000
+  model_info:
+    input_cost_per_token: 1.0e-06
+    output_cost_per_token: 1.0e-06
+- model_name: groq-qwen/qwen3-32b
+  litellm_params:
+    model: groq/qwen/qwen3-32b
+    api_key: os.environ/GROQ_API_KEY
+    max_budget: 0.043478
+    budget_duration: 1d
+    rpm: 60
+    tpm: 100000
+  model_info:
+    input_cost_per_token: 1.0e-06
+    output_cost_per_token: 1.0e-06
+- model_name: groq-groq/compound-mini
+  litellm_params:
+    model: groq/groq/compound-mini
+    api_key: os.environ/GROQ_API_KEY
+    max_budget: 0.021739
+    budget_duration: 1d
+    rpm: 60
+    tpm: 100000
+  model_info:
+    input_cost_per_token: 1.0e-06
+    output_cost_per_token: 1.0e-06
+- model_name: groq-llama31-8b-instant
+  litellm_params:
+    model: groq/llama-3.1-8b-instant
+    api_key: os.environ/GROQ_API_KEY
+    max_budget: 0.021739
+    budget_duration: 1d
+    rpm: 30
+    tpm: 131072
+  model_info:
+    input_cost_per_token: 1.0e-06
+    output_cost_per_token: 1.0e-06
+- model_name: groq-openai/gpt-oss-20b
+  litellm_params:
+    model: groq/openai/gpt-oss-20b
+    api_key: os.environ/GROQ_API_KEY
+    max_budget: 0.043478
+    budget_duration: 1d
+    rpm: 60
+    tpm: 100000
+  model_info:
+    input_cost_per_token: 1.0e-06
+    output_cost_per_token: 1.0e-06
+- model_name: groq-allam-2-7b
+  litellm_params:
+    model: groq/allam-2-7b
+    api_key: os.environ/GROQ_API_KEY
+    max_budget: 0.021739
+    budget_duration: 1d
+    rpm: 60
+    tpm: 100000
+  model_info:
+    input_cost_per_token: 1.0e-06
+    output_cost_per_token: 1.0e-06
+- model_name: groq-openai/gpt-oss-120b
+  litellm_params:
+    model: groq/openai/gpt-oss-120b
+    api_key: os.environ/GROQ_API_KEY
+    max_budget: 0.043478
+    budget_duration: 1d
+    rpm: 60
+    tpm: 100000
+  model_info:
+    input_cost_per_token: 1.0e-06
+    output_cost_per_token: 1.0e-06
+- model_name: groq-llama/llama-4-scout-17b-16e
+  litellm_params:
+    model: groq/meta-llama/llama-4-scout-17b-16e-instruct
+    api_key: os.environ/GROQ_API_KEY
+    max_budget: 0.021739
+    budget_duration: 1d
+    rpm: 60
+    tpm: 100000
+  model_info:
+    input_cost_per_token: 1.0e-06
+    output_cost_per_token: 1.0e-06
+- model_name: sambanova-deepseek-r1-distill-llama-70b
+  litellm_params:
+    model: openai/DeepSeek-R1-Distill-Llama-70B
+    api_key: os.environ/SAMBANOVA_API_KEY
+    api_base: https://api.sambanova.ai/v1
+    max_budget: 10.0
+    budget_duration: 30d
+    rpm: 60
+    tpm: 100000
+  model_info:
+    input_cost_per_token: 1.0e-06
+    output_cost_per_token: 1.0e-06
+- model_name: sambanova-llama33-swallow-70b-v0.4
+  litellm_params:
+    model: openai/Llama-3.3-Swallow-70B-Instruct-v0.4
+    api_key: os.environ/SAMBANOVA_API_KEY
+    api_base: https://api.sambanova.ai/v1
+    max_budget: 10.0
+    budget_duration: 30d
+    rpm: 60
+    tpm: 100000
+  model_info:
+    input_cost_per_token: 1.0e-06
+    output_cost_per_token: 1.0e-06
+- model_name: sambanova-llama33-70b
+  litellm_params:
+    model: openai/Meta-Llama-3.3-70B-Instruct
+    api_key: os.environ/SAMBANOVA_API_KEY
+    api_base: https://api.sambanova.ai/v1
+    max_budget: 10.0
+    budget_duration: 30d
+    rpm: 60
+    tpm: 100000
+  model_info:
+    input_cost_per_token: 1.0e-06
+    output_cost_per_token: 1.0e-06
+- model_name: sambanova-qwen3-32b
+  litellm_params:
+    model: openai/Qwen3-32B
+    api_key: os.environ/SAMBANOVA_API_KEY
+    api_base: https://api.sambanova.ai/v1
+    max_budget: 6.666666
+    budget_duration: 30d
+    rpm: 60
+    tpm: 100000
+  model_info:
+    input_cost_per_token: 1.0e-06
+    output_cost_per_token: 1.0e-06
+- model_name: sambanova-deepseek-r1-0528
+  litellm_params:
+    model: openai/DeepSeek-R1-0528
+    api_key: os.environ/SAMBANOVA_API_KEY
+    api_base: https://api.sambanova.ai/v1
+    max_budget: 6.666666
+    budget_duration: 30d
+    rpm: 60
+    tpm: 100000
+  model_info:
+    input_cost_per_token: 1.0e-06
+    output_cost_per_token: 1.0e-06
+- model_name: sambanova-deepseek-v3-0324
+  litellm_params:
+    model: openai/DeepSeek-V3-0324
+    api_key: os.environ/SAMBANOVA_API_KEY
+    api_base: https://api.sambanova.ai/v1
+    max_budget: 6.666666
+    budget_duration: 30d
+    rpm: 60
+    tpm: 100000
+  model_info:
+    input_cost_per_token: 1.0e-06
+    output_cost_per_token: 1.0e-06
+- model_name: sambanova-deepseek-v3.1
+  litellm_params:
+    model: openai/DeepSeek-V3.1
+    api_key: os.environ/SAMBANOVA_API_KEY
+    api_base: https://api.sambanova.ai/v1
+    max_budget: 6.666666
+    budget_duration: 30d
+    rpm: 60
+    tpm: 100000
+  model_info:
+    input_cost_per_token: 1.0e-06
+    output_cost_per_token: 1.0e-06
+- model_name: sambanova-deepseek-v3.1-terminus
+  litellm_params:
+    model: openai/DeepSeek-V3.1-Terminus
+    api_key: os.environ/SAMBANOVA_API_KEY
+    api_base: https://api.sambanova.ai/v1
+    max_budget: 6.666666
+    budget_duration: 30d
+    rpm: 60
+    tpm: 100000
+  model_info:
+    input_cost_per_token: 1.0e-06
+    output_cost_per_token: 1.0e-06
+- model_name: sambanova-deepseek-v3.1-cb
+  litellm_params:
+    model: openai/DeepSeek-V3.1-cb
+    api_key: os.environ/SAMBANOVA_API_KEY
+    api_base: https://api.sambanova.ai/v1
+    max_budget: 6.666666
+    budget_duration: 30d
+    rpm: 60
+    tpm: 100000
+  model_info:
+    input_cost_per_token: 1.0e-06
+    output_cost_per_token: 1.0e-06
+- model_name: sambanova-deepseek-v3.2
+  litellm_params:
+    model: openai/DeepSeek-V3.2
+    api_key: os.environ/SAMBANOVA_API_KEY
+    api_base: https://api.sambanova.ai/v1
+    max_budget: 6.666666
+    budget_duration: 30d
+    rpm: 60
+    tpm: 100000
+  model_info:
+    input_cost_per_token: 1.0e-06
+    output_cost_per_token: 1.0e-06
+- model_name: sambanova-qwen3-235b
+  litellm_params:
+    model: openai/Qwen3-235B
+    api_key: os.environ/SAMBANOVA_API_KEY
+    api_base: https://api.sambanova.ai/v1
+    max_budget: 6.666666
+    budget_duration: 30d
+    rpm: 60
+    tpm: 100000
+  model_info:
+    input_cost_per_token: 1.0e-06
+    output_cost_per_token: 1.0e-06
+- model_name: sambanova-gpt-oss-120b
+  litellm_params:
+    model: openai/gpt-oss-120b
+    api_key: os.environ/SAMBANOVA_API_KEY
+    api_base: https://api.sambanova.ai/v1
+    max_budget: 6.666666
+    budget_duration: 30d
+    rpm: 60
+    tpm: 100000
+  model_info:
+    input_cost_per_token: 1.0e-06
+    output_cost_per_token: 1.0e-06
+- model_name: sambanova-llama31-8b
+  litellm_params:
+    model: openai/Meta-Llama-3.1-8B-Instruct
+    api_key: os.environ/SAMBANOVA_API_KEY
+    api_base: https://api.sambanova.ai/v1
+    max_budget: 3.333333
+    budget_duration: 30d
+    rpm: 60
+    tpm: 100000
+  model_info:
+    input_cost_per_token: 1.0e-06
+    output_cost_per_token: 1.0e-06
+- model_name: sambanova-minimax-m2.5
+  litellm_params:
+    model: openai/MiniMax-M2.5
+    api_key: os.environ/SAMBANOVA_API_KEY
+    api_base: https://api.sambanova.ai/v1
+    max_budget: 3.333333
+    budget_duration: 30d
+    rpm: 60
+    tpm: 100000
+  model_info:
+    input_cost_per_token: 1.0e-06
+    output_cost_per_token: 1.0e-06
+- model_name: sambanova-e5-mistral-7b
+  litellm_params:
+    model: openai/E5-Mistral-7B-Instruct
+    api_key: os.environ/SAMBANOVA_API_KEY
+    api_base: https://api.sambanova.ai/v1
+    max_budget: 3.333333
+    budget_duration: 30d
+    rpm: 60
+    tpm: 100000
+  model_info:
+    input_cost_per_token: 1.0e-06
+    output_cost_per_token: 1.0e-06
+- model_name: deepseek-deepseek
+  litellm_params:
+    model: deepseek/deepseek-chat
+    api_key: os.environ/DEEPSEEK_API_KEY
+    max_budget: 25.0
+    budget_duration: 30d
+    rpm: 60
+    tpm: 100000
+  model_info:
+    input_cost_per_token: 1.0e-06
+    output_cost_per_token: 1.0e-06
+- model_name: deepseek-deepseek-reasoner
+  litellm_params:
+    model: deepseek/deepseek-reasoner
+    api_key: os.environ/DEEPSEEK_API_KEY
+    max_budget: 25.0
+    budget_duration: 30d
+    rpm: 60
+    tpm: 100000
+  model_info:
+    input_cost_per_token: 1.0e-06
+    output_cost_per_token: 1.0e-06
+- model_name: together-google/imagen-4.0-ultra
+  litellm_params:
+    model: together_ai/google/imagen-4.0-ultra
+    api_key: os.environ/TOGETHER_API_KEY
+    max_budget: 0.25
+    budget_duration: 30d
+    rpm: 5
+  model_info:
+    input_cost_per_token: 1.0e-06
+    output_cost_per_token: 1.0e-06
+- model_name: together-black-forest-labs/flux.1-pro
+  litellm_params:
+    model: together_ai/black-forest-labs/FLUX.1-pro
+    api_key: os.environ/TOGETHER_API_KEY
+    max_budget: 3.636363
+    budget_duration: 30d
+    rpm: 60
+    tpm: 100000
+  model_info:
+    input_cost_per_token: 1.0e-06
+    output_cost_per_token: 1.0e-06
+- model_name: together-qwen/qwen-image-2.0-pro
+  litellm_params:
+    model: together_ai/Qwen/Qwen-Image-2.0-Pro
+    api_key: os.environ/TOGETHER_API_KEY
+    max_budget: 3.636363
+    budget_duration: 30d
+    rpm: 60
+    tpm: 100000
+  model_info:
+    input_cost_per_token: 1.0e-06
+    output_cost_per_token: 1.0e-06
+- model_name: together-bytedance/seedance-1.0-pro
+  litellm_params:
+    model: together_ai/ByteDance/Seedance-1.0-pro
+    api_key: os.environ/TOGETHER_API_KEY
+    max_budget: 3.636363
+    budget_duration: 30d
+    rpm: 60
+    tpm: 100000
+  model_info:
+    input_cost_per_token: 1.0e-06
+    output_cost_per_token: 1.0e-06
+- model_name: together-rundiffusion/juggernaut-pro-flux
+  litellm_params:
+    model: together_ai/RunDiffusion/Juggernaut-pro-flux
+    api_key: os.environ/TOGETHER_API_KEY
+    max_budget: 3.636363
+    budget_duration: 30d
+    rpm: 60
+    tpm: 100000
+  model_info:
+    input_cost_per_token: 1.0e-06
+    output_cost_per_token: 1.0e-06
+- model_name: together-black-forest-labs/flux.1.1-pro
+  litellm_params:
+    model: together_ai/black-forest-labs/FLUX.1.1-pro
+    api_key: os.environ/TOGETHER_API_KEY
+    max_budget: 3.636363
+    budget_duration: 30d
+    rpm: 60
+    tpm: 100000
+  model_info:
+    input_cost_per_token: 1.0e-06
+    output_cost_per_token: 1.0e-06
+- model_name: together-black-forest-labs/flux.1-kontext-pro
+  litellm_params:
+    model: together_ai/black-forest-labs/FLUX.1-kontext-pro
+    api_key: os.environ/TOGETHER_API_KEY
+    max_budget: 3.636363
+    budget_duration: 30d
+    rpm: 60
+    tpm: 100000
+  model_info:
+    input_cost_per_token: 1.0e-06
+    output_cost_per_token: 1.0e-06
+- model_name: together-openai/sora-2-pro
+  litellm_params:
+    model: together_ai/openai/sora-2-pro
+    api_key: os.environ/TOGETHER_API_KEY
+    max_budget: 3.636363
+    budget_duration: 30d
+    rpm: 60
+    tpm: 100000
+  model_info:
+    input_cost_per_token: 1.0e-06
+    output_cost_per_token: 1.0e-06
+- model_name: together-kwaivgi/kling-1.6-pro
+  litellm_params:
+    model: together_ai/kwaivgI/kling-1.6-pro
+    api_key: os.environ/TOGETHER_API_KEY
+    max_budget: 3.636363
+    budget_duration: 30d
+    rpm: 60
+    tpm: 100000
+  model_info:
+    input_cost_per_token: 1.0e-06
+    output_cost_per_token: 1.0e-06
+- model_name: together-kwaivgi/kling-2.1-pro
+  litellm_params:
+    model: together_ai/kwaivgI/kling-2.1-pro
+    api_key: os.environ/TOGETHER_API_KEY
+    max_budget: 3.636363
+    budget_duration: 30d
+    rpm: 60
+    tpm: 100000
+  model_info:
+    input_cost_per_token: 1.0e-06
+    output_cost_per_token: 1.0e-06
+- model_name: together-google/gemini-3-pro-image
+  litellm_params:
+    model: together_ai/google/gemini-3-pro-image
+    api_key: os.environ/TOGETHER_API_KEY
+    max_budget: 3.636363
+    budget_duration: 30d
+    rpm: 60
+    tpm: 100000
+  model_info:
+    input_cost_per_token: 1.0e-06
+    output_cost_per_token: 1.0e-06
+- model_name: together-black-forest-labs/flux.2-pro
+  litellm_params:
+    model: together_ai/black-forest-labs/FLUX.2-pro
+    api_key: os.environ/TOGETHER_API_KEY
+    max_budget: 3.636363
+    budget_duration: 30d
+    rpm: 60
+    tpm: 100000
+  model_info:
+    input_cost_per_token: 1.0e-06
+    output_cost_per_token: 1.0e-06
+- model_name: together-llama/llama31-405b
+  litellm_params:
+    model: together_ai/meta-llama/Llama-3.1-405B-Instruct
+    api_key: os.environ/TOGETHER_API_KEY
+    max_budget: 3.636363
+    budget_duration: 30d
+    rpm: 60
+    tpm: 100000
+  model_info:
+    input_cost_per_token: 1.0e-06
+    output_cost_per_token: 1.0e-06
+- model_name: together-llama/llama33-70b-turbo
+  litellm_params:
+    model: together_ai/meta-llama/Llama-3.3-70B-Instruct-Turbo
+    api_key: os.environ/TOGETHER_API_KEY
+    max_budget: 2.727272
+    budget_duration: 30d
+    rpm: 60
+    tpm: 100000
+  model_info:
+    input_cost_per_token: 1.0e-06
+    output_cost_per_token: 1.0e-06
+# ── Zhipu AI / Z.ai (GLM models) ──────────────────
+- model_name: zhipu-glm-4.7
+  litellm_params:
+    model: openai/glm-4.7
+    api_key: os.environ/ZAI_API_KEY
+    api_base: https://api.z.ai/api/coding/paas/v4
+- model_name: zhipu-glm-5
+  litellm_params:
+    model: openai/glm-5
+    api_key: os.environ/ZAI_API_KEY
+    api_base: https://api.z.ai/api/coding/paas/v4
+- model_name: zhipu-glm-5-turbo
+  litellm_params:
+    model: openai/glm-5-turbo
+    api_key: os.environ/ZAI_API_KEY
+    api_base: https://api.z.ai/api/coding/paas/v4
+- model_name: zhipu-glm-4.6
+  litellm_params:
+    model: openai/glm-4.6
+    api_key: os.environ/ZAI_API_KEY
+    api_base: https://api.z.ai/api/coding/paas/v4
+- model_name: zhipu-glm-4.5
+  litellm_params:
+    model: openai/glm-4.5
+    api_key: os.environ/ZAI_API_KEY
+    api_base: https://api.z.ai/api/coding/paas/v4
+- model_name: zhipu-glm-4.5-air
+  litellm_params:
+    model: openai/glm-4.5-air
+    api_key: os.environ/ZAI_API_KEY
+    api_base: https://api.z.ai/api/coding/paas/v4
+litellm_settings:
+  max_budget: 2000
+  budget_duration: 30d
+  drop_params: true
+  routing_strategy: usage-based-routing-v2
+  default_fallbacks:
+  - mistral-small
+  success_callback:
+  - langfuse
+  failure_callback:
+  - langfuse
+  request_timeout: 60
+  num_retries: 2
+  retry_after: 5
+  cache: true
+  cache_params:
+    type: local
+    ttl: 300
+general_settings:
+  master_key: os.environ/LITELLM_MASTER_KEY
+  database_url: os.environ/LITELLM_DATABASE_URL
+  enable_jwt_auth: false
+  ui_access_mode: admin_only
+environment_variables:
+  LANGFUSE_HOST: http://172.18.0.1:3100
+  LANGFUSE_PUBLIC_KEY: pk-lf-conductor
+  LANGFUSE_SECRET_KEY: sk-lf-conductor
+
+# MCP Servers — GitHub via OpenAPI-to-MCP conversion
+mcp_servers:
+  github:
+    url: "https://api.github.com"
+    spec_path: "/app/github-openapi.json"
+    auth_type: "bearer_token"
+    auth_value: "placeholder"
+    extra_headers:
+      - "authorization"
+    allowed_tools:
+      - "create_issue"
+      - "get_file_contents"
+      - "create_or_update_file"
+      - "create_pull_request"
+      - "create_branch"

--- a/deploy/helm/stronghold/templates/configmap-litellm.yaml
+++ b/deploy/helm/stronghold/templates/configmap-litellm.yaml
@@ -1,0 +1,21 @@
+# LiteLLM proxy model registry.
+#
+# Loaded verbatim from files/litellm-proxy-config.yaml via .Files.Get. The file
+# is ~1500 lines and contains the per-model budgets and synthetic
+# pricing; keeping it in files/ rather than inline in values.yaml follows
+# the Helm chart guide recommendation for "large, non-template payloads".
+#
+# The BerriAI LiteLLM docs document `--config /path/to/config.yaml` as
+# the supported way to pass the model registry at startup.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "stronghold.fullname" . }}-litellm-config
+  namespace: {{ include "stronghold.namespace" . }}
+  labels:
+    {{- include "stronghold.labels" . | nindent 4 }}
+    app.kubernetes.io/component: litellm
+    stronghold.io/priority-tier: P1
+data:
+  litellm_config.yaml: |-
+{{ .Files.Get "files/litellm-proxy-config.yaml" | indent 4 }}

--- a/deploy/helm/stronghold/templates/configmap-postgres-init.yaml
+++ b/deploy/helm/stronghold/templates/configmap-postgres-init.yaml
@@ -1,0 +1,33 @@
+# Postgres init scripts. Mounted into /docker-entrypoint-initdb.d; the
+# official postgres image executes every *.sql file under that directory
+# in lexical order on first boot (see the docker-library/postgres README,
+# "Initialization scripts" section).
+#
+# Port of the SQL from the raw manifest at deploy/k8s/postgres.yaml. The
+# CREATE EXTENSION statements require the pgvector/pgvector:pg17 image.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "stronghold.fullname" . }}-postgres-init
+  namespace: {{ include "stronghold.namespace" . }}
+  labels:
+    {{- include "stronghold.labels" . | nindent 4 }}
+    app.kubernetes.io/component: postgres
+    stronghold.io/priority-tier: P1
+data:
+  001_initial.sql: |
+    CREATE EXTENSION IF NOT EXISTS vector;
+    CREATE EXTENSION IF NOT EXISTS pg_trgm;
+
+    CREATE TABLE IF NOT EXISTS prompts (
+        id SERIAL PRIMARY KEY,
+        name TEXT NOT NULL,
+        version INTEGER NOT NULL,
+        label TEXT,
+        content TEXT NOT NULL,
+        config JSONB NOT NULL DEFAULT '{}',
+        created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+        created_by TEXT NOT NULL DEFAULT 'system',
+        UNIQUE(name, version)
+    );
+    CREATE INDEX IF NOT EXISTS idx_prompts_name ON prompts (name);

--- a/deploy/helm/stronghold/templates/configmap-stronghold.yaml
+++ b/deploy/helm/stronghold/templates/configmap-stronghold.yaml
@@ -1,0 +1,22 @@
+# Non-secret config for the stronghold-api. The example payload mirrors
+# the STRONGHOLD_CONFIG file referenced by the raw manifest at
+# deploy/k8s/stronghold.yaml; real production values come from the
+# values-prod-homelab overlay.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "stronghold.fullname" . }}-config
+  namespace: {{ include "stronghold.namespace" . }}
+  labels:
+    {{- include "stronghold.labels" . | nindent 4 }}
+    app.kubernetes.io/component: stronghold-api
+    stronghold.io/priority-tier: P0
+data:
+  example.yaml: |
+    # Placeholder config. Override via --set-file or a values overlay.
+    server:
+      port: {{ .Values.strongholdApi.containerPort }}
+    database:
+      url: postgres://{{ .Values.postgresql.username }}@{{ include "stronghold.fullname" . }}-postgres:{{ .Values.postgresql.containerPort }}/{{ .Values.postgresql.database }}
+    router:
+      url: http://{{ include "stronghold.fullname" . }}-litellm:{{ .Values.litellmProxy.containerPort }}

--- a/deploy/helm/stronghold/templates/deployment-litellm.yaml
+++ b/deploy/helm/stronghold/templates/deployment-litellm.yaml
@@ -1,0 +1,90 @@
+# LiteLLM proxy Deployment.
+#
+# Replaces the raw manifest at deploy/k8s/litellm.yaml. Pod-level config:
+#   * --config /app/config/litellm_config.yaml  (mounted from ConfigMap)
+#   * --port matches .Values.litellmProxy.containerPort
+# Per ADR-K8S-014 litellm is a P1 chat-tools workload (LLM traffic hot
+# path but not the chat UI itself).
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "stronghold.fullname" . }}-litellm
+  namespace: {{ include "stronghold.namespace" . }}
+  labels:
+    {{- include "stronghold.labels" . | nindent 4 }}
+    app.kubernetes.io/component: litellm
+    stronghold.io/priority-tier: P1
+spec:
+  replicas: {{ .Values.litellmProxy.replicas }}
+  selector:
+    matchLabels:
+      {{- include "stronghold.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: litellm
+  template:
+    metadata:
+      labels:
+        {{- include "stronghold.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: litellm
+        stronghold.io/priority-tier: P1
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap-litellm.yaml") . | sha256sum }}
+    spec:
+      serviceAccountName: {{ include "stronghold.serviceAccountName.litellm" . }}
+      automountServiceAccountToken: false
+      priorityClassName: {{ include "stronghold.priorityClassName" (dict "tier" "P1" "root" .) }}
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: litellm
+          image: {{ include "stronghold.image" (dict "image" .Values.litellmProxy.image "root" .) }}
+          imagePullPolicy: {{ include "stronghold.imagePullPolicy" (dict "image" .Values.litellmProxy.image) }}
+          args:
+            - "--config"
+            - "/app/config/litellm_config.yaml"
+            - "--port"
+            - "{{ .Values.litellmProxy.containerPort }}"
+          ports:
+            - name: http
+              containerPort: {{ .Values.litellmProxy.containerPort }}
+              protocol: TCP
+          envFrom:
+            - secretRef:
+                name: {{ .Values.litellmProxy.envSecretName }}
+          env:
+            - name: DATABASE_URL
+              value: postgresql://$(POSTGRES_USER):$(POSTGRES_PASSWORD)@{{ include "stronghold.fullname" . }}-postgres:{{ .Values.postgresql.containerPort }}/$(POSTGRES_DB)
+          livenessProbe:
+            httpGet:
+              path: {{ .Values.litellmProxy.probes.liveness.path }}
+              port: http
+            initialDelaySeconds: {{ .Values.litellmProxy.probes.liveness.initialDelaySeconds }}
+            periodSeconds: {{ .Values.litellmProxy.probes.liveness.periodSeconds }}
+          readinessProbe:
+            httpGet:
+              path: {{ .Values.litellmProxy.probes.readiness.path }}
+              port: http
+            initialDelaySeconds: {{ .Values.litellmProxy.probes.readiness.initialDelaySeconds }}
+            periodSeconds: {{ .Values.litellmProxy.probes.readiness.periodSeconds }}
+          resources:
+            {{- toYaml .Values.litellmProxy.resources | nindent 12 }}
+          securityContext:
+            allowPrivilegeEscalation: false
+            runAsNonRoot: true
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
+          volumeMounts:
+            - name: config
+              mountPath: /app/config
+              readOnly: true
+            - name: tmp
+              mountPath: /tmp
+      volumes:
+        - name: config
+          configMap:
+            name: {{ include "stronghold.fullname" . }}-litellm-config
+        - name: tmp
+          emptyDir:
+            sizeLimit: 128Mi

--- a/deploy/helm/stronghold/templates/deployment-mcp-dev-tools.yaml
+++ b/deploy/helm/stronghold/templates/deployment-mcp-dev-tools.yaml
@@ -1,0 +1,79 @@
+{{- if .Values.mcp.devTools.enabled }}
+# Dev-tools MCP server Deployment.
+#
+# Replaces the raw manifest at deploy/k8s/dev-tools-mcp.yaml. The raw
+# manifest mounted /stronghold-repo via hostPath which is forbidden by
+# baseline rule 6. Replaced with an optional PVC-backed workspace
+# referenced by name (cluster operator responsibility).
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "stronghold.fullname" . }}-mcp-dev-tools
+  namespace: {{ .Values.extraNamespaces.mcp.name }}
+  labels:
+    {{- include "stronghold.labels" . | nindent 4 }}
+    app.kubernetes.io/component: mcp-dev-tools
+    stronghold.io/priority-tier: P1
+spec:
+  replicas: {{ .Values.mcp.devTools.replicas }}
+  selector:
+    matchLabels:
+      {{- include "stronghold.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: mcp-dev-tools
+  template:
+    metadata:
+      labels:
+        {{- include "stronghold.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: mcp-dev-tools
+        stronghold.io/priority-tier: P1
+    spec:
+      automountServiceAccountToken: false
+      priorityClassName: {{ include "stronghold.priorityClassName" (dict "tier" "P1" "root" .) }}
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: dev-tools-mcp
+          image: {{ include "stronghold.image" (dict "image" .Values.mcp.devTools.image "root" .) }}
+          imagePullPolicy: {{ include "stronghold.imagePullPolicy" (dict "image" .Values.mcp.devTools.image) }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.mcp.devTools.containerPort }}
+              protocol: TCP
+          livenessProbe:
+            tcpSocket:
+              port: http
+            initialDelaySeconds: 15
+            periodSeconds: 20
+          readinessProbe:
+            tcpSocket:
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          resources:
+            {{- toYaml .Values.mcp.devTools.resources | nindent 12 }}
+          securityContext:
+            allowPrivilegeEscalation: false
+            runAsNonRoot: true
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
+          volumeMounts:
+            - name: workspace
+              mountPath: /workspace
+            - name: tmp
+              mountPath: /tmp
+      volumes:
+        - name: workspace
+          {{- if .Values.mcp.devTools.workspacePvcName }}
+          persistentVolumeClaim:
+            claimName: {{ .Values.mcp.devTools.workspacePvcName }}
+          {{- else }}
+          emptyDir:
+            sizeLimit: 1Gi
+          {{- end }}
+        - name: tmp
+          emptyDir:
+            sizeLimit: 128Mi
+{{- end }}

--- a/deploy/helm/stronghold/templates/deployment-mcp-github.yaml
+++ b/deploy/helm/stronghold/templates/deployment-mcp-github.yaml
@@ -1,8 +1,23 @@
-{{- if .Values.mcp.github.enabled }}
-# GitHub MCP server Deployment.
+{{- if and .Values.mcp.github.enabled .Values.mcp.github.devMode }}
+# WARNING: SHARED-PAT SECURITY MODEL — DEV CLUSTERS ONLY
 #
-# Replaces the raw manifest at deploy/k8s/github-mcp.yaml. Lives in the
-# stronghold-mcp namespace per ADR-K8S-001. The PAT is loaded from a
+# This template deploys github-mcp with a SINGLE shared PAT for ALL Stronghold
+# users. Every user who hits this pod acts as the same GitHub identity (whoever
+# owns the PAT in the secretKeyRef). This means: wrong identity in audit logs,
+# permission escalation, no per-user revocation, no per-user rate limits.
+#
+# Per ADR-K8S-018 (per-user credential vault), ADR-K8S-019 (tool policy layer),
+# ADR-K8S-020 (Stronghold as MCP server/gateway), and ADR-K8S-025 (sandboxed
+# MCP guests pattern), the production path is for github to be a Stronghold
+# in-process tool with per-user vault credential injection — NOT a shared MCP
+# server pod. This template exists only as a dev convenience and is gated behind
+# `.Values.mcp.github.devMode: true` (default false).
+#
+# The v0.9.1 Tool Catalog PR will remove this template entirely and replace it
+# with an in-process tool at src/stronghold/tools/github.py.
+#
+# Original description: Replaces the raw manifest at deploy/k8s/github-mcp.yaml.
+# Lives in the stronghold-mcp namespace per ADR-K8S-001. The PAT is loaded from a
 # Secret by name only (never an inline env value) — matches the raw
 # manifest and satisfies baseline rule 6 (no env-var secrets).
 #

--- a/deploy/helm/stronghold/templates/deployment-mcp-github.yaml
+++ b/deploy/helm/stronghold/templates/deployment-mcp-github.yaml
@@ -1,0 +1,84 @@
+{{- if .Values.mcp.github.enabled }}
+# GitHub MCP server Deployment.
+#
+# Replaces the raw manifest at deploy/k8s/github-mcp.yaml. Lives in the
+# stronghold-mcp namespace per ADR-K8S-001. The PAT is loaded from a
+# Secret by name only (never an inline env value) — matches the raw
+# manifest and satisfies baseline rule 6 (no env-var secrets).
+#
+# Per ADR-K8S-014 MCP servers are P1 chat-tools: they are called
+# synchronously on the hot path so they should not be evicted ahead of
+# backend workloads.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "stronghold.fullname" . }}-mcp-github
+  namespace: {{ .Values.extraNamespaces.mcp.name }}
+  labels:
+    {{- include "stronghold.labels" . | nindent 4 }}
+    app.kubernetes.io/component: mcp-github
+    stronghold.io/priority-tier: P1
+spec:
+  replicas: {{ .Values.mcp.github.replicas }}
+  selector:
+    matchLabels:
+      {{- include "stronghold.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: mcp-github
+  template:
+    metadata:
+      labels:
+        {{- include "stronghold.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: mcp-github
+        stronghold.io/priority-tier: P1
+    spec:
+      # MCP workloads in stronghold-mcp run under the namespace default
+      # SA because PR-6 did not create a per-component SA in that
+      # namespace. Token automount is disabled so the pod never carries
+      # a Kubernetes API credential at rest.
+      automountServiceAccountToken: false
+      priorityClassName: {{ include "stronghold.priorityClassName" (dict "tier" "P1" "root" .) }}
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: github-mcp
+          image: {{ include "stronghold.image" (dict "image" .Values.mcp.github.image "root" .) }}
+          imagePullPolicy: {{ include "stronghold.imagePullPolicy" (dict "image" .Values.mcp.github.image) }}
+          args: ["--transport", "sse"]
+          ports:
+            - name: http
+              containerPort: {{ .Values.mcp.github.containerPort }}
+              protocol: TCP
+          env:
+            - name: GITHUB_PERSONAL_ACCESS_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.mcp.github.patSecretName }}
+                  key: token
+          livenessProbe:
+            tcpSocket:
+              port: http
+            initialDelaySeconds: 15
+            periodSeconds: 20
+          readinessProbe:
+            tcpSocket:
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          resources:
+            {{- toYaml .Values.mcp.github.resources | nindent 12 }}
+          securityContext:
+            allowPrivilegeEscalation: false
+            runAsNonRoot: true
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+      volumes:
+        - name: tmp
+          emptyDir:
+            sizeLimit: 64Mi
+{{- end }}

--- a/deploy/helm/stronghold/templates/deployment-phoenix.yaml
+++ b/deploy/helm/stronghold/templates/deployment-phoenix.yaml
@@ -1,0 +1,81 @@
+# Arize Phoenix Deployment.
+#
+# Replaces the raw manifest at deploy/k8s/phoenix.yaml. Per ADR-K8S-014
+# Phoenix is a P1 chat-tools workload: observability for the hot LLM
+# path, evicted before stronghold-api but before the lower tiers.
+#
+# PHOENIX_SQL_DATABASE_URL matches the raw manifest and points at the
+# shared postgres instance (using the `phoenix` database created by the
+# init scripts — or by phoenix on first boot).
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "stronghold.fullname" . }}-phoenix
+  namespace: {{ include "stronghold.namespace" . }}
+  labels:
+    {{- include "stronghold.labels" . | nindent 4 }}
+    app.kubernetes.io/component: phoenix
+    stronghold.io/priority-tier: P1
+spec:
+  replicas: {{ .Values.phoenixSvc.replicas }}
+  selector:
+    matchLabels:
+      {{- include "stronghold.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: phoenix
+  template:
+    metadata:
+      labels:
+        {{- include "stronghold.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: phoenix
+        stronghold.io/priority-tier: P1
+    spec:
+      serviceAccountName: {{ include "stronghold.serviceAccountName.phoenix" . }}
+      automountServiceAccountToken: false
+      priorityClassName: {{ include "stronghold.priorityClassName" (dict "tier" "P1" "root" .) }}
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: phoenix
+          image: {{ include "stronghold.image" (dict "image" .Values.phoenixSvc.image "root" .) }}
+          imagePullPolicy: {{ include "stronghold.imagePullPolicy" (dict "image" .Values.phoenixSvc.image) }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.phoenixSvc.containerPort }}
+              protocol: TCP
+          env:
+            - name: PHOENIX_SQL_DATABASE_URL
+              value: postgresql://$(POSTGRES_USER):$(POSTGRES_PASSWORD)@{{ include "stronghold.fullname" . }}-postgres:{{ .Values.postgresql.containerPort }}/phoenix
+            - name: PHOENIX_WORKING_DIR
+              value: /tmp/phoenix
+          envFrom:
+            - secretRef:
+                name: {{ if .Values.postgresql.existingSecret }}{{ .Values.postgresql.existingSecret }}{{ else }}{{ include "stronghold.fullname" . }}-postgres-credentials{{ end }}
+          livenessProbe:
+            httpGet:
+              path: {{ .Values.phoenixSvc.probes.liveness.path }}
+              port: http
+            initialDelaySeconds: {{ .Values.phoenixSvc.probes.liveness.initialDelaySeconds }}
+            periodSeconds: {{ .Values.phoenixSvc.probes.liveness.periodSeconds }}
+          readinessProbe:
+            httpGet:
+              path: {{ .Values.phoenixSvc.probes.readiness.path }}
+              port: http
+            initialDelaySeconds: {{ .Values.phoenixSvc.probes.readiness.initialDelaySeconds }}
+            periodSeconds: {{ .Values.phoenixSvc.probes.readiness.periodSeconds }}
+          resources:
+            {{- toYaml .Values.phoenixSvc.resources | nindent 12 }}
+          securityContext:
+            allowPrivilegeEscalation: false
+            runAsNonRoot: true
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
+          volumeMounts:
+            - name: phoenix-tmp
+              mountPath: /tmp
+      volumes:
+        - name: phoenix-tmp
+          emptyDir:
+            sizeLimit: 512Mi

--- a/deploy/helm/stronghold/templates/deployment-stronghold.yaml
+++ b/deploy/helm/stronghold/templates/deployment-stronghold.yaml
@@ -1,0 +1,140 @@
+# Stronghold API Deployment.
+#
+# Replaces the single-container raw manifest at deploy/k8s/stronghold.yaml
+# and closes BACKLOG R3. The key architectural change versus the raw
+# manifest is the two-container pod: the main `stronghold` container
+# contains NO kubeconfig and cannot talk to the Kubernetes API directly,
+# while the `mcp-deployer` sidecar runs under the least-privilege
+# stronghold-mcp-deployer ServiceAccount (PR-6 RBAC) and exposes a Unix
+# domain socket over a shared emptyDir volume. This matches the
+# Kubernetes "Sidecar containers" pattern documented in the workloads
+# concept guide.
+#
+# PriorityClass is P0 per ADR-K8S-014 — stronghold-api is the chat-critical
+# hot path and is evicted last.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "stronghold.fullname" . }}-api
+  namespace: {{ include "stronghold.namespace" . }}
+  labels:
+    {{- include "stronghold.labels" . | nindent 4 }}
+    app.kubernetes.io/component: stronghold-api
+    stronghold.io/priority-tier: P0
+spec:
+  replicas: {{ .Values.strongholdApi.replicas }}
+  selector:
+    matchLabels:
+      {{- include "stronghold.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: stronghold-api
+  template:
+    metadata:
+      labels:
+        {{- include "stronghold.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: stronghold-api
+        stronghold.io/priority-tier: P0
+      annotations:
+        # Rollout on config changes. The checksum/config pattern is from
+        # the Helm chart development guide ("Automatically Roll Deployments").
+        checksum/config: {{ include (print $.Template.BasePath "/configmap-stronghold.yaml") . | sha256sum }}
+    spec:
+      serviceAccountName: {{ include "stronghold.serviceAccountName.strongholdApi" . }}
+      automountServiceAccountToken: true
+      priorityClassName: {{ include "stronghold.priorityClassName" (dict "tier" "P0" "root" .) }}
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: stronghold
+          image: {{ include "stronghold.image" (dict "image" .Values.strongholdApi.image "root" .) }}
+          imagePullPolicy: {{ include "stronghold.imagePullPolicy" (dict "image" .Values.strongholdApi.image) }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.strongholdApi.containerPort }}
+              protocol: TCP
+          env:
+            - name: DATABASE_URL
+              value: postgresql://$(POSTGRES_USER):$(POSTGRES_PASSWORD)@{{ include "stronghold.fullname" . }}-postgres:{{ .Values.postgresql.containerPort }}/$(POSTGRES_DB)
+            - name: LITELLM_URL
+              value: http://{{ include "stronghold.fullname" . }}-litellm:{{ .Values.litellmProxy.containerPort }}
+            - name: PHOENIX_COLLECTOR_ENDPOINT
+              value: http://{{ include "stronghold.fullname" . }}-phoenix:{{ .Values.phoenixSvc.containerPort }}
+            - name: STRONGHOLD_CONFIG
+              value: {{ .Values.strongholdApi.config.strongholdConfigPath | quote }}
+            - name: MCP_DEPLOYER_SOCKET
+              value: {{ .Values.strongholdApi.mcpDeployerSidecar.socketPath | quote }}
+          envFrom:
+            - secretRef:
+                name: {{ if .Values.postgresql.existingSecret }}{{ .Values.postgresql.existingSecret }}{{ else }}{{ include "stronghold.fullname" . }}-postgres-credentials{{ end }}
+          livenessProbe:
+            httpGet:
+              path: {{ .Values.strongholdApi.probes.liveness.path }}
+              port: http
+            initialDelaySeconds: {{ .Values.strongholdApi.probes.liveness.initialDelaySeconds }}
+            periodSeconds: {{ .Values.strongholdApi.probes.liveness.periodSeconds }}
+          readinessProbe:
+            httpGet:
+              path: {{ .Values.strongholdApi.probes.readiness.path }}
+              port: http
+            initialDelaySeconds: {{ .Values.strongholdApi.probes.readiness.initialDelaySeconds }}
+            periodSeconds: {{ .Values.strongholdApi.probes.readiness.periodSeconds }}
+          resources:
+            {{- toYaml .Values.strongholdApi.resources | nindent 12 }}
+          securityContext:
+            allowPrivilegeEscalation: false
+            runAsNonRoot: true
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
+          volumeMounts:
+            - name: config
+              mountPath: /app/config
+              readOnly: true
+            - name: mcp-deployer-socket
+              mountPath: /run/stronghold
+            - name: tmp
+              mountPath: /tmp
+        # Sidecar: mcp-deployer. Runs under its own SA (mcp-deployer)
+        # which has the namespace-scoped Role to deploy MCP servers in
+        # stronghold-mcp. The main container never sees this token.
+        - name: mcp-deployer
+          image: {{ include "stronghold.image" (dict "image" .Values.strongholdApi.mcpDeployerSidecar.image "root" .) }}
+          imagePullPolicy: {{ include "stronghold.imagePullPolicy" (dict "image" .Values.strongholdApi.mcpDeployerSidecar.image) }}
+          env:
+            - name: MCP_DEPLOYER_SOCKET
+              value: {{ .Values.strongholdApi.mcpDeployerSidecar.socketPath | quote }}
+            - name: MCP_TARGET_NAMESPACE
+              value: {{ .Values.extraNamespaces.mcp.name | quote }}
+          resources:
+            requests:
+              cpu: 50m
+              memory: 64Mi
+            limits:
+              cpu: 200m
+              memory: 256Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            runAsNonRoot: true
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
+          volumeMounts:
+            - name: mcp-deployer-socket
+              mountPath: /run/stronghold
+            - name: mcp-deployer-tmp
+              mountPath: /tmp
+      volumes:
+        - name: config
+          configMap:
+            name: {{ include "stronghold.fullname" . }}-config
+        - name: mcp-deployer-socket
+          emptyDir:
+            medium: Memory
+            sizeLimit: 16Mi
+        - name: tmp
+          emptyDir:
+            sizeLimit: 64Mi
+        - name: mcp-deployer-tmp
+          emptyDir:
+            sizeLimit: 32Mi

--- a/deploy/helm/stronghold/templates/extra-namespaces.yaml
+++ b/deploy/helm/stronghold/templates/extra-namespaces.yaml
@@ -1,0 +1,32 @@
+{{- if and .Values.namespace.create .Values.extraNamespaces.create }}
+# Additional workload namespaces per ADR-K8S-001.
+#
+# Rendered only when the chart is explicitly asked to manage namespace
+# creation. In most GitOps setups these are created out-of-band (e.g. by
+# an Argo CD app-of-apps pattern) and this flag stays false.
+#
+# PodSecurity admission labels mirror the release namespace (restricted)
+# so vanilla-k8s installs get an equivalent security posture to the
+# OpenShift restricted-v2 SCC (ADR-K8S-007).
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: {{ .Values.extraNamespaces.mcp.name }}
+  labels:
+    {{- include "stronghold.labels" . | nindent 4 }}
+    app.kubernetes.io/component: mcp
+    pod-security.kubernetes.io/enforce: restricted
+    pod-security.kubernetes.io/audit: restricted
+    pod-security.kubernetes.io/warn: restricted
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: {{ .Values.extraNamespaces.data.name }}
+  labels:
+    {{- include "stronghold.labels" . | nindent 4 }}
+    app.kubernetes.io/component: data
+    pod-security.kubernetes.io/enforce: restricted
+    pod-security.kubernetes.io/audit: restricted
+    pod-security.kubernetes.io/warn: restricted
+{{- end }}

--- a/deploy/helm/stronghold/templates/ingress-litellm.yaml
+++ b/deploy/helm/stronghold/templates/ingress-litellm.yaml
@@ -1,0 +1,24 @@
+{{- if and (not (include "stronghold.openshiftEnabled" .)) .Values.ingressRoutes.enabled .Values.litellmProxy.exposed }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "stronghold.fullname" . }}-litellm
+  namespace: {{ include "stronghold.namespace" . }}
+  labels:
+    {{- include "stronghold.labels" . | nindent 4 }}
+    app.kubernetes.io/component: litellm
+    stronghold.io/priority-tier: P1
+spec:
+  ingressClassName: {{ .Values.ingressRoutes.className | quote }}
+  rules:
+    - host: {{ .Values.ingressRoutes.litellm.host | quote }}
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ include "stronghold.fullname" . }}-litellm
+                port:
+                  name: http
+{{- end }}

--- a/deploy/helm/stronghold/templates/ingress-phoenix.yaml
+++ b/deploy/helm/stronghold/templates/ingress-phoenix.yaml
@@ -1,0 +1,24 @@
+{{- if and (not (include "stronghold.openshiftEnabled" .)) .Values.ingressRoutes.enabled .Values.phoenixSvc.exposed }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "stronghold.fullname" . }}-phoenix
+  namespace: {{ include "stronghold.namespace" . }}
+  labels:
+    {{- include "stronghold.labels" . | nindent 4 }}
+    app.kubernetes.io/component: phoenix
+    stronghold.io/priority-tier: P1
+spec:
+  ingressClassName: {{ .Values.ingressRoutes.className | quote }}
+  rules:
+    - host: {{ .Values.ingressRoutes.phoenix.host | quote }}
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ include "stronghold.fullname" . }}-phoenix
+                port:
+                  name: http
+{{- end }}

--- a/deploy/helm/stronghold/templates/ingress-stronghold.yaml
+++ b/deploy/helm/stronghold/templates/ingress-stronghold.yaml
@@ -1,0 +1,29 @@
+{{- if and (not (include "stronghold.openshiftEnabled" .)) .Values.ingressRoutes.enabled }}
+# Vanilla Kubernetes Ingress fallback for the stronghold-api.
+#
+# Used on EKS/GKE/AKS/RKE2/k3s per ADR-K8S-007. OpenShift installs
+# render templates/route-stronghold.yaml instead; the two are mutually
+# exclusive via the `openshift.enabled` gate.
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "stronghold.fullname" . }}-api
+  namespace: {{ include "stronghold.namespace" . }}
+  labels:
+    {{- include "stronghold.labels" . | nindent 4 }}
+    app.kubernetes.io/component: stronghold-api
+    stronghold.io/priority-tier: P0
+spec:
+  ingressClassName: {{ .Values.ingressRoutes.className | quote }}
+  rules:
+    - host: {{ .Values.ingressRoutes.stronghold.host | quote }}
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ include "stronghold.fullname" . }}-api
+                port:
+                  name: http
+{{- end }}

--- a/deploy/helm/stronghold/templates/route-litellm.yaml
+++ b/deploy/helm/stronghold/templates/route-litellm.yaml
@@ -1,0 +1,26 @@
+{{- if and (include "stronghold.openshiftEnabled" .) .Values.litellmProxy.exposed }}
+# Optional Route for LiteLLM. Off by default; LiteLLM is an internal
+# proxy and should only be exposed for debugging or third-party
+# integrations that need direct model access.
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: {{ include "stronghold.fullname" . }}-litellm
+  namespace: {{ include "stronghold.namespace" . }}
+  labels:
+    {{- include "stronghold.labels" . | nindent 4 }}
+    app.kubernetes.io/component: litellm
+    stronghold.io/priority-tier: P1
+spec:
+  host: {{ .Values.route.litellm.host | quote }}
+  to:
+    kind: Service
+    name: {{ include "stronghold.fullname" . }}-litellm
+    weight: 100
+  port:
+    targetPort: http
+  tls:
+    termination: {{ .Values.route.litellm.tlsTermination }}
+    insecureEdgeTerminationPolicy: Redirect
+  wildcardPolicy: None
+{{- end }}

--- a/deploy/helm/stronghold/templates/route-phoenix.yaml
+++ b/deploy/helm/stronghold/templates/route-phoenix.yaml
@@ -1,0 +1,25 @@
+{{- if and (include "stronghold.openshiftEnabled" .) .Values.phoenixSvc.exposed }}
+# Optional Route for Arize Phoenix. Off by default; enable for teams
+# that need external access to the tracing UI.
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: {{ include "stronghold.fullname" . }}-phoenix
+  namespace: {{ include "stronghold.namespace" . }}
+  labels:
+    {{- include "stronghold.labels" . | nindent 4 }}
+    app.kubernetes.io/component: phoenix
+    stronghold.io/priority-tier: P1
+spec:
+  host: {{ .Values.route.phoenix.host | quote }}
+  to:
+    kind: Service
+    name: {{ include "stronghold.fullname" . }}-phoenix
+    weight: 100
+  port:
+    targetPort: http
+  tls:
+    termination: {{ .Values.route.phoenix.tlsTermination }}
+    insecureEdgeTerminationPolicy: Redirect
+  wildcardPolicy: None
+{{- end }}

--- a/deploy/helm/stronghold/templates/route-stronghold.yaml
+++ b/deploy/helm/stronghold/templates/route-stronghold.yaml
@@ -1,0 +1,29 @@
+{{- if (include "stronghold.openshiftEnabled" .) }}
+# OpenShift Route for the stronghold-api.
+#
+# Route is an OpenShift-native API (route.openshift.io/v1). Documented
+# in the OpenShift networking guide under "Configuring Routes". On
+# vanilla Kubernetes distros this resource is not rendered; see
+# templates/ingress-stronghold.yaml for the fallback.
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: {{ include "stronghold.fullname" . }}-api
+  namespace: {{ include "stronghold.namespace" . }}
+  labels:
+    {{- include "stronghold.labels" . | nindent 4 }}
+    app.kubernetes.io/component: stronghold-api
+    stronghold.io/priority-tier: P0
+spec:
+  host: {{ .Values.route.stronghold.host | quote }}
+  to:
+    kind: Service
+    name: {{ include "stronghold.fullname" . }}-api
+    weight: 100
+  port:
+    targetPort: http
+  tls:
+    termination: {{ .Values.route.stronghold.tlsTermination }}
+    insecureEdgeTerminationPolicy: Redirect
+  wildcardPolicy: None
+{{- end }}

--- a/deploy/helm/stronghold/templates/secret-litellm-env.yaml
+++ b/deploy/helm/stronghold/templates/secret-litellm-env.yaml
@@ -1,0 +1,30 @@
+{{- if .Values.litellmProxy.createStubSecret }}
+# Stub envFrom Secret for LiteLLM provider API keys.
+#
+# LiteLLM's model registry references provider keys via os.environ/*
+# (see files/litellm_config.yaml lines 1-20 for examples). The stub
+# below exists so `helm install` succeeds on a fresh cluster; production
+# installs MUST disable createStubSecret and provide the Secret via
+# sealed-secrets or External Secrets Operator per ADR-K8S-003.
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Values.litellmProxy.envSecretName }}
+  namespace: {{ include "stronghold.namespace" . }}
+  labels:
+    {{- include "stronghold.labels" . | nindent 4 }}
+    app.kubernetes.io/component: litellm
+    stronghold.io/priority-tier: P1
+  annotations:
+    stronghold.io/stub: "true"
+type: Opaque
+stringData:
+  MISTRAL_API_KEY: ""
+  CEREBRAS_API_KEY: ""
+  GEMINI_API_KEY: ""
+  GROQ_API_KEY: ""
+  OPENAI_API_KEY: ""
+  ANTHROPIC_API_KEY: ""
+  DEEPSEEK_API_KEY: ""
+  TOGETHER_API_KEY: ""
+{{- end }}

--- a/deploy/helm/stronghold/templates/secret-postgres-auth.yaml
+++ b/deploy/helm/stronghold/templates/secret-postgres-auth.yaml
@@ -1,0 +1,33 @@
+{{- if not .Values.postgresql.existingSecret }}
+# Stub credentials Secret. Rendered only when postgresql.existingSecret
+# is empty. Production installs MUST set postgresql.existingSecret to a
+# Secret managed by sealed-secrets or External Secrets Operator per
+# ADR-K8S-003.
+#
+# The password is generated once per install via randAlphaNum and stored
+# in the release — subsequent `helm upgrade` runs will reuse the value by
+# looking it up from the existing Secret resource. This matches the
+# pattern documented in the Helm "Generating a Secret on install" section
+# of the chart development guide.
+{{- $existing := lookup "v1" "Secret" (include "stronghold.namespace" .) (printf "%s-postgres-credentials" (include "stronghold.fullname" .)) -}}
+{{- $password := "" -}}
+{{- if and $existing $existing.data -}}
+  {{- $password = index $existing.data "POSTGRES_PASSWORD" | b64dec -}}
+{{- else -}}
+  {{- $password = randAlphaNum 32 -}}
+{{- end -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "stronghold.fullname" . }}-postgres-credentials
+  namespace: {{ include "stronghold.namespace" . }}
+  labels:
+    {{- include "stronghold.labels" . | nindent 4 }}
+    app.kubernetes.io/component: postgres
+    stronghold.io/priority-tier: P1
+type: Opaque
+stringData:
+  POSTGRES_USER: {{ .Values.postgresql.username | quote }}
+  POSTGRES_PASSWORD: {{ $password | quote }}
+  POSTGRES_DB: {{ .Values.postgresql.database | quote }}
+{{- end }}

--- a/deploy/helm/stronghold/templates/service-litellm.yaml
+++ b/deploy/helm/stronghold/templates/service-litellm.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "stronghold.fullname" . }}-litellm
+  namespace: {{ include "stronghold.namespace" . }}
+  labels:
+    {{- include "stronghold.labels" . | nindent 4 }}
+    app.kubernetes.io/component: litellm
+    stronghold.io/priority-tier: P1
+spec:
+  type: ClusterIP
+  selector:
+    {{- include "stronghold.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: litellm
+  ports:
+    - name: http
+      port: {{ .Values.litellmProxy.containerPort }}
+      targetPort: http
+      protocol: TCP

--- a/deploy/helm/stronghold/templates/service-mcp-dev-tools.yaml
+++ b/deploy/helm/stronghold/templates/service-mcp-dev-tools.yaml
@@ -1,0 +1,21 @@
+{{- if .Values.mcp.devTools.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "stronghold.fullname" . }}-mcp-dev-tools
+  namespace: {{ .Values.extraNamespaces.mcp.name }}
+  labels:
+    {{- include "stronghold.labels" . | nindent 4 }}
+    app.kubernetes.io/component: mcp-dev-tools
+    stronghold.io/priority-tier: P1
+spec:
+  type: ClusterIP
+  selector:
+    {{- include "stronghold.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: mcp-dev-tools
+  ports:
+    - name: http
+      port: {{ .Values.mcp.devTools.containerPort }}
+      targetPort: http
+      protocol: TCP
+{{- end }}

--- a/deploy/helm/stronghold/templates/service-mcp-github.yaml
+++ b/deploy/helm/stronghold/templates/service-mcp-github.yaml
@@ -1,0 +1,21 @@
+{{- if .Values.mcp.github.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "stronghold.fullname" . }}-mcp-github
+  namespace: {{ .Values.extraNamespaces.mcp.name }}
+  labels:
+    {{- include "stronghold.labels" . | nindent 4 }}
+    app.kubernetes.io/component: mcp-github
+    stronghold.io/priority-tier: P1
+spec:
+  type: ClusterIP
+  selector:
+    {{- include "stronghold.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: mcp-github
+  ports:
+    - name: http
+      port: {{ .Values.mcp.github.containerPort }}
+      targetPort: http
+      protocol: TCP
+{{- end }}

--- a/deploy/helm/stronghold/templates/service-mcp-github.yaml
+++ b/deploy/helm/stronghold/templates/service-mcp-github.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.mcp.github.enabled }}
+{{- if and .Values.mcp.github.enabled .Values.mcp.github.devMode }}
 apiVersion: v1
 kind: Service
 metadata:

--- a/deploy/helm/stronghold/templates/service-phoenix.yaml
+++ b/deploy/helm/stronghold/templates/service-phoenix.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "stronghold.fullname" . }}-phoenix
+  namespace: {{ include "stronghold.namespace" . }}
+  labels:
+    {{- include "stronghold.labels" . | nindent 4 }}
+    app.kubernetes.io/component: phoenix
+    stronghold.io/priority-tier: P1
+spec:
+  type: ClusterIP
+  selector:
+    {{- include "stronghold.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: phoenix
+  ports:
+    - name: http
+      port: {{ .Values.phoenixSvc.containerPort }}
+      targetPort: http
+      protocol: TCP

--- a/deploy/helm/stronghold/templates/service-postgres.yaml
+++ b/deploy/helm/stronghold/templates/service-postgres.yaml
@@ -1,0 +1,25 @@
+# Headless Service for the postgres StatefulSet. clusterIP: None gives
+# each pod a stable DNS record of the form
+#   <pod>.<service>.<namespace>.svc.cluster.local
+# per the Kubernetes "Headless Services" documentation, which is the
+# standard pattern for stateful single-writer workloads.
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "stronghold.fullname" . }}-postgres
+  namespace: {{ include "stronghold.namespace" . }}
+  labels:
+    {{- include "stronghold.labels" . | nindent 4 }}
+    app.kubernetes.io/component: postgres
+    stronghold.io/priority-tier: P1
+spec:
+  type: ClusterIP
+  clusterIP: None
+  selector:
+    {{- include "stronghold.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: postgres
+  ports:
+    - name: postgres
+      port: {{ .Values.postgresql.containerPort }}
+      targetPort: postgres
+      protocol: TCP

--- a/deploy/helm/stronghold/templates/service-stronghold.yaml
+++ b/deploy/helm/stronghold/templates/service-stronghold.yaml
@@ -1,0 +1,25 @@
+# ClusterIP Service for the stronghold-api.
+#
+# External access is via an OpenShift Route (templates/route-stronghold.yaml)
+# or a vanilla-k8s Ingress (templates/ingress-stronghold.yaml); this
+# Service itself is internal-only. The raw manifest used NodePort which
+# violates the baseline "no LoadBalancer/NodePort" policy.
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "stronghold.fullname" . }}-api
+  namespace: {{ include "stronghold.namespace" . }}
+  labels:
+    {{- include "stronghold.labels" . | nindent 4 }}
+    app.kubernetes.io/component: stronghold-api
+    stronghold.io/priority-tier: P0
+spec:
+  type: ClusterIP
+  selector:
+    {{- include "stronghold.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: stronghold-api
+  ports:
+    - name: http
+      port: {{ .Values.strongholdApi.containerPort }}
+      targetPort: http
+      protocol: TCP

--- a/deploy/helm/stronghold/templates/statefulset-postgres.yaml
+++ b/deploy/helm/stronghold/templates/statefulset-postgres.yaml
@@ -1,0 +1,107 @@
+# PostgreSQL StatefulSet.
+#
+# Replaces the Deployment from deploy/k8s/postgres.yaml. A StatefulSet is
+# required here because the raw Deployment variant lost durability on
+# every pod reschedule — the PVC was anonymous and got garbage-collected.
+# The Kubernetes "Running a Replicated Stateful Application" tutorial
+# documents StatefulSet + volumeClaimTemplates as the correct pattern for
+# single-writer RDBMS workloads.
+#
+# Placement note: ADR-K8S-001 specifies stronghold-data for stateful
+# workloads, but PR-6 pinned the postgres ServiceAccount to the release
+# namespace. Rather than cross-namespace a SA reference (which does not
+# work in Kubernetes), this StatefulSet is rendered in the release
+# namespace alongside its SA. A follow-up PR will relocate both together.
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ include "stronghold.fullname" . }}-postgres
+  namespace: {{ include "stronghold.namespace" . }}
+  labels:
+    {{- include "stronghold.labels" . | nindent 4 }}
+    app.kubernetes.io/component: postgres
+    stronghold.io/priority-tier: P1
+spec:
+  serviceName: {{ include "stronghold.fullname" . }}-postgres
+  replicas: 1
+  selector:
+    matchLabels:
+      {{- include "stronghold.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: postgres
+  template:
+    metadata:
+      labels:
+        {{- include "stronghold.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: postgres
+        stronghold.io/priority-tier: P1
+    spec:
+      serviceAccountName: {{ include "stronghold.serviceAccountName.postgres" . }}
+      automountServiceAccountToken: false
+      priorityClassName: {{ include "stronghold.priorityClassName" (dict "tier" "P1" "root" .) }}
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+        fsGroup: 26
+      containers:
+        - name: postgres
+          image: {{ include "stronghold.image" (dict "image" .Values.postgresql.image "root" .) }}
+          imagePullPolicy: {{ include "stronghold.imagePullPolicy" (dict "image" .Values.postgresql.image) }}
+          ports:
+            - name: postgres
+              containerPort: {{ .Values.postgresql.containerPort }}
+              protocol: TCP
+          envFrom:
+            - secretRef:
+                name: {{ if .Values.postgresql.existingSecret }}{{ .Values.postgresql.existingSecret }}{{ else }}{{ include "stronghold.fullname" . }}-postgres-credentials{{ end }}
+          env:
+            # pgvector/pgvector:pg17 honors PGDATA; put it under a subdir
+            # of the PVC so initdb does not conflict with lost+found on
+            # ext4-backed volumes.
+            - name: PGDATA
+              value: /var/lib/postgresql/data/pgdata
+          readinessProbe:
+            exec:
+              command: ["pg_isready", "-U", {{ .Values.postgresql.username | quote }}, "-d", {{ .Values.postgresql.database | quote }}]
+            initialDelaySeconds: {{ .Values.postgresql.probes.readiness.initialDelaySeconds }}
+            periodSeconds: {{ .Values.postgresql.probes.readiness.periodSeconds }}
+          livenessProbe:
+            exec:
+              command: ["pg_isready", "-U", {{ .Values.postgresql.username | quote }}, "-d", {{ .Values.postgresql.database | quote }}]
+            initialDelaySeconds: {{ .Values.postgresql.probes.liveness.initialDelaySeconds }}
+            periodSeconds: {{ .Values.postgresql.probes.liveness.periodSeconds }}
+          resources:
+            {{- toYaml .Values.postgresql.resources | nindent 12 }}
+          securityContext:
+            allowPrivilegeEscalation: false
+            runAsNonRoot: true
+            # postgres image runs as uid 999 by default; readOnlyRootFilesystem
+            # is left false because initdb writes to /var/run/postgresql.
+            readOnlyRootFilesystem: false
+            capabilities:
+              drop: ["ALL"]
+          volumeMounts:
+            - name: data
+              mountPath: /var/lib/postgresql/data
+            - name: init-scripts
+              mountPath: /docker-entrypoint-initdb.d
+              readOnly: true
+      volumes:
+        - name: init-scripts
+          configMap:
+            name: {{ include "stronghold.fullname" . }}-postgres-init
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+        labels:
+          {{- include "stronghold.labels" . | nindent 10 }}
+          app.kubernetes.io/component: postgres
+      spec:
+        accessModes:
+          {{- toYaml .Values.postgresql.persistence.accessModes | nindent 10 }}
+        {{- if .Values.postgresql.persistence.storageClassName }}
+        storageClassName: {{ .Values.postgresql.persistence.storageClassName | quote }}
+        {{- end }}
+        resources:
+          requests:
+            storage: {{ .Values.postgresql.persistence.size | quote }}

--- a/deploy/helm/stronghold/values-prod-homelab.yaml
+++ b/deploy/helm/stronghold/values-prod-homelab.yaml
@@ -26,3 +26,10 @@ namespace:
 
 rbac:
   create: true
+
+# Enable the shared-PAT github-mcp template for the homelab dev cluster.
+# This is acceptable for a single-user dev cluster but NOT for production.
+# See ADR-K8S-018/019/020/025 for the production credential isolation path.
+mcp:
+  github:
+    devMode: true

--- a/deploy/helm/stronghold/values.yaml
+++ b/deploy/helm/stronghold/values.yaml
@@ -311,6 +311,14 @@ phoenixSvc:
 mcp:
   github:
     enabled: true
+    # WARNING: devMode=true deploys a SHARED-PAT github-mcp pod where every
+    # Stronghold user acts as the same GitHub identity. This is a known security
+    # gap (wrong audit identity, permission escalation, no per-user revocation).
+    # Per ADR-K8S-018/019/020/025, the production path is an in-process Stronghold
+    # tool with per-user vault credential injection. This template is dev-only
+    # and will be removed in v0.9.1 (replaced by src/stronghold/tools/github.py).
+    # Set to true ONLY for dev/homelab clusters where a single PAT is acceptable.
+    devMode: false
     replicas: 1
     image:
       registry: ghcr.io

--- a/deploy/helm/stronghold/values.yaml
+++ b/deploy/helm/stronghold/values.yaml
@@ -151,3 +151,223 @@ serviceAccounts:
 # separately from workloads).
 rbac:
   create: true
+
+# -----------------------------------------------------------------------------
+# PR-7..PR-10 additions: workload templates (Deployments, StatefulSet,
+# Services, Routes/Ingress, ConfigMaps, Secrets). These extend the PR-6
+# skeleton with the actual runnable workloads per ADR-K8S-013.
+# -----------------------------------------------------------------------------
+
+# Extra namespaces managed by the chart. ADR-K8S-001 specifies three
+# namespaces: stronghold-platform (release namespace), stronghold-mcp
+# (MCP servers), and stronghold-data (stateful workloads). The additional
+# namespaces below are rendered when extraNamespaces.create is true.
+# NOTE: PR-6 pinned the postgres ServiceAccount to the release namespace,
+# so the PR-7 postgres StatefulSet is rendered in the release namespace
+# rather than stronghold-data; relocating both together is a follow-up.
+extraNamespaces:
+  create: false
+  mcp:
+    name: stronghold-mcp
+  data:
+    name: stronghold-data
+
+# Stronghold API — main platform workload (replaces the single-container
+# raw manifest at deploy/k8s/stronghold.yaml). Sidecar-first architecture
+# per R3 resolution: the main container has NO kubeconfig, it communicates
+# with the mcp-deployer sidecar over a Unix domain socket in a shared
+# emptyDir. See ADR-K8S-002 §4 and ADR-K8S-013 §"Hybrid execution model".
+strongholdApi:
+  replicas: 1
+  image:
+    registry: ghcr.io
+    repository: agent-stronghold/stronghold
+    tag: "0.1.0"
+    pullPolicy: IfNotPresent
+  containerPort: 8100
+  mcpDeployerSidecar:
+    image:
+      registry: ghcr.io
+      repository: agent-stronghold/mcp-deployer
+      tag: "0.1.0"
+      pullPolicy: IfNotPresent
+    socketPath: /run/stronghold/mcp-deployer.sock
+  resources:
+    requests:
+      cpu: 500m
+      memory: 512Mi
+    limits:
+      cpu: "2"
+      memory: 2Gi
+  probes:
+    liveness:
+      path: /health
+      initialDelaySeconds: 15
+      periodSeconds: 20
+    readiness:
+      path: /health
+      initialDelaySeconds: 5
+      periodSeconds: 10
+  config:
+    routerApiKeySecretName: stronghold-secrets
+    strongholdConfigPath: /app/config/example.yaml
+
+# PostgreSQL StatefulSet (replaces the Deployment in deploy/k8s/postgres.yaml
+# which lacked PV durability — closes the PR-7 durability gap). Image is
+# pinned to pgvector/pgvector:pg17 because the application requires the
+# pgvector and pg_trgm extensions.
+postgresql:
+  image:
+    registry: ""
+    repository: pgvector/pgvector
+    tag: "pg17"
+    pullPolicy: IfNotPresent
+  containerPort: 5432
+  persistence:
+    size: 20Gi
+    storageClassName: ""
+    accessModes:
+      - ReadWriteOnce
+  resources:
+    requests:
+      cpu: 500m
+      memory: 1Gi
+    limits:
+      cpu: "2"
+      memory: 4Gi
+  # Name of an externally-managed Secret with POSTGRES_USER /
+  # POSTGRES_PASSWORD / POSTGRES_DB keys. When empty, the chart renders
+  # a stub secret-postgres-credentials.yaml. Production installs should
+  # populate via sealed-secrets or ESO per ADR-K8S-003.
+  existingSecret: ""
+  username: stronghold
+  database: stronghold
+  probes:
+    liveness:
+      initialDelaySeconds: 30
+      periodSeconds: 20
+    readiness:
+      initialDelaySeconds: 5
+      periodSeconds: 10
+
+# LiteLLM proxy — model gateway for Stronghold. The large model config
+# is embedded from files/litellm_config.yaml via .Files.Get.
+litellmProxy:
+  replicas: 1
+  image:
+    registry: ghcr.io
+    repository: berriai/litellm
+    tag: "main-v1.81.12-stable"
+    pullPolicy: IfNotPresent
+  containerPort: 4000
+  exposed: false
+  resources:
+    requests:
+      cpu: 250m
+      memory: 512Mi
+    limits:
+      cpu: "1"
+      memory: 2Gi
+  probes:
+    liveness:
+      path: /health/liveliness
+      initialDelaySeconds: 30
+      periodSeconds: 30
+    readiness:
+      path: /health/readiness
+      initialDelaySeconds: 10
+      periodSeconds: 10
+  envSecretName: litellm-secrets
+  createStubSecret: true
+
+# Arize Phoenix — LLM tracing/observability.
+phoenixSvc:
+  replicas: 1
+  image:
+    registry: ""
+    repository: arizephoenix/phoenix
+    tag: "latest"
+    pullPolicy: Always
+  containerPort: 6006
+  exposed: false
+  resources:
+    requests:
+      cpu: 200m
+      memory: 512Mi
+    limits:
+      cpu: "1"
+      memory: 2Gi
+  probes:
+    liveness:
+      path: /healthz
+      initialDelaySeconds: 30
+      periodSeconds: 30
+    readiness:
+      path: /healthz
+      initialDelaySeconds: 10
+      periodSeconds: 10
+
+# MCP servers (live in stronghold-mcp namespace per ADR-K8S-001).
+mcp:
+  github:
+    enabled: true
+    replicas: 1
+    image:
+      registry: ghcr.io
+      repository: modelcontextprotocol/server-github
+      tag: "latest"
+      pullPolicy: Always
+    containerPort: 3000
+    patSecretName: github-pat
+    resources:
+      requests:
+        cpu: 100m
+        memory: 128Mi
+      limits:
+        cpu: 500m
+        memory: 512Mi
+  devTools:
+    enabled: true
+    replicas: 1
+    image:
+      registry: ""
+      repository: agent-stronghold/dev-tools-mcp
+      tag: "0.1.0"
+      pullPolicy: IfNotPresent
+    containerPort: 8300
+    # The raw manifest mounted /stronghold-repo via hostPath (rejected by
+    # baseline rule 6). Replaced with an optional PVC-backed workspace.
+    workspacePvcName: ""
+    resources:
+      requests:
+        cpu: 100m
+        memory: 128Mi
+      limits:
+        cpu: 500m
+        memory: 512Mi
+
+# OpenShift Routes (rendered when openshift.enabled=true).
+route:
+  stronghold:
+    host: stronghold.apps.cluster.example.com
+    tlsTermination: edge
+  litellm:
+    host: litellm.apps.cluster.example.com
+    tlsTermination: edge
+  phoenix:
+    host: phoenix.apps.cluster.example.com
+    tlsTermination: edge
+
+# Vanilla Kubernetes Ingress fallbacks (rendered when
+# openshift.enabled=false AND ingressRoutes.enabled=true). The PR-6
+# top-level `ingress` block is preserved for backward compatibility;
+# ingressRoutes below is the PR-10 per-component fallback.
+ingressRoutes:
+  enabled: false
+  className: nginx
+  stronghold:
+    host: stronghold.example.com
+  litellm:
+    host: litellm.example.com
+  phoenix:
+    host: phoenix.example.com


### PR DESCRIPTION
## Summary

Builds **PR-7 + PR-8 + PR-9 + PR-10** of the v0.9 K8s hardening sequence (parent epic #64) on top of #945 (PR-6 chart skeleton). Adds the actual workload templates.

**Base branch is `feat/k8s-phase2-chart-base`** (PR #945), not `integration` — this PR depends on PR-6's SAs, RBAC, helpers, and PriorityClasses.

**Closes BACKLOG R3** — the cluster-admin kubeconfig is no longer in the main app pod; an mcp-deployer sidecar handles all K8s operations via a Unix-domain socket and namespace-scoped RBAC.

## Object counts

| Overlay | Object count |
|---|---|
| `values-prod-homelab.yaml` (OKD) | **39** = PR-6's 21 + 18 workload (incl. stronghold-api Route) |
| `values-vanilla-k8s.yaml` | **34** = no Routes, no SCC ClusterRole, Ingresses gated off by default |

`helm lint`: clean (only an INFO about missing icon).

## Per-PR breakdown

### PR-7 — Postgres StatefulSet
- `statefulset-postgres.yaml` — `pgvector/pgvector:pg17`, volumeClaimTemplates, `pg_isready` probes, **P1**
- `service-postgres.yaml` — headless ClusterIP
- `configmap-postgres-init.yaml` — `CREATE EXTENSION vector` + `pg_trgm` + `prompts` table
- `secret-postgres-auth.yaml` — stub Secret with lookup-based password persistence
- `extra-namespaces.yaml` — optional creation of `stronghold-mcp` + `stronghold-data`

### PR-8 — Stronghold API + mcp-deployer sidecar (closes R3)
- `deployment-stronghold.yaml` — 2-container pod: main API + mcp-deployer sidecar talking over an emptyDir Unix-domain socket. **No kubeconfig in main container env.** Sidecar SA is namespace-scoped per ADR-K8S-002. **P0** (chat-critical, ADR-K8S-014).
- `service-stronghold.yaml` — ClusterIP
- `configmap-stronghold.yaml` — non-secret config

### PR-9 — LiteLLM + Phoenix + MCP servers
- `deployment-litellm.yaml` — `ghcr.io/berriai/litellm:main-v1.81.12-stable`, **P1**
- `configmap-litellm.yaml` — embeds the verbatim 1501-line litellm config via `.Files.Get`
- `secret-litellm-env.yaml` — stub envFrom Secret
- `service-litellm.yaml` — ClusterIP
- `deployment-phoenix.yaml` — `arizephoenix/phoenix:latest`, **P1**, `PHOENIX_SQL_DATABASE_URL` points at the shared postgres
- `service-phoenix.yaml` — ClusterIP
- `deployment-mcp-github.yaml` — `ghcr.io/modelcontextprotocol/server-github:latest --transport sse`, in `stronghold-mcp`, GitHub PAT via secretKeyRef, **P1**
- `deployment-mcp-dev-tools.yaml` — in `stronghold-mcp`, **P1**. **hostPath removed** (baseline rule 6 forbids); replaced with an optional `workspacePvcName` value or 1Gi emptyDir fallback.
- `service-mcp-github.yaml`, `service-mcp-dev-tools.yaml` — ClusterIP

### PR-10 — Routes (OpenShift) + Ingress (vanilla) gating
- `route-stronghold.yaml` — always-on when `openshift.enabled`
- `route-litellm.yaml`, `route-phoenix.yaml` — gated on per-service `exposed` flags
- `ingress-stronghold.yaml`, `ingress-litellm.yaml`, `ingress-phoenix.yaml` — gated on `(not openshift.enabled) AND ingressRoutes.enabled`

## Honest tradeoffs flagged for review

1. **Postgres lives in the release namespace**, not `stronghold-data` per ADR-K8S-001. PR-6 pinned the postgres SA in the release namespace, so the StatefulSet renders alongside it. **Follow-up PR** should relocate SA + StatefulSet together. Documented inline in `statefulset-postgres.yaml`.

2. **MCP server Deployments in `stronghold-mcp` use the `default` SA** (with `automountServiceAccountToken: false`). PR-6 only created an SA for the mcp-deployer sidecar in the release namespace. **Follow-up PR** should add dedicated per-MCP-server SAs inside `stronghold-mcp`.

3. **Two image tags are GUESSED** because the raw manifests used local kind-only tags (`stronghold:dev` with `imagePullPolicy: Never`):
   - `ghcr.io/agent-stronghold/stronghold:0.1.0` for the main API
   - `ghcr.io/agent-stronghold/mcp-deployer:0.1.0` for the sidecar (no raw manifest exists)
   **Real image tags must be set in `values-prod-homelab.yaml` before merge.**

4. **NodePort → ClusterIP**: raw `stronghold.yaml` and `phoenix.yaml` used NodePort. External access is now via Route (OKD) or Ingress (vanilla). Routes/Ingresses use placeholder hostnames in the chart defaults that must be overridden per environment.

5. **File renames forced by `.gitignore`**:
   - `secret-postgres-credentials.yaml` → `secret-postgres-auth.yaml` (repo `.gitignore` has `*credentials*`)
   - `files/litellm_config.yaml` → `files/litellm-proxy-config.yaml` (repo `.gitignore` has `litellm_config.yaml`)
   In-cluster resource names (Secret name, ConfigMap data key) are unchanged.

## Verification

- `helm lint deploy/helm/stronghold` — clean
- `helm template ... -f values-prod-homelab.yaml` renders 39 objects
- `helm template ... -f values-vanilla-k8s.yaml` renders 34 objects
- Forbidden-string grep: zero matches (`archestra|semantic-router|vllm|LocalAGI|LocalAI|iris-guard|jedai|stronghold-eval`, `co-authored-by`)
- All workload pods have `securityContext: {runAsNonRoot: true, capabilities: {drop: [ALL]}}`
- All workload pods set `priorityClassName` from PR-6's tier set
- All workload pods have liveness + readiness probes sourced from the raw manifests

## Test plan

- [ ] CI passes
- [ ] `helm install` succeeds against a vanilla k8s cluster (k3s on the homelab is the dev target — see #945 for the validation gate)
- [ ] Real image tags set in `values-prod-homelab.yaml` for stronghold + mcp-deployer
- [ ] Smoke test: stronghold-api pod comes up Healthy, can talk to postgres + litellm + phoenix
- [ ] R3 verification: `oc exec` into the main stronghold container, `printenv | grep -i kube` returns nothing

## Out of scope (still pending)

- PR-11: NetworkPolicy decision matrix + manifests
- PR-12: PodDisruptionBudget templates
- Postgres relocation to `stronghold-data` (follow-up)
- Per-MCP-server SAs in `stronghold-mcp` (follow-up)