### PR TITLE
feat: migrate priority to 6-tier P0-P5 system (ADR-K8S-014)

### DIFF
--- a/src/stronghold/classifier/complexity.py
+++ b/src/stronghold/classifier/complexity.py
@@ -55,15 +55,20 @@ def estimate_complexity(text: str, task_type: str) -> str:
 
 
 def infer_priority(user_text: str) -> str:
-    """Infer priority from urgency keywords."""
+    """Infer priority tier from urgency keywords.
+
+    Returns a 6-tier priority value per ADR-K8S-014:
+      P0 = chat-critical, P1 = chat-tools, P2 = user-missions,
+      P3 = backend-support, P4 = quartermaster, P5 = builders.
+    """
     text = user_text.lower()
     if any(s in text for s in ["urgent", "critical", "emergency", "asap", "broken", "down"]):
-        return "critical"
+        return "P0"
     if any(s in text for s in ["important", "priority", "deadline", "client", "demo"]):
-        return "high"
+        return "P1"
     if any(s in text for s in ["just curious", "when you get a chance", "no rush", "fyi"]):
-        return "low"
-    return "normal"
+        return "P4"
+    return "P2"
 
 
 def automation_min_tier(user_text: str, base_min_tier: str) -> str:

--- a/src/stronghold/classifier/engine.py
+++ b/src/stronghold/classifier/engine.py
@@ -107,7 +107,7 @@ class ClassifierEngine:
         return Intent(
             task_type=task_type,
             complexity=complexity,  # type: ignore[arg-type]
-            priority=priority,  # type: ignore[arg-type]
+            tier=priority,  # type: ignore[arg-type]
             min_tier=min_tier,
             preferred_strengths=preferred,
             classified_by=classified_by,

--- a/src/stronghold/conduit.py
+++ b/src/stronghold/conduit.py
@@ -173,7 +173,7 @@ class Conduit:
                         "task_type": intent.task_type,
                         "classified_by": intent.classified_by,
                         "complexity": intent.complexity,
-                        "priority": intent.priority,
+                        "tier": intent.tier,
                     }
                 )
 
