### PR TITLE
feat: add priority_tier to AgentIdentity + populate all agents

### DIFF
--- a/agents/arbiter/agent.yaml
+++ b/agents/arbiter/agent.yaml
@@ -20,6 +20,7 @@ memory:
   scope: global
 rules: []
 trust_tier: t0
+priority_tier: "P1"
 permissions:
   rate_limit: 120/minute
 sub_agents:

--- a/agents/artificer/agent.yaml
+++ b/agents/artificer/agent.yaml
@@ -36,6 +36,7 @@ rules:
   - "MUST-ALWAYS follow the architecture in ARCHITECTURE.md"
   - "MUST-NEVER introduce hardcoded credentials"
 trust_tier: t1
+priority_tier: "P2"
 permissions:
   max_tool_calls_per_request: 30
   rate_limit: 20/minute

--- a/agents/auditor/agent.yaml
+++ b/agents/auditor/agent.yaml
@@ -35,6 +35,7 @@ rules:
   - "MUST-NEVER approve PRs with critical or high severity findings"
   - "MUST-NEVER leave vague comments without specific file/line references"
 trust_tier: t1
+priority_tier: "P3"
 permissions:
   max_tool_calls_per_request: 20
   rate_limit: 30/minute

--- a/agents/davinci/agent.yaml
+++ b/agents/davinci/agent.yaml
@@ -31,6 +31,7 @@ rules:
   - "MUST-NEVER bake text into AI-generated images"
   - "MUST-NEVER mix art styles across layers in the same scene"
 trust_tier: t1
+priority_tier: "P2"
 permissions:
   max_tool_calls_per_request: 20
   rate_limit: 30/minute

--- a/agents/default/agent.yaml
+++ b/agents/default/agent.yaml
@@ -14,6 +14,7 @@ memory:
   learnings: true
   session: true
 trust_tier: t1
+priority_tier: "P1"
 permissions:
   max_tool_calls_per_request: 5
   rate_limit: 30/minute

--- a/agents/fabulist/agent.yaml
+++ b/agents/fabulist/agent.yaml
@@ -31,6 +31,7 @@ rules:
   - "MUST-NEVER rush through the creative process — the brainstorming IS the experience"
   - "MUST-NEVER generate text-heavy illustrations — canvas text handles all words"
 trust_tier: t1
+priority_tier: "P2"
 permissions:
   max_tool_calls_per_request: 25
   rate_limit: 30/minute

--- a/agents/frank/agent.yaml
+++ b/agents/frank/agent.yaml
@@ -38,6 +38,7 @@ rules:
   - "MUST-NEVER approve criteria that cannot be tested"
   - "MUST-NEVER skip the self-review loop"
 trust_tier: t1
+priority_tier: "P5"
 permissions:
   max_tool_calls_per_request: 30
   rate_limit: 20/minute

--- a/agents/mason/agent.yaml
+++ b/agents/mason/agent.yaml
@@ -88,6 +88,7 @@ rules:
   - "MUST-NEVER bundle unrelated changes in one PR"
   - "MUST-NEVER ignore review feedback from Auditor"
 trust_tier: t1
+priority_tier: "P5"
 permissions:
   max_tool_calls_per_request: 50
   rate_limit: 20/minute

--- a/agents/ranger/agent.yaml
+++ b/agents/ranger/agent.yaml
@@ -29,6 +29,7 @@ rules:
   - "MUST-ALWAYS cite sources for factual claims"
   - "MUST-ALWAYS return raw results alongside any synthesis"
 trust_tier: t1
+priority_tier: "P1"
 permissions:
   max_tool_calls_per_request: 10
   rate_limit: 60/minute

--- a/agents/scribe/agent.yaml
+++ b/agents/scribe/agent.yaml
@@ -24,6 +24,7 @@ rules:
   - "MUST-ALWAYS write in clear, professional prose unless instructed otherwise"
   - "MUST-NEVER fabricate quotes or citations"
 trust_tier: t1
+priority_tier: "P1"
 permissions:
   max_tool_calls_per_request: 10
   rate_limit: 30/minute

--- a/agents/warden-at-arms/agent.yaml
+++ b/agents/warden-at-arms/agent.yaml
@@ -29,6 +29,7 @@ rules:
   - "MUST-ALWAYS confirm destructive actions before executing"
   - "MUST-ALWAYS use exact entity_ids from the device list"
 trust_tier: t1
+priority_tier: "P1"
 permissions:
   max_tool_calls_per_request: 5
   rate_limit: 30/minute

--- a/src/stronghold/agents/factory.py
+++ b/src/stronghold/agents/factory.py
@@ -150,6 +150,7 @@ def _build_identity_from_manifest(manifest: dict[str, Any]) -> AgentIdentity:
         reasoning_strategy=reasoning.get("strategy", "direct"),
         memory_config=manifest.get("memory", {}),
         phases=tuple(reasoning.get("phases", ())),
+        priority_tier=manifest.get("priority_tier", "P2"),
     )
 
 
@@ -170,6 +171,7 @@ def _build_identity_from_record(record: Any) -> AgentIdentity:
         max_tool_rounds=record.max_tool_rounds,
         reasoning_strategy=record.reasoning_strategy,
         memory_config=record.memory_config or {},
+        priority_tier=getattr(record, "priority_tier", "P2"),
     )
 
 

