### PR TITLE
fix(builders): close the Gatekeeper feedback loop (PR-Q10)

### DIFF
--- a/src/stronghold/api/routes/builders.py
+++ b/src/stronghold/api/routes/builders.py
@@ -700,10 +700,15 @@ async def _review_pass(container: Any, owner: str, repo: str) -> None:
     prs = [i for i in items if i.get("is_pr", False)]
     reviewed_set = _scheduler_state["reviewed_prs"]
     completed_set = _scheduler_state["completed_issues"]
+    failed_set = _scheduler_state["failed_issues"]
 
-    # Review at most 2 PRs per loop
+    # Review at most 5 PRs per loop. The previous limit of 2 + the
+    # 5-minute scheduler interval meant 8 review_changes_requested
+    # PRs took at least 20 minutes to cycle through, leaving Mason
+    # idle while the queue piled up. 5 keeps the per-tick budget
+    # bounded but moves through small queues in a single tick.
     pipeline = _build_pipeline(container)
-    review_slots = 2
+    review_slots = 5
     for pr_item in prs:
         if review_slots <= 0:
             break
@@ -759,14 +764,43 @@ async def _review_pass(container: Any, owner: str, repo: str) -> None:
                 if result.evidence.get("merged"):
                     _scheduler_state["stats"]["merged"] += 1
             else:
-                # REQUEST_CHANGES — unblock the parent issue for re-dispatch
+                # REQUEST_CHANGES — unblock the parent issue for re-dispatch.
+                # Three previous bugs lived here:
+                #
+                #   1. The discard was gated on `parent_issue in completed_set`.
+                #      In-process scheduler state is lost on every container
+                #      restart, so completed_set is frequently empty even when
+                #      the parent had previously completed → the discard was
+                #      a no-op and the issue stayed permanently un-rotated.
+                #
+                #   2. The discard only touched completed_set. If the parent
+                #      had landed in failed_set on an earlier outer-loop
+                #      retry, it stayed there forever — the rank function
+                #      skips failed_set members.
+                #
+                #   3. There was no fast-path to push the issue back into
+                #      rotation. The fix relies on the next scheduler tick
+                #      re-ranking; combined with bugs #1 and #2 above, the
+                #      loop simply never closed.
+                #
+                # The fix: always discard the parent from BOTH sets if a
+                # parent number was extracted, regardless of its prior
+                # presence. The next scheduler tick will then rank the
+                # issue normally and dispatch it. Mason's _fetch_prior_runs
+                # picks up the Gatekeeper Verdict comment via PR-Q10's
+                # regex broadening so the next analysis sees the rejection
+                # as prior history.
                 _scheduler_state["stats"]["review_changes_requested"] += 1
-                if parent_issue and parent_issue in completed_set:
+                if parent_issue:
+                    was_completed = parent_issue in completed_set
+                    was_failed = parent_issue in failed_set
                     completed_set.discard(parent_issue)
+                    failed_set.discard(parent_issue)
                     logger.info(
                         "Gatekeeper requested changes on PR #%d — "
-                        "re-opening issue #%d for scheduler",
-                        pr_number, parent_issue,
+                        "re-opening issue #%d for scheduler "
+                        "(was_completed=%s was_failed=%s)",
+                        pr_number, parent_issue, was_completed, was_failed,
                     )
 
             review_slots -= 1

--- a/src/stronghold/builders/pipeline.py
+++ b/src/stronghold/builders/pipeline.py
@@ -8,6 +8,7 @@ The LLM never sees tool definitions.
 from __future__ import annotations
 
 import logging
+import re
 from dataclasses import dataclass, field
 from typing import Any
 
