### PR TITLE
fix: repair 4 broken tests that block every Mason PR

### DIFF
--- a/src/stronghold/dashboard/index.html
+++ b/src/stronghold/dashboard/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" class="scroll-smooth">
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/src/stronghold/dashboard/index.html
+++ b/src/stronghold/dashboard/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en" class="scroll-smooth">
+<html lang="en">
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -54,7 +54,7 @@
   .badge-blocked { background: rgba(139,37,0,0.2); color: #ff6b6b; border: 1px solid var(--blood); }
 
   /* Stats */
-  .stat-value { font-size: 2rem; font-weight: 700; font-family: 'Playfly Display', serif; }
+  .stat-value { font-size: 2rem; font-weight: 700; font-family: 'Playfair Display', serif; }
   .stat-label { font-size: 0.75rem; color: var(--iron-light); text-transform: uppercase; letter-spacing: 1px; }
 
   /* Chat area */
@@ -157,3 +157,593 @@
     <a href="/dashboard/security" class="sidebar-item">
       <span class="sidebar-icon">&#x1F5FC;</span> Watchtower
     </a>
+    <a href="/dashboard/outcomes" class="sidebar-item">
+      <span class="sidebar-icon">&#x1F4B0;</span> Treasury
+    </a>
+    <a href="/dashboard/quota" class="sidebar-item">
+      <span class="sidebar-icon">&#x2696;</span> Ledger
+    </a>
+    <a href="/prompts" class="sidebar-item">
+      <span class="sidebar-icon">&#x1F4DC;</span> Scrolls
+    </a>
+  </div>
+  <div class="py-2 border-t border-[var(--iron)]">
+    <div class="px-5 py-2 text-xs text-[var(--iron-light)] uppercase tracking-wider">Admin</div>
+    <a href="/dashboard/mason" class="sidebar-item"><span style="width:24px;text-align:center">&#x1F9F1;</span> Workshop</a>
+  </div>
+  <div class="py-2 border-t border-[var(--iron)]">
+    <a href="/dashboard/profile" class="sidebar-item"><span style="width:24px;text-align:center">&#x1F464;</span> Profile</a>
+  </div>
+
+  <!-- Mission History -->
+  <div class="border-t border-[var(--iron)] flex-1 overflow-hidden flex flex-col">
+    <div class="p-3 text-xs font-bold text-[var(--gold-dim)] uppercase tracking-wider">Previous Missions</div>
+    <div id="mission-history" class="flex-1 overflow-y-auto px-2 pb-2 space-y-1" style="max-height: 200px;"></div>
+  </div>
+
+  <div class="p-4 border-t border-[var(--iron)] text-xs text-[var(--iron-light)]">
+    <div class="flex justify-between items-center">
+      <span>v0.1.0</span>
+      <a href="/logout" onclick="strongholdLogout();return false" style="color:var(--iron-light);text-decoration:none;transition:color 0.2s" class="sh-logout">Logout</a>
+    </div>
+    <div id="health-status">Checking...</div>
+  </div>
+</nav>
+
+<!-- Main Content — The Great Hall -->
+<main class="flex-1 overflow-auto">
+  <!-- Header -->
+  <header class="px-8 py-6 border-b border-[var(--iron)]">
+    <div class="flex items-center gap-3">
+      <button class="mobile-menu-btn" onclick="openSidebar()">&#x2630;</button>
+      <div>
+        <h2 class="text-2xl">The Great Hall</h2>
+        <p class="text-sm text-[var(--iron-light)] mt-1 hidden sm:block">Command center for your agent fortress</p>
+      </div>
+    </div>
+  </header>
+
+  <!-- Stats Row -->
+  <div class="grid grid-cols-2 md:grid-cols-4 gap-3 md:gap-4 px-8 py-6">
+    <div class="card card-body text-center">
+      <div class="stat-value text-[var(--gold)]" id="stat-agents">—</div>
+      <div class="stat-label">Active Knights</div>
+    </div>
+    <div class="card card-body text-center">
+      <div class="stat-value text-[var(--emerald)]" id="stat-health">—</div>
+      <div class="stat-label">Fortress Health</div>
+    </div>
+    <div class="card card-body text-center">
+      <div class="stat-value text-[#60a5fa]" id="stat-models">—</div>
+      <div class="stat-label">Available Models</div>
+    </div>
+    <div class="card card-body text-center">
+      <div class="stat-value text-[var(--blood)]" id="stat-blocked">0</div>
+      <div class="stat-label">Threats Blocked</div>
+    </div>
+  </div>
+
+  <!-- War Room (Chat) -->
+  <div class="px-8 pb-8">
+    <div class="card">
+      <div class="card-header flex items-center justify-between">
+        <h3 class="text-lg">&#x2694; War Room</h3>
+        <span class="badge badge-agent" id="form-toggle" style="cursor:pointer" onclick="toggleForm()">Configure Mission</span>
+      </div>
+
+      <!-- Mission Config Form -->
+      <div id="mission-form" class="card-body form-expanded border-b border-[var(--iron)]">
+        <div class="form-fields">
+          <div class="grid grid-cols-1 sm:grid-cols-3 gap-3 sm:gap-4 mb-4">
+            <div>
+              <label class="text-xs text-[var(--iron-light)] mb-1 block">Mode</label>
+              <select id="mode" class="w-full text-sm">
+                <option value="persistent">Persistent (asks before acting)</option>
+                <option value="quick">Quick (best effort)</option>
+                <option value="supervised">Supervised (human-in-loop)</option>
+              </select>
+            </div>
+            <div>
+              <label class="text-xs text-[var(--iron-light)] mb-1 block">Intent</label>
+              <select id="intent" class="w-full text-sm">
+                <option value="">Auto-detect</option>
+                <option value="code">Code</option>
+                <option value="search">Search</option>
+                <option value="creative">Creative</option>
+                <option value="automation">Automation</option>
+                <option value="reasoning">Reasoning</option>
+              </select>
+            </div>
+            <div>
+              <label class="text-xs text-[var(--iron-light)] mb-1 block">Repo/Context</label>
+              <input type="text" id="repo" class="w-full text-sm" placeholder="Optional workspace path">
+            </div>
+          </div>
+          <div class="mb-4">
+            <label class="text-xs text-[var(--iron-light)] mb-1 block">Mission Objective</label>
+            <textarea id="goal" class="w-full text-sm" rows="3" placeholder="What needs to be accomplished?"></textarea>
+          </div>
+          <div class="flex gap-2">
+            <button class="btn-gold text-sm" onclick="submitMission()">&#x2694; Deploy</button>
+            <button class="btn-iron text-sm" onclick="toggleForm()">Collapse</button>
+          </div>
+        </div>
+        <div class="form-summary p-2" onclick="toggleForm()" style="cursor:pointer">
+          <span class="text-[var(--gold)]">&#x25B6;</span> Click to configure a new mission
+        </div>
+      </div>
+
+      <!-- Conversation -->
+      <div id="conversation" class="card-body space-y-4 max-h-[500px] overflow-y-auto" style="min-height: 100px;">
+        <div class="text-center text-sm text-[var(--iron-light)] py-8">
+          <div class="crest mb-2" style="font-size:3rem">&#x1F3F0;</div>
+          <p>The fortress awaits your command.</p>
+          <p class="text-xs mt-1">Configure a mission above, or type below.</p>
+        </div>
+      </div>
+
+      <!-- Quick Input -->
+      <div class="card-body border-t border-[var(--iron)] flex gap-2">
+        <input type="text" id="followup" class="chat-input flex-1 text-sm px-4 py-3 rounded-lg" placeholder="Send a follow-up command..." onkeydown="if(event.key==='Enter')sendFollowup()">
+        <button class="btn-gold text-sm px-6" onclick="sendFollowup()">Send</button>
+        <button class="btn-iron text-sm px-4" onclick="startNewMission()" title="Start a new mission (new session)">&#x2694; New</button>
+      </div>
+    </div>
+  </div>
+</main>
+
+<script>
+const API = '';
+let sessionId = 'sh-' + crypto.randomUUID().split('-')[0];
+let chatHistory = [];
+
+// User identity badge is handled globally by auth.js
+
+async function fetchStats() {
+  try {
+    var healthResp = await fetch(API + '/health');
+    var health = await healthResp.json();
+    var agents = await fetch(API + '/v1/stronghold/agents', {headers: authHeaders()}).then(function(r){return r.json()}).catch(function(){return []});
+    var models = await fetch(API + '/v1/models', {headers: authHeaders()}).then(function(r){return r.json()}).catch(function(){return {data:[]}});
+    document.getElementById('stat-health').textContent = health.status === 'ok' ? '100%' : '??';
+    document.getElementById('health-status').textContent = health.status === 'ok' ? '\u25cf Fortress Online' : '\u25cb Offline';
+    document.getElementById('health-status').style.color = health.status === 'ok' ? '#4ade80' : '#ff6b6b';
+    document.getElementById('stat-agents').textContent = Array.isArray(agents) ? agents.length : '?';
+    document.getElementById('stat-models').textContent = models.data ? models.data.length : '?';
+  } catch(e) {
+    document.getElementById('health-status').textContent = '\u25cb Unreachable';
+    document.getElementById('health-status').style.color = '#ff6b6b';
+  }
+}
+
+function toggleForm() {
+  const form = document.getElementById('mission-form');
+  form.classList.toggle('form-collapsed');
+  form.classList.toggle('form-expanded');
+}
+
+function esc(s) { const d = document.createElement('div'); d.textContent = String(s ?? ''); return d.innerHTML; }
+function showSecurityAlert(err) {
+  var strike = err.strike || {};
+  var flags = err.flags || [];
+  var num = strike.number || '?';
+  var max = strike.max || 3;
+  var level = strike.scrutiny_level || 'elevated';
+  var locked = strike.locked_until || '';
+  var disabled = strike.account_disabled || false;
+
+  // Severity colors
+  var severity = num >= 3 || disabled ? 'critical' : num >= 2 ? 'locked' : 'warning';
+  var bgColor = severity === 'critical' ? 'rgba(139,37,0,0.25)' : severity === 'locked' ? 'rgba(251,191,36,0.15)' : 'rgba(226,165,41,0.12)';
+  var borderColor = severity === 'critical' ? '#ff4444' : severity === 'locked' ? '#fbbf24' : 'var(--gold)';
+  var iconColor = severity === 'critical' ? '#ff4444' : severity === 'locked' ? '#fbbf24' : 'var(--gold)';
+
+  var conv = document.getElementById('conversation');
+  if (conv.querySelector('.crest')) conv.innerHTML = '';
+
+  var alert = document.createElement('div');
+  alert.className = 'msg';
+  alert.style.cssText = 'animation:fadeIn 0.3s ease';
+
+  var banner = document.createElement('div');
+  banner.style.cssText = 'background:'+bgColor+';border:2px solid '+borderColor+';border-radius:12px;padding:24px 28px;margin:8px 0;';
+
+  // Header row: icon + title
+  var hdr = document.createElement('div');
+  hdr.style.cssText = 'display:flex;align-items:center;gap:12px;margin-bottom:16px;';
+  var icon = document.createElement('div');
+  icon.style.cssText = 'font-size:2.5rem;line-height:1;';
+  icon.textContent = severity === 'critical' ? '\u{1F6D1}' : severity === 'locked' ? '\u{1F512}' : '\u{26A0}\u{FE0F}';
+  var titleBlock = document.createElement('div');
+  var title = document.createElement('div');
+  title.style.cssText = 'font-family:Playfair Display,serif;font-size:1.4rem;font-weight:700;color:'+iconColor+';';
+  title.textContent = disabled ? 'Account Disabled' : severity === 'locked' ? 'Account Locked' : 'Security Warning';
+  var subtitle = document.createElement('div');
+  subtitle.style.cssText = 'font-size:0.8rem;color:var(--iron-light);margin-top:2px;';
+  subtitle.textContent = 'Strike ' + num + ' of ' + max + ' \u2014 ' + level;
+  titleBlock.appendChild(title);
+  titleBlock.appendChild(subtitle);
+  hdr.appendChild(icon);
+  hdr.appendChild(titleBlock);
+  banner.appendChild(hdr);
+
+  // Message
+  var msg = document.createElement('div');
+  msg.style.cssText = 'font-size:0.9rem;line-height:1.6;color:var(--parchment);margin-bottom:16px;';
+  msg.textContent = err.message || 'Your request was blocked by the security system.';
+  banner.appendChild(msg);
+
+  // Flags
+  if (flags.length > 0) {
+    var flagBox = document.createElement('div');
+    flagBox.style.cssText = 'background:rgba(0,0,0,0.2);border-radius:6px;padding:10px 14px;margin-bottom:16px;';
+    var flagLabel = document.createElement('div');
+    flagLabel.style.cssText = 'font-size:0.65rem;text-transform:uppercase;letter-spacing:1px;color:var(--iron-light);margin-bottom:6px;';
+    flagLabel.textContent = 'Detected Flags';
+    flagBox.appendChild(flagLabel);
+    flags.forEach(function(f) {
+      var chip = document.createElement('span');
+      chip.style.cssText = 'display:inline-block;padding:3px 10px;margin:2px 4px 2px 0;border-radius:4px;font-size:0.7rem;background:rgba(139,37,0,0.3);color:#ff6b6b;';
+      chip.textContent = f;
+      flagBox.appendChild(chip);
+    });
+    banner.appendChild(flagBox);
+  }
+
+  // Lockout info
+  if (locked) {
+    var lockInfo = document.createElement('div');
+    lockInfo.style.cssText = 'font-size:0.8rem;color:#fbbf24;margin-bottom:12px;';
+    lockInfo.textContent = '\u{1F512} Locked until ' + locked.slice(0,19).replace('T',' ') + ' UTC';
+    banner.appendChild(lockInfo);
+  }
+
+  // Strike meter
+  var meter = document.createElement('div');
+  meter.style.cssText = 'display:flex;gap:8px;align-items:center;margin-bottom:16px;';
+  var meterLabel = document.createElement('span');
+  meterLabel.style.cssText = 'font-size:0.7rem;color:var(--iron-light);';
+  meterLabel.textContent = 'Strikes:';
+  meter.appendChild(meterLabel);
+  for (var i = 1; i <= max; i++) {
+    var dot = document.createElement('div');
+    dot.style.cssText = 'width:32px;height:8px;border-radius:4px;' + (i <= num ? 'background:'+iconColor+';' : 'background:rgba(74,74,90,0.4);');
+    meter.appendChild(dot);
+  }
+  banner.appendChild(meter);
+
+  // Escalation info
+  var esc = document.createElement('div');
+  esc.style.cssText = 'font-size:0.7rem;color:var(--iron-light);line-height:1.5;border-top:1px solid rgba(74,74,90,0.3);padding-top:12px;';
+  esc.innerHTML = '<strong style="color:var(--parchment)">Escalation ladder:</strong> '
+    + 'Strike 1 = elevated scrutiny &bull; '
+    + 'Strike 2 = 8-hour lockout &bull; '
+    + 'Strike 3 = account disabled<br>'
+    + 'If you believe this is an error, submit an appeal to your administrator.';
+  banner.appendChild(esc);
+
+  alert.appendChild(banner);
+  conv.appendChild(alert);
+  conv.scrollTop = conv.scrollHeight;
+}
+
+function addMessage(role, content, meta = {}) {
+  const conv = document.getElementById('conversation');
+  // Remove welcome message
+  if (conv.querySelector('.crest')) conv.innerHTML = '';
+
+  const div = document.createElement('div');
+  div.className = 'msg';
+  const isUser = role === 'user';
+
+  const row = document.createElement('div');
+  row.className = 'flex gap-3' + (isUser ? ' justify-end' : '');
+  const bubble = document.createElement('div');
+  bubble.className = (isUser ? 'parchment' : 'card') + ' p-4 max-w-[80%] text-sm';
+  bubble.style.whiteSpace = 'pre-wrap';
+
+  const header = document.createElement('div');
+  header.className = 'flex items-center gap-2 mb-2';
+  const nameSpan = document.createElement('span');
+  nameSpan.className = 'font-bold ' + (isUser ? 'text-[#5a4a2a]' : 'text-[var(--gold)]');
+  nameSpan.textContent = isUser ? 'You' : '\u{1F3F0} Stronghold';
+  header.appendChild(nameSpan);
+  if (meta.agent) { const b = document.createElement('span'); b.className = 'badge badge-agent'; b.textContent = meta.agent; header.appendChild(b); }
+  if (meta.intent) { const b = document.createElement('span'); b.className = 'badge badge-intent'; b.textContent = meta.intent; header.appendChild(b); }
+  if (meta.model) { const b = document.createElement('span'); b.className = 'badge badge-model'; b.textContent = meta.model; header.appendChild(b); }
+
+  const body = document.createElement('div');
+  body.textContent = content;
+
+  bubble.appendChild(header);
+  bubble.appendChild(body);
+  row.appendChild(bubble);
+  div.appendChild(row);
+  conv.appendChild(div);
+  conv.scrollTop = conv.scrollHeight;
+}
+
+async function submitMission() {
+  const goal = document.getElementById('goal').value.trim();
+  if (!goal) return;
+
+  addMessage('user', goal);
+  chatHistory.push({role: 'user', content: goal});
+
+  const mode = document.getElementById('mode').value;
+  const intent = document.getElementById('intent').value;
+  toggleForm();
+
+  // Show spinner
+  const spinner = document.createElement('div');
+  spinner.id = 'spinner';
+  spinner.className = 'text-center py-4 text-[var(--gold-dim)] text-sm';
+  spinner.innerHTML = '&#x2694; Deploying agent<span class="animate-pulse">...</span>';
+  document.getElementById('conversation').appendChild(spinner);
+
+  try {
+    const resp = await fetch(API + '/v1/stronghold/request/stream', {
+      method: 'POST',
+      headers: authHeaders(),
+      body: JSON.stringify({
+        goal, execution_mode: mode, intent_hint: intent,
+        session_id: sessionId, details: '',
+      }),
+    });
+
+    document.getElementById('spinner')?.remove();
+
+    if (!resp.ok) {
+      const err = await resp.json().catch(() => ({error: {message: 'Request failed'}}));
+      if (err.error && err.error.code === 'BLOCKED_BY_GATE') {
+        showSecurityAlert(err.error);
+      } else {
+        addMessage('assistant', 'Error: ' + (err.error?.message || resp.status), {});
+      }
+      return;
+    }
+
+    // SSE streaming
+    const reader = resp.body.getReader();
+    const decoder = new TextDecoder();
+    let buffer = '';
+    let fullContent = '';
+    let meta = {};
+    let errorMessage = '';
+
+    while (true) {
+      const {done, value} = await reader.read();
+      if (done) break;
+      buffer += decoder.decode(value, {stream: true});
+      const lines = buffer.split('\n');
+      buffer = lines.pop() || '';
+      for (const line of lines) {
+        if (!line.startsWith('data: ')) continue;
+        const data = line.slice(6);
+        if (data === '[DONE]') continue;
+        try {
+          const parsed = JSON.parse(data);
+          if (parsed.type === 'status') {
+            document.getElementById('spinner')?.remove();
+            const s = document.createElement('div');
+            s.id = 'spinner';
+            s.className = 'text-center py-2 text-[var(--iron-light)] text-xs';
+            s.textContent = parsed.message;
+            document.getElementById('conversation').appendChild(s);
+          } else if (parsed.type === 'error') {
+            document.getElementById('spinner')?.remove();
+            errorMessage = parsed.message || 'Mission failed';
+          } else if (parsed.type === 'done') {
+            document.getElementById('spinner')?.remove();
+            fullContent = parsed.content || '';
+            meta = parsed._routing || {};
+          }
+        } catch(e) {}
+      }
+    }
+
+    if (errorMessage) {
+      addMessage('assistant', 'Error: ' + errorMessage, {});
+      return;
+    }
+
+    if (fullContent) {
+      addMessage('assistant', fullContent, {
+        agent: meta.agent, intent: meta.intent?.task_type, model: meta.model
+      });
+      chatHistory.push({role: 'assistant', content: fullContent});
+      saveMission();
+    }
+  } catch(e) {
+    document.getElementById('spinner')?.remove();
+    addMessage('assistant', 'Connection error: unable to reach server', {});
+  }
+}
+
+async function sendFollowup() {
+  const input = document.getElementById('followup');
+  const text = input.value.trim();
+  if (!text) return;
+  input.value = '';
+
+  addMessage('user', text);
+  chatHistory.push({role: 'user', content: text});
+
+  try {
+    const resp = await fetch(API + '/v1/chat/completions', {
+      method: 'POST',
+      headers: authHeaders(),
+      body: JSON.stringify({
+        model: 'auto',
+        messages: chatHistory,
+        session_id: sessionId,
+      }),
+    });
+    const data = await resp.json();
+    if (data.error && data.error.code === 'BLOCKED_BY_GATE') {
+      showSecurityAlert(data.error);
+      return;
+    }
+    const content = data.choices?.[0]?.message?.content || 'No response';
+    const routing = data._routing || {};
+    addMessage('assistant', content, {
+      agent: routing.agent, intent: routing.intent?.task_type, model: routing.model
+    });
+    chatHistory.push({role: 'assistant', content});
+    saveMission();
+  } catch(e) {
+    addMessage('assistant', 'Connection error: unable to reach server', {});
+  }
+}
+
+// ── Mission History (localStorage) ────────────────────────
+function saveMission() {
+  if (chatHistory.length < 2) return;
+  var firstMsg = chatHistory.find(function(m) { return m.role === 'user'; });
+  var preview = firstMsg ? firstMsg.content.slice(0, 60) : 'Mission';
+  var missions = JSON.parse(localStorage.getItem('sh_missions') || '[]');
+  var existing = missions.findIndex(function(m) { return m.id === sessionId; });
+  var entry = {id: sessionId, preview: preview, history: chatHistory, ts: Date.now()};
+  if (existing >= 0) missions[existing] = entry;
+  else missions.unshift(entry);
+  if (missions.length > 20) missions = missions.slice(0, 20);
+  localStorage.setItem('sh_missions', JSON.stringify(missions));
+  renderMissionHistory();
+}
+
+function renderMissionHistory() {
+  var el = document.getElementById('mission-history');
+  if (!el) return;
+  el.innerHTML = '';
+  var missions = JSON.parse(localStorage.getItem('sh_missions') || '[]');
+  if (missions.length === 0) {
+    var empty = document.createElement('div');
+    empty.className = 'text-xs text-[var(--iron-light)] px-2 py-2';
+    empty.textContent = 'No missions yet';
+    el.appendChild(empty);
+    return;
+  }
+  missions.forEach(function(m) {
+    var btn = document.createElement('button');
+    btn.className = 'w-full text-left text-xs px-2 py-2 rounded hover:bg-[rgba(226,165,41,0.1)] transition-colors';
+    btn.style.color = m.id === sessionId ? 'var(--gold)' : 'var(--iron-light)';
+    btn.style.borderLeft = m.id === sessionId ? '2px solid var(--gold)' : '2px solid transparent';
+    var label = document.createElement('div');
+    label.className = 'truncate';
+    label.textContent = m.preview || 'Mission';
+    var time = document.createElement('div');
+    time.className = 'text-[10px] opacity-50 mt-0.5';
+    time.textContent = new Date(m.ts).toLocaleString(undefined, {month:'short', day:'numeric', hour:'2-digit', minute:'2-digit'});
+    btn.appendChild(label);
+    btn.appendChild(time);
+    btn.addEventListener('click', function() { resumeMission(m.id); });
+    el.appendChild(btn);
+  });
+}
+
+async function resumeMission(missionId) {
+  var missions = JSON.parse(localStorage.getItem('sh_missions') || '[]');
+  var mission = missions.find(function(m) { return m.id === missionId; });
+  if (!mission) return;
+  sessionId = mission.id;
+
+  // Lazy-load from server if this is a server-only session with no local history
+  if ((!mission.history || mission.history.length === 0) && mission.server) {
+    try {
+      var resp = await fetch('/v1/stronghold/sessions/' + encodeURIComponent(missionId), {headers: authHeaders()});
+      if (resp.ok) {
+        var data = await resp.json();
+        mission.history = (data.messages || []).map(function(m) { return {role: m.role, content: m.content}; });
+        var firstUser = mission.history.find(function(m) { return m.role === 'user'; });
+        if (firstUser) mission.preview = firstUser.content.slice(0, 60);
+        var idx = missions.findIndex(function(m2) { return m2.id === missionId; });
+        if (idx >= 0) missions[idx] = mission;
+        localStorage.setItem('sh_missions', JSON.stringify(missions));
+      }
+    } catch(e) {}
+  }
+
+  chatHistory = mission.history || [];
+  var conv = document.getElementById('conversation');
+  conv.innerHTML = '';
+  chatHistory.forEach(function(msg) {
+    addMessage(msg.role, msg.content, {});
+  });
+  var form = document.getElementById('mission-form');
+  form.classList.add('form-collapsed');
+  form.classList.remove('form-expanded');
+  renderMissionHistory();
+}
+
+function startNewMission() {
+  sessionId = 'sh-' + crypto.randomUUID().split('-')[0];
+  chatHistory = [];
+  const conv = document.getElementById('conversation');
+  conv.innerHTML = '';
+  const welcome = document.createElement('div');
+  welcome.className = 'text-center text-sm text-[var(--iron-light)] py-8';
+  welcome.innerHTML = '<div class="crest mb-2" style="font-size:3rem">&#x1F3F0;</div>'
+    + '<p>New mission. The fortress awaits your command.</p>'
+    + '<p class="text-xs mt-1">Configure a mission above, or type below.</p>';
+  conv.appendChild(welcome);
+  // Re-expand the mission form
+  const form = document.getElementById('mission-form');
+  form.classList.remove('form-collapsed');
+  form.classList.add('form-expanded');
+  // Clear inputs
+  document.getElementById('goal').value = '';
+  document.getElementById('followup').value = '';
+  document.getElementById('intent').value = '';
+}
+
+// Mobile sidebar
+function openSidebar() {
+  document.getElementById('sidebar').classList.add('open');
+  document.getElementById('sidebar-overlay').classList.add('open');
+}
+function closeSidebar() {
+  document.getElementById('sidebar').classList.remove('open');
+  document.getElementById('sidebar-overlay').classList.remove('open');
+}
+
+// Load server-side sessions into mission history
+async function loadServerMissions() {
+  try {
+    var resp = await fetch('/v1/stronghold/sessions', {headers: authHeaders()});
+    if (!resp.ok) return;
+    var sessions = await resp.json();
+    if (!Array.isArray(sessions) || sessions.length === 0) return;
+
+    var localMissions = JSON.parse(localStorage.getItem('sh_missions') || '[]');
+    var localIds = {};
+    localMissions.forEach(function(m) { localIds[m.id] = true; });
+
+    var newEntries = [];
+    sessions.forEach(function(s) {
+      if (localIds[s.session_id]) return;
+      newEntries.push({
+        id: s.session_id,
+        preview: (s.message_count || 0) + ' messages',
+        history: [],
+        ts: (s.last_activity || 0) * 1000 || Date.now(),
+        server: true,
+      });
+    });
+
+    if (newEntries.length === 0) return;
+    var combined = localMissions.concat(newEntries);
+    combined.sort(function(a, b) { return (b.ts || 0) - (a.ts || 0); });
+    combined = combined.slice(0, 30);
+    localStorage.setItem('sh_missions', JSON.stringify(combined));
+    renderMissionHistory();
+  } catch(e) {}
+}
+
+// Boot
+fetchStats();
+renderMissionHistory();
+loadServerMissions();
+setInterval(function() { fetchStats(); }, 30000);
+</script>
+</body>
+</html>

--- a/src/stronghold/memory/learnings/embeddings.py
+++ b/src/stronghold/memory/learnings/embeddings.py
@@ -85,7 +85,7 @@ class FakeEmbeddingClient:
     async def embed(self, text: str) -> list[float]:
         import hashlib
 
-        digest = hashlib.md5(text.encode("utf-8")).digest()
+        digest = hashlib.md5(text.encode("utf-8"), usedforsecurity=False).digest()  # noqa: S324
         # Pull bits from the digest deterministically. The +0.001
         # ensures the vector is never strict-all-zero (which would
         # trip the noop-client check in find_relevant).

--- a/src/stronghold/memory/learnings/embeddings.py
+++ b/src/stronghold/memory/learnings/embeddings.py
@@ -86,10 +86,13 @@ class FakeEmbeddingClient:
         import hashlib
 
         digest = hashlib.md5(text.encode("utf-8")).digest()
-        # Pull bits from the digest deterministically. Add 1 to each
-        # output value so we never produce a strict-all-zero vector
-        # even in the (impossible) case where every selected bit is 0.
-        return [float(((digest[i % len(digest)] >> (i % 8)) & 1) + 0.001) for i in range(self._dimension)]
+        # Pull bits from the digest deterministically. The +0.001
+        # ensures the vector is never strict-all-zero (which would
+        # trip the noop-client check in find_relevant).
+        return [
+            float(((digest[i % len(digest)] >> (i % 8)) & 1) + 0.001)
+            for i in range(self._dimension)
+        ]
 
     async def embed_batch(self, texts: list[str]) -> list[list[float]]:
         return [await self.embed(t) for t in texts]

--- a/src/stronghold/memory/learnings/embeddings.py
+++ b/src/stronghold/memory/learnings/embeddings.py
@@ -59,7 +59,21 @@ class NoopEmbeddingClient:
 
 
 class FakeEmbeddingClient:
-    """Returns deterministic vectors based on text hash. For testing hybrid search."""
+    """Returns deterministic vectors based on text hash. For testing hybrid search.
+
+    Uses hashlib.md5 (NOT Python's built-in hash()) so the output is
+    stable across processes. The previous version used hash() which is
+    randomized per process via PYTHONHASHSEED — this caused the
+    test_find_relevant_embeds_uncached_learnings test to flake roughly
+    1 run in 256, because some hash seeds happened to produce an
+    all-zero embedding for the query string, which then tripped the
+    `all(v == 0.0)` noop-client check in HybridLearningStore.find_relevant
+    and early-returned without populating the embedding cache.
+
+    Switching to md5 keeps the fake deterministic across runs and
+    eliminates the all-zero vector path entirely (md5 of any non-empty
+    string has non-zero bits).
+    """
 
     def __init__(self, dimension: int = 8) -> None:
         self._dimension = dimension
@@ -69,8 +83,13 @@ class FakeEmbeddingClient:
         return self._dimension
 
     async def embed(self, text: str) -> list[float]:
-        h = hash(text) % (10**9)
-        return [float((h >> i) & 1) for i in range(self._dimension)]
+        import hashlib
+
+        digest = hashlib.md5(text.encode("utf-8")).digest()
+        # Pull bits from the digest deterministically. Add 1 to each
+        # output value so we never produce a strict-all-zero vector
+        # even in the (impossible) case where every selected bit is 0.
+        return [float(((digest[i % len(digest)] >> (i % 8)) & 1) + 0.001) for i in range(self._dimension)]
 
     async def embed_batch(self, texts: list[str]) -> list[list[float]]:
         return [await self.embed(t) for t in texts]

--- a/tests/api/test_issue_446.py
+++ b/tests/api/test_issue_446.py
@@ -6,7 +6,7 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 
-from stronghold.cache.redis_pool import get_redis
+from stronghold.cache.redis_pool import close_redis, get_redis
 
 
 @pytest.fixture(autouse=True)
@@ -30,13 +30,19 @@ class TestF541Fix:
 
     @patch("stronghold.cache.redis_pool.aioredis.from_url")
     async def test_no_f541_error_in_close_redis(self, mock_from_url: AsyncMock) -> None:
+        # The earlier version of this test created a local AsyncMock named
+        # `close_redis` and called THAT instead of the real close_redis
+        # function from stronghold.cache.redis_pool — so the assertion
+        # `mock_redis.aclose.assert_called_once()` never had a chance to
+        # pass and the test was permanently red. Fixed: import the real
+        # close_redis from the module under test and verify it actually
+        # calls aclose() on the pooled client.
         mock_redis = AsyncMock()
         mock_redis.ping = AsyncMock(return_value=True)
         mock_redis.aclose = AsyncMock()
         mock_from_url.return_value = mock_redis
 
         await get_redis()
-        close_redis = AsyncMock()
         await close_redis()
         mock_redis.aclose.assert_called_once()
 

--- a/tests/api/test_issue_451.py
+++ b/tests/api/test_issue_451.py
@@ -77,15 +77,23 @@ class TestQuotedTypeAnnotations:
 
 class TestRuffFormatCompliance:
     def test_ruff_format_passes_for_services(self, services_file: Path) -> None:
-        """Test that ruff format --check passes for services.py with no formatting issues."""
+        """Test that ruff format --check passes for services.py.
+
+        Ruff's `format --check` exits 0 when the file is correctly
+        formatted and 1 when it is not. On success it still prints a
+        status line like '1 file already formatted' to stdout — that
+        text is normal output, NOT a failure signal. The earlier
+        version of this test asserted `not result.stdout.strip()`
+        which incorrectly treated the success status line as a
+        failure, so the test was permanently red. Fixed: rely on the
+        return code only.
+        """
         result = subprocess.run(
             ["ruff", "format", "--check", str(services_file)],
             capture_output=True,
             text=True,
         )
         assert result.returncode == 0, (
-            f"ruff format --check failed for services.py with return code {result.returncode}. "
-            f"stdout: {result.stdout}\nstderr: {result.stderr}"
+            f"ruff format --check failed for services.py with return code "
+            f"{result.returncode}.\nstdout: {result.stdout}\nstderr: {result.stderr}"
         )
-        assert not result.stdout.strip(), "ruff format --check produced stdout output"
-        assert not result.stderr.strip(), "ruff format --check produced stderr output"


### PR DESCRIPTION
## Summary
Four tests on main have been failing on every Mason branch, blocking the entire Mason pipeline. Mason's workspace tool clones from `origin/main`, so every new workspace inherits these broken tests. This PR fixes all four.

## The 4 fixes

| Test | Root cause | Fix |
|---|---|---|
| `test_form_includes_repo_field` | Mason rewrote `dashboard/index.html` (Bug 7) and dropped the Repo/Context input field | Restore the full dashboard from integration (749 lines vs the lobotomized 158-line stub) |
| `test_no_f541_error_in_close_redis` | Test created a local `AsyncMock` named `close_redis` instead of calling the real function | Import and call the real `close_redis` from `stronghold.cache.redis_pool` |
| `test_ruff_format_passes_for_services` | Test asserted `not result.stdout.strip()` but ruff prints "1 file already formatted" on success | Check `returncode == 0` only, drop the stdout emptiness assertion |
| `test_find_relevant_embeds_uncached_learnings` | `FakeEmbeddingClient.embed()` used Python's `hash()` which is randomized per `PYTHONHASHSEED`; ~1/256 runs produced all-zero embeddings that tripped a noop-client early-return | Replace `hash()` with `hashlib.md5` for cross-process determinism; add `+0.001` offset so output is never strict all-zero |

## Test plan
- [x] All 4 tests pass locally
- [x] Test #4 verified with 5 consecutive runs using different `PYTHONHASHSEED` values — zero flakes
- [ ] CI passes on this PR (release.yml 95% gate applies since base is main)

## Impact
After this merges to main, every new Mason workspace will inherit the fixed tests. The ~10 existing Mason PRs targeting main will still fail (they were created before this fix), but all NEW Mason dispatches will start with clean tests.