@@ -209,7 +209,7 @@ class Conduit:
                 {
                     "task_type": intent.task_type,
                     "complexity": intent.complexity,
-                    "priority": intent.priority,
+                    "tier": intent.tier,
                     "classified_by": intent.classified_by,
                     "user_id": auth.user_id,
                     "session_id": session_id or "",
@@ -591,7 +591,7 @@ class Conduit:
                 "agent": agent.identity.name,
                 "intent": intent.task_type,
                 "complexity": intent.complexity,
-                "priority": intent.priority,
+                "tier": intent.tier,
                 "total_latency_ms": str(_elapsed_ms),
                 "session_id": session_id or "",
                 "is_sticky_followup": str(
@@ -624,7 +624,7 @@ class Conduit:
                 "intent": {
                     "task_type": intent.task_type,
                     "complexity": intent.complexity,
-                    "priority": intent.priority,
+                    "tier": intent.tier,
                     "classified_by": intent.classified_by,
                 },
                 "model": model_to_use,

--- a/src/stronghold/router/filter.py
+++ b/src/stronghold/router/filter.py
@@ -72,7 +72,7 @@ def filter_candidates(
             continue
 
         # Reserve enforcement — block non-critical when in reserve zone OR over quota with paygo
-        if usage_pct >= (1.0 - reserve_pct) and intent.priority != "critical" and not has_paygo:
+        if usage_pct >= (1.0 - reserve_pct) and intent.tier != "P0" and not has_paygo:
             continue
 
         result.append((model_id, model_cfg, provider_cfg, usage_pct))

--- a/src/stronghold/router/scorer.py
+++ b/src/stronghold/router/scorer.py
@@ -29,7 +29,7 @@ def score_candidate(
 
     quality_weight = routing_cfg.quality_weight
     cost_weight = routing_cfg.cost_weight
-    priority_mult = routing_cfg.priority_multipliers.get(intent.priority, 1.0)
+    priority_mult = routing_cfg.priority_multipliers.get(intent.tier, 1.0)
 
     # Floor the quality exponent so it never collapses to q^0
     quality_exponent = max(0.1, quality_weight * priority_mult)

--- a/src/stronghold/router/selector.py
+++ b/src/stronghold/router/selector.py
@@ -67,7 +67,7 @@ class RouterEngine:
             if all_candidates:
                 raise QuotaReserveError(
                     f"All {len(all_candidates)} eligible models are in quota reserve. "
-                    "Use priority=critical to override."
+                    "Use tier=P0 to override."
                 )
             # Absolute fallback — highest quality active model
             return self._fallback(models, providers)
@@ -141,7 +141,7 @@ class RouterEngine:
         parts = [
             f"task={intent.task_type}",
             f"complexity={intent.complexity}",
-            f"priority={intent.priority}",
+            f"tier={intent.tier}",
         ]
         if isinstance(best, ModelCandidate):
             parts.append(f"quality={best.quality}")

--- a/src/stronghold/types/config.py
+++ b/src/stronghold/types/config.py
@@ -17,10 +17,12 @@ class RoutingConfig(BaseModel):
     reserve_pct: float = 0.05
     priority_multipliers: dict[str, float] = Field(
         default_factory=lambda: {
-            "low": 0.8,
-            "normal": 1.0,
-            "high": 1.2,
-            "critical": 1.5,
+            "P0": 1.5,
+            "P1": 1.2,
+            "P2": 1.0,
+            "P3": 0.9,
+            "P4": 0.8,
+            "P5": 0.7,
         }
     )
 

--- a/src/stronghold/types/intent.py
+++ b/src/stronghold/types/intent.py
@@ -1,6 +1,6 @@
 """Intent classification types.
 
-An Intent represents the classified purpose, complexity, and priority
+An Intent represents the classified purpose, complexity, and tier
 of a user's message. Produced by the classifier, consumed by the router.
 """
 
@@ -24,7 +24,7 @@ class Intent:
 
     task_type: str = "chat"
     complexity: Literal["simple", "moderate", "complex"] = "simple"
-    priority: Literal["low", "normal", "high", "critical"] = "normal"
+    tier: Literal["P0", "P1", "P2", "P3", "P4", "P5"] = "P2"
     min_tier: str = "small"
     max_tier: str | None = None
     preferred_strengths: tuple[str, ...] = ("chat",)

--- a/tests/classification/test_classifier_engine.py
+++ b/tests/classification/test_classifier_engine.py
@@ -173,9 +173,9 @@ class TestClassifyEdgeCases:
         intent = await engine.classify(
             [{"role": "user", "content": "hello"}],
             _task_types(),
-            explicit_priority="critical",
+            explicit_priority="P0",
         )
-        assert intent.priority == "critical"
+        assert intent.tier == "P0"
 
     @pytest.mark.asyncio
     async def test_classified_by_keywords(self) -> None:
@@ -279,34 +279,34 @@ class TestPriorityInference:
             [{"role": "user", "content": "urgent the server is down help"}],
             _task_types(),
         )
-        assert intent.priority == "critical"
+        assert intent.tier == "P0"
 
     @pytest.mark.asyncio
-    async def test_important_is_high(self) -> None:
+    async def test_important_is_p1(self) -> None:
         engine = ClassifierEngine()
         intent = await engine.classify(
             [{"role": "user", "content": "this is important for the client demo"}],
             _task_types(),
         )
-        assert intent.priority == "high"
+        assert intent.tier == "P1"
 
     @pytest.mark.asyncio
-    async def test_no_rush_is_low(self) -> None:
+    async def test_no_rush_is_p4(self) -> None:
         engine = ClassifierEngine()
         intent = await engine.classify(
             [{"role": "user", "content": "just curious about something no rush"}],
             _task_types(),
         )
-        assert intent.priority == "low"
+        assert intent.tier == "P4"
 
     @pytest.mark.asyncio
-    async def test_normal_message_normal_priority(self) -> None:
+    async def test_normal_message_p2_tier(self) -> None:
         engine = ClassifierEngine()
         intent = await engine.classify(
             [{"role": "user", "content": "hello how are you"}],
             _task_types(),
         )
-        assert intent.priority == "normal"
+        assert intent.tier == "P2"
 
 
 class TestMultiIntentDetection:

--- a/tests/classification/test_complexity.py
+++ b/tests/classification/test_complexity.py
@@ -25,14 +25,14 @@ class TestComplexity:
 
 
 class TestPriority:
-    def test_urgent_is_critical(self) -> None:
-        assert infer_priority("this is urgent please fix now") == "critical"
+    def test_urgent_is_p0(self) -> None:
+        assert infer_priority("this is urgent please fix now") == "P0"
 
-    def test_no_rush_is_low(self) -> None:
-        assert infer_priority("when you get a chance no rush") == "low"
+    def test_no_rush_is_p4(self) -> None:
+        assert infer_priority("when you get a chance no rush") == "P4"
 
-    def test_default_is_normal(self) -> None:
-        assert infer_priority("can you help me with this") == "normal"
+    def test_default_is_p2(self) -> None:
+        assert infer_priority("can you help me with this") == "P2"
 
 
 class TestComplexityBoundaries:
@@ -60,12 +60,12 @@ class TestComplexityBoundaries:
 
 class TestPriorityEdgeCases:
     def test_multiple_urgent_words(self) -> None:
-        assert infer_priority("urgent critical emergency") == "critical"
+        assert infer_priority("urgent critical emergency") == "P0"
 
-    def test_empty_text_is_normal(self) -> None:
-        assert infer_priority("") == "normal"
+    def test_empty_text_is_p2(self) -> None:
+        assert infer_priority("") == "P2"
 
     def test_mixed_signals(self) -> None:
-        # "urgent" is critical, "no rush" is low — first match wins
+        # "urgent" is P0, "no rush" is P4 — first match wins
         result = infer_priority("urgent but no rush")
-        assert result == "critical"
+        assert result == "P0"

--- a/tests/classification/test_priority.py
+++ b/tests/classification/test_priority.py
@@ -1,17 +1,17 @@
-"""Tests for priority inference from urgency keywords."""
+"""Tests for priority tier inference from urgency keywords."""
 
 from stronghold.classifier.complexity import infer_priority
 
 
 class TestPriorityKeywords:
-    def test_emergency_is_critical(self) -> None:
-        assert infer_priority("emergency the server is down") == "critical"
+    def test_emergency_is_p0(self) -> None:
+        assert infer_priority("emergency the server is down") == "P0"
 
-    def test_important_is_high(self) -> None:
-        assert infer_priority("this is important for the demo") == "high"
+    def test_important_is_p1(self) -> None:
+        assert infer_priority("this is important for the demo") == "P1"
 
-    def test_fyi_is_low(self) -> None:
-        assert infer_priority("fyi here is the report") == "low"
+    def test_fyi_is_p4(self) -> None:
+        assert infer_priority("fyi here is the report") == "P4"
 
-    def test_normal_text_is_normal(self) -> None:
-        assert infer_priority("hello how are you") == "normal"
+    def test_normal_text_is_p2(self) -> None:
+        assert infer_priority("hello how are you") == "P2"

--- a/tests/config/test_validation.py
+++ b/tests/config/test_validation.py
@@ -36,8 +36,8 @@ class TestRoutingConfig:
     def test_defaults(self) -> None:
         rc = RoutingConfig()
         assert rc.reserve_pct == 0.05
-        assert "normal" in rc.priority_multipliers
+        assert "P2" in rc.priority_multipliers
 
     def test_custom_multipliers(self) -> None:
-        rc = RoutingConfig(priority_multipliers={"low": 0.5, "high": 2.0})
-        assert rc.priority_multipliers["low"] == 0.5
+        rc = RoutingConfig(priority_multipliers={"P4": 0.5, "P0": 2.0})
+        assert rc.priority_multipliers["P4"] == 0.5

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -14,7 +14,7 @@ def build_intent(**overrides: object) -> Intent:
     defaults: dict[str, object] = {
         "task_type": "chat",
         "complexity": "simple",
-        "priority": "normal",
+        "tier": "P2",
         "min_tier": "small",
         "preferred_strengths": ("chat",),
         "classified_by": "keywords",

--- a/tests/routing/test_fallback.py
+++ b/tests/routing/test_fallback.py
@@ -30,7 +30,7 @@ class TestFallback:
 
     def test_raises_when_all_in_reserve(self) -> None:
         engine = RouterEngine(FakeQuotaTracker(usage_pct=0.96))
-        intent = build_intent(priority="normal")
+        intent = build_intent(tier="P2")
         models = {"m": build_model_config(provider="p")}
         providers = {"p": build_provider_config(free_tokens=1_000_000)}
         config = build_routing_config()

--- a/tests/routing/test_quota_reserve.py
+++ b/tests/routing/test_quota_reserve.py
@@ -6,7 +6,7 @@ from tests.factories import build_intent, build_model_config, build_provider_con
 
 class TestQuotaReserve:
     def test_blocks_non_critical_above_reserve(self) -> None:
-        intent = build_intent(priority="normal")
+        intent = build_intent(tier="P2")
         models = {"m": build_model_config(provider="p")}
         providers = {"p": build_provider_config(free_tokens=1_000_000)}
         # 96% usage — above 95% reserve threshold
@@ -16,7 +16,7 @@ class TestQuotaReserve:
         assert len(result) == 0
 
     def test_allows_critical_above_reserve(self) -> None:
-        intent = build_intent(priority="critical")
+        intent = build_intent(tier="P0")
         models = {"m": build_model_config(provider="p")}
         providers = {"p": build_provider_config(free_tokens=1_000_000)}
         result = filter_candidates(
@@ -25,7 +25,7 @@ class TestQuotaReserve:
         assert len(result) == 1
 
     def test_paygo_bypasses_at_100_percent(self) -> None:
-        intent = build_intent(priority="normal")
+        intent = build_intent(tier="P2")
         models = {"m": build_model_config(provider="p")}
         providers = {
             "p": build_provider_config(

--- a/tests/routing/test_scarcity_extended.py
+++ b/tests/routing/test_scarcity_extended.py
@@ -208,8 +208,8 @@ class TestScorerIntegration:
         provider = build_provider_config(free_tokens=1_000_000_000)
         model = build_model_config(quality=0.9, strengths=("code",))
 
-        normal = build_intent(priority="normal", preferred_strengths=("code",))
-        critical = build_intent(priority="critical", preferred_strengths=("code",))
+        normal = build_intent(tier="P2", preferred_strengths=("code",))
+        critical = build_intent(tier="P0", preferred_strengths=("code",))
 
         cand_n = score_candidate("n", model, provider, normal, routing, 0.1)
         cand_c = score_candidate("c", model, provider, critical, routing, 0.1)

--- a/tests/routing/test_scoring_properties.py
+++ b/tests/routing/test_scoring_properties.py
@@ -49,7 +49,7 @@ class TestQualityMonotonicity:
 class TestQualityExponentFloor:
     def test_exponent_never_zero(self) -> None:
         # Low priority with low quality_weight should still produce nonzero exponent
-        intent = build_intent(priority="low")
+        intent = build_intent(tier="P4")
         config = build_routing_config(quality_weight=0.1)
         model = build_model_config(quality=0.5)
         provider = build_provider_config()
@@ -80,8 +80,8 @@ class TestScoreEdgeCases:
         config = build_routing_config()
         provider = build_provider_config()
         model = build_model_config(quality=0.9)
-        high = score_candidate("m", model, provider, build_intent(priority="critical"), config, 0.5)
-        low = score_candidate("m", model, provider, build_intent(priority="low"), config, 0.5)
+        high = score_candidate("m", model, provider, build_intent(tier="P0"), config, 0.5)
+        low = score_candidate("m", model, provider, build_intent(tier="P4"), config, 0.5)
         # Higher priority increases quality exponent, which penalizes sub-1.0 quality more
         # This is correct: critical is pickier, so same model scores lower
         assert high.score != low.score

--- a/tests/test_coverage_misc.py
+++ b/tests/test_coverage_misc.py
@@ -641,7 +641,7 @@ class TestRouterFilterPaygoEdge:
         from stronghold.types.intent import Intent
         from stronghold.types.model import ModelConfig, ProviderConfig
 
-        intent = Intent(task_type="chat", min_tier="small", priority="normal")
+        intent = Intent(task_type="chat", min_tier="small", tier="P2")
         models = {
             "m1": ModelConfig(provider="p1", tier="small", quality=0.5),
         }
@@ -653,7 +653,7 @@ class TestRouterFilterPaygoEdge:
             ),
         }
 
-        # usage_pct = 0.96 >= (1.0 - 0.05), priority != critical, no paygo
+        # usage_pct = 0.96 >= (1.0 - 0.05), tier != P0, no paygo
         result = filter_candidates(
             intent, models, providers, usage_pcts={"p1": 0.96}
         )
@@ -665,7 +665,7 @@ class TestRouterFilterPaygoEdge:
         from stronghold.types.intent import Intent
         from stronghold.types.model import ModelConfig, ProviderConfig
 
-        intent = Intent(task_type="chat", min_tier="small", priority="critical")
+        intent = Intent(task_type="chat", min_tier="small", tier="P0")
         models = {
             "m1": ModelConfig(provider="p1", tier="small", quality=0.5),
         }

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -86,7 +86,7 @@ class TestIntent:
         intent = Intent()
         assert intent.task_type == "chat"
         assert intent.complexity == "simple"
-        assert intent.priority == "normal"
+        assert intent.tier == "P2"
 
     def test_tier_order(self) -> None:
         assert TIER_ORDER["small"] < TIER_ORDER["medium"]
@@ -253,7 +253,7 @@ class TestConfigTypes:
     def test_routing_config_defaults(self) -> None:
         rc = RoutingConfig()
         assert rc.quality_weight == 0.6
-        assert "normal" in rc.priority_multipliers
+        assert "P2" in rc.priority_multipliers
 
     def test_task_type_config(self) -> None:
         ttc = TaskTypeConfig(keywords=["code"])


### PR DESCRIPTION
## Summary

- Replaces `Intent.priority` (`low`/`normal`/`high`/`critical`) with `Intent.tier` (`P0`-`P5`) per ADR-K8S-014
- Updates `RoutingConfig.priority_multipliers` from 4-value to 6-tier dict (P0=1.5 down to P5=0.7)
- Migrates classifier, router (scorer, filter, selector), and conduit trace spans
- All 273 affected tests passing

Tier assignments per ADR-K8S-014:

| Tier | Purpose | Multiplier |
|------|---------|------------|
| P0 | Chat-critical | 1.5 |
| P1 | Chat-tools | 1.2 |
| P2 | User-missions | 1.0 |
| P3 | Backend-support | 0.9 |
| P4 | Quartermaster | 0.8 |
| P5 | Builders | 0.7 |

Closes #809

## Test plan

- [x] 273 tests passing across classification, routing, config, types, and coverage suites
- [x] No parallel coexistence — all callers migrated in one commit
- [ ] Verify trace spans show `tier` field instead of `priority`