@@ -21,6 +22,27 @@ from stronghold.builders.extractors import (
 logger = logging.getLogger("stronghold.builders.pipeline")
 
 MAX_LLM_RETRIES = 3
+
+
+# ── Prior-run signal patterns (module-level so tests can import the
+#    source of truth instead of re-declaring local copies) ──────────
+
+# `## Builders Run \`(run|sched)-<hex>\`` — header comment that Mason
+# posts at the start of every run. The id prefix is `run-` for manual
+# /runs flow and `sched-` for scheduler-dispatched flow. Both must
+# match so _fetch_prior_runs sees scheduler-dispatched history.
+BUILDERS_RUN_PATTERN = re.compile(
+    r"##\s*Builders Run\s*`?((?:run|sched)-[a-f0-9]+)`?"
+)
+
+# `## Gatekeeper Verdict on PR #N` — comment that review_pr posts to
+# the parent issue when Gatekeeper approves or requests changes on a
+# Mason PR. _fetch_prior_runs picks these up so Mason can learn from
+# rejections on the next outer-loop attempt.
+GATEKEEPER_VERDICT_PATTERN = re.compile(
+    r"##\s*Gatekeeper Verdict on PR\s*#(\d+)",
+    re.IGNORECASE,
+)
 
 
 # ── Issue type registry for context-aware onboarding ─────────────────
@@ -518,7 +540,6 @@ class RuntimePipeline:
         Excludes the current run if exclude_run_id is set.
         """
         import json as _json
-        import re as _re
 
         result = await self._td.execute(
             "github",
@@ -540,22 +561,15 @@ class RuntimePipeline:
             return []
 
         prior_runs: list[dict[str, str]] = []
-        # Accept both manual `run-` and scheduler `sched-` ID prefixes.
-        run_id_pattern = _re.compile(
-            r"##\s*Builders Run\s*`?((?:run|sched)-[a-f0-9]+)`?"
-        )
-        # Gatekeeper verdicts use a different shape and don't carry a
-        # run id — synthesize a stable id from the PR number so Mason
-        # can deduplicate verdicts when re-running.
-        gatekeeper_pattern = _re.compile(
-            r"##\s*Gatekeeper Verdict on PR\s*#(\d+)",
-            _re.IGNORECASE,
-        )
 
         for comment in comments:
-            body = comment.get("body", "") if isinstance(comment, dict) else ""
+            if not isinstance(comment, dict):
+                continue
+            body = comment.get("body", "") or ""
 
-            run_match = run_id_pattern.search(body)
+            # Builders Run header — accepts both manual and scheduler
+            # ID prefixes (see BUILDERS_RUN_PATTERN module docstring).
+            run_match = BUILDERS_RUN_PATTERN.search(body)
             if run_match:
                 run_id = run_match.group(1)
                 if run_id == exclude_run_id:
@@ -563,12 +577,17 @@ class RuntimePipeline:
                 prior_runs.append({"run_id": run_id, "summary": body})
                 continue
 
-            gk_match = gatekeeper_pattern.search(body)
+            # Gatekeeper verdict — synthesize a stable id from the PR
+            # number AND the GitHub comment id so multiple verdicts on
+            # the same PR (e.g., three reject cycles) each get a unique
+            # entry in prior_runs instead of colliding on the same id.
+            gk_match = GATEKEEPER_VERDICT_PATTERN.search(body)
             if gk_match:
                 pr_number = gk_match.group(1)
+                comment_id = comment.get("id", "x")
                 prior_runs.append(
                     {
-                        "run_id": f"gatekeeper-pr{pr_number}",
+                        "run_id": f"gatekeeper-pr{pr_number}-{comment_id}",
                         "summary": body,
                     }
                 )

--- a/src/stronghold/builders/pipeline.py
+++ b/src/stronghold/builders/pipeline.py
@@ -495,10 +495,26 @@ class RuntimePipeline:
         *,
         exclude_run_id: str = "",
     ) -> list[dict[str, str]]:
-        """Fetch prior Builders Run comments from the issue.
+        """Fetch prior Builders Run + Gatekeeper Verdict comments.
 
-        Returns list of dicts with run_id and summary for each prior run.
-        Filters to only comments starting with '## Builders Run'.
+        Returns a list of dicts with `run_id` and `summary` for each prior
+        signal Mason should learn from when re-running this issue:
+
+        1. Prior `## Builders Run` comments — ID can be either
+           `run-<hex>` (manual /runs flow) or `sched-<hex>` (scheduler-
+           dispatched flow). The previous version of this regex only
+           matched `run-`, so scheduler-dispatched runs were silently
+           invisible to Frank's prior-history lookup and the
+           "learn from prior failures" feedback loop never closed for
+           anything the scheduler picked up.
+
+        2. Prior `## Gatekeeper Verdict on PR #N` comments — these
+           carry the changes-requested feedback Mason needs to see on
+           the next outer loop. Without this, Mason would re-run the
+           same issue, produce the same broken PR, and Gatekeeper would
+           reject again forever. With this, Mason's analysis sees the
+           verdict in its prior-history block and can adjust.
+
         Excludes the current run if exclude_run_id is set.
         """
         import json as _json
@@ -523,17 +539,39 @@ class RuntimePipeline:
         if not isinstance(comments, list):
             return []
 
-        prior_runs = []
-        run_id_pattern = _re.compile(r"##\s*Builders Run\s*`?(run-[a-f0-9]+)`?")
+        prior_runs: list[dict[str, str]] = []
+        # Accept both manual `run-` and scheduler `sched-` ID prefixes.
+        run_id_pattern = _re.compile(
+            r"##\s*Builders Run\s*`?((?:run|sched)-[a-f0-9]+)`?"
+        )
+        # Gatekeeper verdicts use a different shape and don't carry a
+        # run id — synthesize a stable id from the PR number so Mason
+        # can deduplicate verdicts when re-running.
+        gatekeeper_pattern = _re.compile(
+            r"##\s*Gatekeeper Verdict on PR\s*#(\d+)",
+            _re.IGNORECASE,
+        )
+
         for comment in comments:
             body = comment.get("body", "") if isinstance(comment, dict) else ""
-            match = run_id_pattern.search(body)
-            if not match:
+
+            run_match = run_id_pattern.search(body)
+            if run_match:
+                run_id = run_match.group(1)
+                if run_id == exclude_run_id:
+                    continue
+                prior_runs.append({"run_id": run_id, "summary": body})
                 continue
-            run_id = match.group(1)
-            if run_id == exclude_run_id:
-                continue
-            prior_runs.append({"run_id": run_id, "summary": body})
+
+            gk_match = gatekeeper_pattern.search(body)
+            if gk_match:
+                pr_number = gk_match.group(1)
+                prior_runs.append(
+                    {
+                        "run_id": f"gatekeeper-pr{pr_number}",
+                        "summary": body,
+                    }
+                )
 
         return prior_runs
 

--- a/tests/builders/core/test_fetch_prior_runs_signals.py
+++ b/tests/builders/core/test_fetch_prior_runs_signals.py
@@ -1,30 +1,16 @@
 """Unit-level coverage for the regex shape used by _fetch_prior_runs.
 
 The full method is async and reads from a tool dispatcher; testing it
-end-to-end would require fakes for the GitHub tool. The regexes
-themselves are pure and capture the contract that PR-Q10 broadens:
-
-  - prior 'Builders Run' comments accept BOTH `run-<hex>` (manual flow)
-    and `sched-<hex>` (scheduler flow) ID prefixes
-  - prior 'Gatekeeper Verdict on PR #N' comments are picked up
-
-These tests pin both shapes against the live regex literals from
-pipeline.py so any future change to the regex without a corresponding
-test update will fail loudly.
+end-to-end would require fakes for the GitHub tool. The regex
+constants themselves are pure and module-level, so we import them
+directly from pipeline.py — any future change to either pattern
+without an accompanying test update will fail loudly.
 """
 from __future__ import annotations
 
-import re
-
-# Mirror the patterns from pipeline.py — keep these in sync if the
-# source changes. The duplication is intentional: we want a
-# breaking-test-on-divergence to surface naturally.
-RUN_ID_PATTERN = re.compile(
-    r"##\s*Builders Run\s*`?((?:run|sched)-[a-f0-9]+)`?"
-)
-GATEKEEPER_PATTERN = re.compile(
-    r"##\s*Gatekeeper Verdict on PR\s*#(\d+)",
-    re.IGNORECASE,
+from stronghold.builders.pipeline import (
+    BUILDERS_RUN_PATTERN,
+    GATEKEEPER_VERDICT_PATTERN,
 )
 
 
@@ -33,34 +19,34 @@ GATEKEEPER_PATTERN = re.compile(
 
 def test_run_id_pattern_matches_manual_run_prefix() -> None:
     body = "## Builders Run `run-f23c8f66`\n\nIssue analysis follows."
-    match = RUN_ID_PATTERN.search(body)
+    match = BUILDERS_RUN_PATTERN.search(body)
     assert match is not None
     assert match.group(1) == "run-f23c8f66"
 
 
 def test_run_id_pattern_matches_scheduler_sched_prefix() -> None:
     body = "## Builders Run `sched-bac9832f`\n\nFrank executing acceptance_defined."
-    match = RUN_ID_PATTERN.search(body)
+    match = BUILDERS_RUN_PATTERN.search(body)
     assert match is not None
     assert match.group(1) == "sched-bac9832f"
 
 
 def test_run_id_pattern_matches_unbacktick_form() -> None:
     body = "## Builders Run sched-abc1234\n"
-    match = RUN_ID_PATTERN.search(body)
+    match = BUILDERS_RUN_PATTERN.search(body)
     assert match is not None
     assert match.group(1) == "sched-abc1234"
 
 
 def test_run_id_pattern_rejects_unrelated_prefixes() -> None:
     body = "## Builders Run `manual-12345`\n"
-    match = RUN_ID_PATTERN.search(body)
+    match = BUILDERS_RUN_PATTERN.search(body)
     assert match is None
 
 
 def test_run_id_pattern_rejects_non_builders_comments() -> None:
     body = "## Auditor Review: `tests_written` (attempt 1)\n\nVerdict: APPROVED"
-    match = RUN_ID_PATTERN.search(body)
+    match = BUILDERS_RUN_PATTERN.search(body)
     assert match is None
 
 
@@ -69,34 +55,34 @@ def test_run_id_pattern_rejects_non_builders_comments() -> None:
 
 def test_gatekeeper_pattern_matches_basic_verdict() -> None:
     body = "## Gatekeeper Verdict on PR #943\n\n**Decision:** REQUEST_CHANGES"
-    match = GATEKEEPER_PATTERN.search(body)
+    match = GATEKEEPER_VERDICT_PATTERN.search(body)
     assert match is not None
     assert match.group(1) == "943"
 
 
 def test_gatekeeper_pattern_matches_no_space_before_hash() -> None:
     body = "## Gatekeeper Verdict on PR#56\n"
-    match = GATEKEEPER_PATTERN.search(body)
+    match = GATEKEEPER_VERDICT_PATTERN.search(body)
     assert match is not None
     assert match.group(1) == "56"
 
 
 def test_gatekeeper_pattern_is_case_insensitive() -> None:
     body = "## gatekeeper verdict on pr #999\n"
-    match = GATEKEEPER_PATTERN.search(body)
+    match = GATEKEEPER_VERDICT_PATTERN.search(body)
     assert match is not None
     assert match.group(1) == "999"
 
 
 def test_gatekeeper_pattern_rejects_non_verdict_mentions() -> None:
     body = "We discussed the Gatekeeper verdict for PR 42 earlier."
-    match = GATEKEEPER_PATTERN.search(body)
+    match = GATEKEEPER_VERDICT_PATTERN.search(body)
     assert match is None
 
 
 def test_gatekeeper_pattern_rejects_auditor_reviews() -> None:
     body = "## Auditor Review: `acceptance_defined` (attempt 1)\n"
-    match = GATEKEEPER_PATTERN.search(body)
+    match = GATEKEEPER_VERDICT_PATTERN.search(body)
     assert match is None
 
 
@@ -110,8 +96,178 @@ def test_run_and_gatekeeper_patterns_are_disjoint() -> None:
     builders_body = "## Builders Run `sched-deadbeef`\n"
     gatekeeper_body = "## Gatekeeper Verdict on PR #100\n"
 
-    assert RUN_ID_PATTERN.search(builders_body) is not None
-    assert GATEKEEPER_PATTERN.search(builders_body) is None
+    assert BUILDERS_RUN_PATTERN.search(builders_body) is not None
+    assert GATEKEEPER_VERDICT_PATTERN.search(builders_body) is None
 
-    assert RUN_ID_PATTERN.search(gatekeeper_body) is None
-    assert GATEKEEPER_PATTERN.search(gatekeeper_body) is not None
+    assert BUILDERS_RUN_PATTERN.search(gatekeeper_body) is None
+    assert GATEKEEPER_VERDICT_PATTERN.search(gatekeeper_body) is not None
+
+
+# ── End-to-end coverage of _fetch_prior_runs with a fake dispatcher ─
+#
+# These tests exercise the actual method (not just the regex) so
+# changes to the iteration / filtering logic are caught too. The
+# fake dispatcher only needs to implement execute(name, args).
+
+
+import json
+import pytest
+
+from stronghold.builders.pipeline import RuntimePipeline
+
+
+class _FakeDispatcher:
+    """Minimal tool dispatcher that returns canned JSON for github
+    list_issue_comments calls and asserts it isn't called for anything
+    else (the test should be fully insulated from real I/O)."""
+
+    def __init__(self, comments: list[dict]) -> None:
+        self._comments = comments
+        self.call_count = 0
+
+    async def execute(self, name: str, args: dict) -> str:
+        self.call_count += 1
+        assert name == "github", f"unexpected tool: {name}"
+        assert args.get("action") == "list_issue_comments"
+        return json.dumps(self._comments)
+
+
+def _make_pipeline(comments: list[dict]) -> RuntimePipeline:
+    return RuntimePipeline(llm=None, tool_dispatcher=_FakeDispatcher(comments))
+
+
+@pytest.mark.asyncio
+async def test_fetch_prior_runs_picks_up_scheduler_dispatched_runs() -> None:
+    """Regression test for the original bug: scheduler-dispatched
+    runs use `sched-` IDs but the old regex only matched `run-`."""
+    pipeline = _make_pipeline(
+        [
+            {"id": 1, "body": "## Builders Run `sched-bac9832f`\n\nFrank started."},
+            {"id": 2, "body": "## Auditor Review: `issue_analyzed` (attempt 1)"},
+        ]
+    )
+    runs = await pipeline._fetch_prior_runs("org", "repo", 42)
+    assert len(runs) == 1
+    assert runs[0]["run_id"] == "sched-bac9832f"
+
+
+@pytest.mark.asyncio
+async def test_fetch_prior_runs_picks_up_gatekeeper_verdicts() -> None:
+    """Regression test for the second half of the bug: Gatekeeper
+    verdicts were never picked up so Mason couldn't see rejections."""
+    pipeline = _make_pipeline(
+        [
+            {"id": 100, "body": "## Gatekeeper Verdict on PR #943\n\n**Decision:** REQUEST_CHANGES\n\nMissing tests."},
+        ]
+    )
+    runs = await pipeline._fetch_prior_runs("org", "repo", 42)
+    assert len(runs) == 1
+    assert runs[0]["run_id"] == "gatekeeper-pr943-100"
+    assert "REQUEST_CHANGES" in runs[0]["summary"]
+
+
+@pytest.mark.asyncio
+async def test_fetch_prior_runs_multiple_gatekeeper_verdicts_unique_ids() -> None:
+    """Multiple Gatekeeper rejections on the same PR each get a
+    unique synthesized id (was a collision before the comment-id
+    suffix was added). All three verdicts should appear in the
+    prior_runs list independently so Frank's prompt sees all of
+    them."""
+    pipeline = _make_pipeline(
+        [
+            {"id": 100, "body": "## Gatekeeper Verdict on PR #943\n\nFirst reject."},
+            {"id": 200, "body": "## Gatekeeper Verdict on PR #943\n\nSecond reject."},
+            {"id": 300, "body": "## Gatekeeper Verdict on PR #943\n\nThird reject."},
+        ]
+    )
+    runs = await pipeline._fetch_prior_runs("org", "repo", 42)
+    assert len(runs) == 3
+    ids = [r["run_id"] for r in runs]
+    assert ids == [
+        "gatekeeper-pr943-100",
+        "gatekeeper-pr943-200",
+        "gatekeeper-pr943-300",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_fetch_prior_runs_mixes_runs_and_verdicts() -> None:
+    """A real conversation has interleaved Builders Run and Gatekeeper
+    Verdict comments. _fetch_prior_runs should return all of them in
+    document order."""
+    pipeline = _make_pipeline(
+        [
+            {"id": 1, "body": "## Builders Run `sched-aaaa1111`\n"},
+            {"id": 2, "body": "## Gatekeeper Verdict on PR #100\n\nRequest changes."},
+            {"id": 3, "body": "## Builders Run `run-bbbb2222`\n"},
+            {"id": 4, "body": "Just a chat comment from a user."},
+        ]
+    )
+    runs = await pipeline._fetch_prior_runs("org", "repo", 42)
+    ids = [r["run_id"] for r in runs]
+    assert ids == [
+        "sched-aaaa1111",
+        "gatekeeper-pr100-2",
+        "run-bbbb2222",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_fetch_prior_runs_excludes_current_run_id() -> None:
+    """exclude_run_id prevents Mason from seeing its own current run
+    in the prior history. Applies only to Builders Run ids — gatekeeper
+    ids are never excluded since the current run can't have one."""
+    pipeline = _make_pipeline(
+        [
+            {"id": 1, "body": "## Builders Run `sched-aaaa1111`\n"},
+            {"id": 2, "body": "## Builders Run `sched-bbbb2222`\n"},
+        ]
+    )
+    runs = await pipeline._fetch_prior_runs(
+        "org", "repo", 42, exclude_run_id="sched-aaaa1111",
+    )
+    assert len(runs) == 1
+    assert runs[0]["run_id"] == "sched-bbbb2222"
+
+
+@pytest.mark.asyncio
+async def test_fetch_prior_runs_returns_empty_on_tool_error() -> None:
+    """When the github tool returns an Error: prefix, the function
+    returns an empty list rather than raising."""
+
+    class _ErrorDispatcher:
+        async def execute(self, name: str, args: dict) -> str:
+            return "Error: GitHub API rate limit exceeded"
+
+    pipeline = RuntimePipeline(llm=None, tool_dispatcher=_ErrorDispatcher())
+    runs = await pipeline._fetch_prior_runs("org", "repo", 42)
+    assert runs == []
+
+
+@pytest.mark.asyncio
+async def test_fetch_prior_runs_returns_empty_on_malformed_json() -> None:
+    """Malformed JSON from the tool returns an empty list rather
+    than raising."""
+
+    class _BadJsonDispatcher:
+        async def execute(self, name: str, args: dict) -> str:
+            return "this is not json"
+
+    pipeline = RuntimePipeline(llm=None, tool_dispatcher=_BadJsonDispatcher())
+    runs = await pipeline._fetch_prior_runs("org", "repo", 42)
+    assert runs == []
+
+
+@pytest.mark.asyncio
+async def test_fetch_prior_runs_skips_non_dict_comments() -> None:
+    """Defensive: a malformed entry in the comments list (e.g., a
+    string instead of a dict) is silently skipped."""
+    pipeline = _make_pipeline(
+        [
+            "this should not be here",  # type: ignore[list-item]
+            {"id": 1, "body": "## Builders Run `sched-cccc3333`\n"},
+        ]
+    )
+    runs = await pipeline._fetch_prior_runs("org", "repo", 42)
+    assert len(runs) == 1
+    assert runs[0]["run_id"] == "sched-cccc3333"

--- a/tests/builders/core/test_fetch_prior_runs_signals.py
+++ b/tests/builders/core/test_fetch_prior_runs_signals.py
@@ -1,0 +1,117 @@
+"""Unit-level coverage for the regex shape used by _fetch_prior_runs.
+
+The full method is async and reads from a tool dispatcher; testing it
+end-to-end would require fakes for the GitHub tool. The regexes
+themselves are pure and capture the contract that PR-Q10 broadens:
+
+  - prior 'Builders Run' comments accept BOTH `run-<hex>` (manual flow)
+    and `sched-<hex>` (scheduler flow) ID prefixes
+  - prior 'Gatekeeper Verdict on PR #N' comments are picked up
+
+These tests pin both shapes against the live regex literals from
+pipeline.py so any future change to the regex without a corresponding
+test update will fail loudly.
+"""
+from __future__ import annotations
+
+import re
+
+# Mirror the patterns from pipeline.py — keep these in sync if the
+# source changes. The duplication is intentional: we want a
+# breaking-test-on-divergence to surface naturally.
+RUN_ID_PATTERN = re.compile(
+    r"##\s*Builders Run\s*`?((?:run|sched)-[a-f0-9]+)`?"
+)
+GATEKEEPER_PATTERN = re.compile(
+    r"##\s*Gatekeeper Verdict on PR\s*#(\d+)",
+    re.IGNORECASE,
+)
+
+
+# ── Builders Run regex ──────────────────────────────────────────────
+
+
+def test_run_id_pattern_matches_manual_run_prefix() -> None:
+    body = "## Builders Run `run-f23c8f66`\n\nIssue analysis follows."
+    match = RUN_ID_PATTERN.search(body)
+    assert match is not None
+    assert match.group(1) == "run-f23c8f66"
+
+
+def test_run_id_pattern_matches_scheduler_sched_prefix() -> None:
+    body = "## Builders Run `sched-bac9832f`\n\nFrank executing acceptance_defined."
+    match = RUN_ID_PATTERN.search(body)
+    assert match is not None
+    assert match.group(1) == "sched-bac9832f"
+
+
+def test_run_id_pattern_matches_unbacktick_form() -> None:
+    body = "## Builders Run sched-abc1234\n"
+    match = RUN_ID_PATTERN.search(body)
+    assert match is not None
+    assert match.group(1) == "sched-abc1234"
+
+
+def test_run_id_pattern_rejects_unrelated_prefixes() -> None:
+    body = "## Builders Run `manual-12345`\n"
+    match = RUN_ID_PATTERN.search(body)
+    assert match is None
+
+
+def test_run_id_pattern_rejects_non_builders_comments() -> None:
+    body = "## Auditor Review: `tests_written` (attempt 1)\n\nVerdict: APPROVED"
+    match = RUN_ID_PATTERN.search(body)
+    assert match is None
+
+
+# ── Gatekeeper Verdict regex ────────────────────────────────────────
+
+
+def test_gatekeeper_pattern_matches_basic_verdict() -> None:
+    body = "## Gatekeeper Verdict on PR #943\n\n**Decision:** REQUEST_CHANGES"
+    match = GATEKEEPER_PATTERN.search(body)
+    assert match is not None
+    assert match.group(1) == "943"
+
+
+def test_gatekeeper_pattern_matches_no_space_before_hash() -> None:
+    body = "## Gatekeeper Verdict on PR#56\n"
+    match = GATEKEEPER_PATTERN.search(body)
+    assert match is not None
+    assert match.group(1) == "56"
+
+
+def test_gatekeeper_pattern_is_case_insensitive() -> None:
+    body = "## gatekeeper verdict on pr #999\n"
+    match = GATEKEEPER_PATTERN.search(body)
+    assert match is not None
+    assert match.group(1) == "999"
+
+
+def test_gatekeeper_pattern_rejects_non_verdict_mentions() -> None:
+    body = "We discussed the Gatekeeper verdict for PR 42 earlier."
+    match = GATEKEEPER_PATTERN.search(body)
+    assert match is None
+
+
+def test_gatekeeper_pattern_rejects_auditor_reviews() -> None:
+    body = "## Auditor Review: `acceptance_defined` (attempt 1)\n"
+    match = GATEKEEPER_PATTERN.search(body)
+    assert match is None
+
+
+# ── Disjoint patterns: same body never matches both ─────────────────
+
+
+def test_run_and_gatekeeper_patterns_are_disjoint() -> None:
+    """A single comment body should not match both patterns —
+    _fetch_prior_runs uses an else-branch and we want to make sure
+    the categorization is unambiguous."""
+    builders_body = "## Builders Run `sched-deadbeef`\n"
+    gatekeeper_body = "## Gatekeeper Verdict on PR #100\n"
+
+    assert RUN_ID_PATTERN.search(builders_body) is not None
+    assert GATEKEEPER_PATTERN.search(builders_body) is None
+
+    assert RUN_ID_PATTERN.search(gatekeeper_body) is None
+    assert GATEKEEPER_PATTERN.search(gatekeeper_body) is not None


### PR DESCRIPTION
## Summary
Three bugs in the same loop kept Gatekeeper's REQUEST_CHANGES verdicts from ever feeding back to Mason. Once a PR was kicked back, the parent issue was permanently stuck in the scheduler's "skip me" sets and Mason had no way to see the rejection on its next attempt. This PR fixes all three.

## The bugs

### Bug 8a — `_review_pass` discards too narrowly

The unblock-on-REQUEST_CHANGES branch in `builders.py:_review_pass` (line 764) gated the discard on `parent_issue in completed_set`. The in-process scheduler state is lost on every container restart, so `completed_set` is frequently empty even when the parent had previously completed — the discard was a no-op and the issue stayed permanently un-rotated.

Compounding it: `failed_set` was never touched, so a parent that landed in `failed_set` on an earlier outer-loop retry stayed there forever.

**Fix**: always discard the parent from BOTH `completed_set` and `failed_set` when Gatekeeper requests changes, regardless of which set (or neither) it was previously in.

### Bug 8b — `_fetch_prior_runs` regex misses scheduler IDs

`pipeline.py:_fetch_prior_runs` filtered for `## Builders Run \`run-<hex>\`` comments. But scheduler-dispatched runs use the prefix `sched-<hex>`, not `run-`. **100% of scheduler-dispatched runs were silently invisible to Frank's prior-history lookup** — the "learn from prior failures" feedback block was always empty when re-running an issue the scheduler picked up.

**Fix**: broaden the regex to accept both `run-` and `sched-` prefixes.

### Bug 8c — `_fetch_prior_runs` ignores Gatekeeper Verdict comments

Even with bug 8b fixed, Mason wouldn't see Gatekeeper's feedback — those comments use a `## Gatekeeper Verdict on PR #N` shape that the prior-runs filter didn't match. The verdict comment IS posted to the parent issue by `review_pr()`, but `_fetch_prior_runs` never returned it as a prior signal.

**Fix**: add a second regex that picks up Gatekeeper verdict comments and synthesizes a stable run id `gatekeeper-pr<N>` so Mason can deduplicate verdicts. Both patterns feed into the same `prior_runs` list that Frank's `analyze_issue` prompt injects into the feedback block.

## Bonus: review_slots bumped 2 → 5

With `review_slots=2` and a 5-minute scheduler interval, 8 review_changes_requested PRs took at least 20 minutes to cycle through, leaving Mason idle. 5 keeps the per-tick budget bounded but moves through small queues in a single tick.

## Test plan

- [x] 11 new unit tests in `tests/builders/core/test_fetch_prior_runs_signals.py` pin both regex shapes against future drift, all pass locally
- [x] Python syntax checks clean on `pipeline.py` and `builders.py`
- [ ] After container rebuild: dispatch one of the 8 currently-stuck `review_changes_requested` PRs and verify the parent issue gets re-dispatched on the next tick
- [ ] Verify Mason's next analyze_issue on a re-dispatched issue includes "Prior Run History" containing the Gatekeeper verdict

## Out of scope

- **Bug 7** (Mason rewrites entire shared files instead of editing surgically) — separate PR
- **The structural risk of in-process scheduler state being lost on every container restart** — needs a small persistence layer for `completed_issues` / `failed_issues`. Q10 mitigates the symptom (the failed-set growth), not the root cause.