--- a/src/stronghold/api/routes/agents.py
+++ b/src/stronghold/api/routes/agents.py
@@ -187,6 +187,7 @@ async def list_agents(request: Request) -> JSONResponse:
                 "reasoning_strategy": agent.identity.reasoning_strategy,
                 "tools": list(agent.identity.tools),
                 "trust_tier": agent.identity.trust_tier,
+                "priority_tier": agent.identity.priority_tier,
             }
             for agent in container.agents.values()
             if not org_id or not agent.identity.org_id or agent.identity.org_id == org_id

--- a/src/stronghold/types/agent.py
+++ b/src/stronghold/types/agent.py
@@ -36,6 +36,7 @@ class AgentIdentity:
     reasoning_strategy: str = "direct"
     memory_config: dict[str, Any] = field(default_factory=dict)
     phases: tuple[dict[str, Any], ...] = ()
+    priority_tier: str = "P2"  # P0..P5 per ADR-K8S-014
     org_id: str = ""
 
     # Trust & review tracking

--- a/tests/agents/test_loader_priority_tier.py
+++ b/tests/agents/test_loader_priority_tier.py
@@ -1,0 +1,64 @@
+"""Tests for priority_tier loading from agent.yaml (ADR-K8S-014)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+from stronghold.agents.factory import _build_identity_from_manifest
+
+
+def test_manifest_with_priority_tier() -> None:
+    manifest = {"name": "mason", "priority_tier": "P5"}
+    identity = _build_identity_from_manifest(manifest)
+    assert identity.priority_tier == "P5"
+
+
+def test_manifest_without_priority_tier_defaults_p2() -> None:
+    manifest = {"name": "legacy-agent"}
+    identity = _build_identity_from_manifest(manifest)
+    assert identity.priority_tier == "P2"
+
+
+def test_all_agent_yamls_have_priority_tier() -> None:
+    agents_dir = Path("agents")
+    if not agents_dir.exists():
+        return  # skip if running from different cwd
+    for agent_dir in sorted(agents_dir.iterdir()):
+        yaml_path = agent_dir / "agent.yaml"
+        if not yaml_path.exists():
+            continue
+        data = yaml.safe_load(yaml_path.read_text())
+        assert "priority_tier" in data, f"{yaml_path} missing priority_tier"
+        assert data["priority_tier"] in (
+            "P0", "P1", "P2", "P3", "P4", "P5",
+        ), f"{yaml_path} has invalid priority_tier: {data['priority_tier']}"
+
+
+def test_loaded_identities_match_yaml_assignments() -> None:
+    expected = {
+        "arbiter": "P1",
+        "artificer": "P2",
+        "auditor": "P3",
+        "davinci": "P2",
+        "default": "P1",
+        "fabulist": "P2",
+        "frank": "P5",
+        "mason": "P5",
+        "ranger": "P1",
+        "scribe": "P1",
+        "warden-at-arms": "P1",
+    }
+    agents_dir = Path("agents")
+    if not agents_dir.exists():
+        return
+    for name, tier in expected.items():
+        yaml_path = agents_dir / name / "agent.yaml"
+        if not yaml_path.exists():
+            continue
+        data = yaml.safe_load(yaml_path.read_text())
+        identity = _build_identity_from_manifest(data)
+        assert identity.priority_tier == tier, (
+            f"{name}: expected {tier}, got {identity.priority_tier}"
+        )

--- a/tests/types/test_priority_tier.py
+++ b/tests/types/test_priority_tier.py
@@ -1,0 +1,28 @@
+"""Tests for priority_tier field on AgentIdentity (ADR-K8S-014)."""
+
+from __future__ import annotations
+
+from stronghold.types.agent import AgentIdentity
+
+
+def test_default_priority_tier_is_p2() -> None:
+    identity = AgentIdentity(name="test-agent")
+    assert identity.priority_tier == "P2"
+
+
+def test_priority_tier_round_trip() -> None:
+    for tier in ("P0", "P1", "P2", "P3", "P4", "P5"):
+        identity = AgentIdentity(name="test-agent", priority_tier=tier)
+        assert identity.priority_tier == tier
+
+
+def test_priority_tier_preserved_in_dataclass() -> None:
+    identity = AgentIdentity(
+        name="mason",
+        version="2.0.0",
+        priority_tier="P5",
+        trust_tier="t1",
+    )
+    assert identity.name == "mason"
+    assert identity.priority_tier == "P5"
+    assert identity.trust_tier == "t1"


### PR DESCRIPTION
## Summary

- Adds `priority_tier` field to `AgentIdentity` (default `P2` for backward compat) per ADR-K8S-014
- Plumbs through both manifest loader and DB record loader
- Exposes in agent listing API (`GET /agents`)
- Populates all 11 existing `agent.yaml` files with assigned tiers:
  - **P1**: arbiter, default, ranger, scribe, warden-at-arms
  - **P2**: artificer, davinci, fabulist
  - **P3**: auditor
  - **P5**: frank, mason

Closes #901, closes #902. Refs #809 (Intent migration is separate).

## Test plan

- [x] `tests/types/test_priority_tier.py` — round-trip, default, preservation (3 tests)
- [x] `tests/agents/test_loader_priority_tier.py` — manifest loading, defaults, yaml validation, assignment verification (4 tests)
- [x] 7/7 new tests passing
- [ ] Verify agent listing API returns `priority_tier` field

> **Note:** Pre-existing test failures on `integration` (`test_types.py::TestIntent::test_defaults`, `test_types.py::TestConfigTypes::test_routing_config_defaults`) are from partial Intent.tier migration (#809) — not introduced by this PR.