### PR TITLE
feat: Tool Policy layer with embedded Casbin (refs #959)

### DIFF
--- a/config/tool_policy.csv
+++ b/config/tool_policy.csv
@@ -1,0 +1,2 @@
+p, *, *, *, tool_call, allow
+p, *, *, *, task_create, allow

--- a/config/tool_policy_model.conf
+++ b/config/tool_policy_model.conf
@@ -1,0 +1,11 @@
+[request_definition]
+r = sub, org, obj, act
+
+[policy_definition]
+p = sub, org, obj, act, eft
+
+[policy_effect]
+e = some(where (p.eft == allow)) && !some(where (p.eft == deny))
+
+[matchers]
+m = (r.sub == p.sub || p.sub == "*") && (r.org == p.org || p.org == "*") && (r.obj == p.obj || p.obj == "*") && (r.act == p.act || p.act == "*")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ dependencies = [
     "pgvector>=0.3.0",
     "kubernetes>=28.0.0",
     "regex>=2024.0.0",
+    "casbin>=1.36.0",
     # CVE pinning (2026-03-31 audit)
     "cryptography>=46.0.6",       # CVE-2026-34073
     "urllib3>=2.6.3",              # CVE-2026-21441

--- a/src/stronghold/security/tool_policy.py
+++ b/src/stronghold/security/tool_policy.py
@@ -1,0 +1,58 @@
+"""Tool Policy layer — Casbin-based access control for tool calls and tasks.
+
+ADR-K8S-019: two policy gates evaluated at runtime:
+  1. Per-tool-call: (user, org, tool, "tool_call") -> allow/deny
+  2. Per-task-creation: (user, org, agent, "task_create") -> allow/deny
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Protocol, runtime_checkable
+
+import casbin
+
+logger = logging.getLogger("stronghold.security.tool_policy")
+
+
+@runtime_checkable
+class ToolPolicyProtocol(Protocol):
+    def check_tool_call(self, user_id: str, org_id: str, tool_name: str) -> bool: ...
+    def check_task_creation(self, user_id: str, org_id: str, agent_name: str) -> bool: ...
+
+
+class CasbinToolPolicy:
+    def __init__(self, model_path: str, policy_path: str) -> None:
+        self._model_path = model_path
+        self._policy_path = policy_path
+        self._enforcer = casbin.Enforcer(model_path, policy_path)
+
+    def check_tool_call(self, user_id: str, org_id: str, tool_name: str) -> bool:
+        result: bool = self._enforcer.enforce(user_id, org_id, tool_name, "tool_call")
+        if not result:
+            logger.warning("Tool call DENIED: user=%s org=%s tool=%s", user_id, org_id, tool_name)
+        return result
+
+    def check_task_creation(self, user_id: str, org_id: str, agent_name: str) -> bool:
+        result: bool = self._enforcer.enforce(user_id, org_id, agent_name, "task_create")
+        if not result:
+            logger.warning("Task creation DENIED: user=%s org=%s agent=%s", user_id, org_id, agent_name)
+        return result
+
+    def reload_policy(self) -> None:
+        self._enforcer.load_policy()
+
+    def add_policy(self, sub: str, org: str, obj: str, act: str, eft: str = "allow") -> bool:
+        return bool(self._enforcer.add_policy(sub, org, obj, act, eft))
+
+    def remove_policy(self, sub: str, org: str, obj: str, act: str, eft: str = "allow") -> bool:
+        return bool(self._enforcer.remove_policy(sub, org, obj, act, eft))
+
+
+def create_tool_policy(model_path: str | None = None, policy_path: str | None = None) -> CasbinToolPolicy:
+    config_dir = Path("config")
+    return CasbinToolPolicy(
+        model_path or str(config_dir / "tool_policy_model.conf"),
+        policy_path or str(config_dir / "tool_policy.csv"),
+    )

--- a/tests/fakes.py
+++ b/tests/fakes.py
@@ -572,3 +572,23 @@ def make_test_container(
     }
     fields.update(overrides)
     return Container(**fields)
+
+
+class FakeToolPolicy:
+    """In-memory tool policy for testing (ADR-K8S-019)."""
+
+    def __init__(self) -> None:
+        self._denied_tool_calls: set[tuple[str, str, str]] = set()
+        self._denied_task_creates: set[tuple[str, str, str]] = set()
+
+    def deny_tool_call(self, user_id: str, org_id: str, tool_name: str) -> None:
+        self._denied_tool_calls.add((user_id, org_id, tool_name))
+
+    def deny_task_creation(self, user_id: str, org_id: str, agent_name: str) -> None:
+        self._denied_task_creates.add((user_id, org_id, agent_name))
+
+    def check_tool_call(self, user_id: str, org_id: str, tool_name: str) -> bool:
+        return (user_id, org_id, tool_name) not in self._denied_tool_calls
+
+    def check_task_creation(self, user_id: str, org_id: str, agent_name: str) -> bool:
+        return (user_id, org_id, agent_name) not in self._denied_task_creates

--- a/tests/security/test_tool_policy.py
+++ b/tests/security/test_tool_policy.py
@@ -1,0 +1,105 @@
+"""Tests for CasbinToolPolicy (ADR-K8S-019)."""
+
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+
+from stronghold.security.tool_policy import CasbinToolPolicy, ToolPolicyProtocol
+from tests.fakes import FakeToolPolicy
+
+MODEL_CONF = """\
+[request_definition]
+r = sub, org, obj, act
+
+[policy_definition]
+p = sub, org, obj, act, eft
+
+[policy_effect]
+e = some(where (p.eft == allow)) && !some(where (p.eft == deny))
+
+[matchers]
+m = (r.sub == p.sub || p.sub == "*") && (r.org == p.org || p.org == "*") && (r.obj == p.obj || p.obj == "*") && (r.act == p.act || p.act == "*")
+"""
+
+DEFAULT_POLICY = """\
+p, *, *, *, tool_call, allow
+p, *, *, *, task_create, allow
+"""
+
+
+def _make_policy(model: str = MODEL_CONF, policy: str = DEFAULT_POLICY) -> CasbinToolPolicy:
+    tmp = tempfile.mkdtemp()
+    model_path = Path(tmp) / "model.conf"
+    policy_path = Path(tmp) / "policy.csv"
+    model_path.write_text(model)
+    policy_path.write_text(policy)
+    return CasbinToolPolicy(str(model_path), str(policy_path))
+
+
+def test_default_allows_tool_call() -> None:
+    assert _make_policy().check_tool_call("alice", "acme", "web_search") is True
+
+
+def test_default_allows_task_creation() -> None:
+    assert _make_policy().check_task_creation("alice", "acme", "artificer") is True
+
+
+def test_deny_blocks_tool_for_user() -> None:
+    p = _make_policy(policy=DEFAULT_POLICY + "p, alice, *, shell, tool_call, deny\n")
+    assert p.check_tool_call("alice", "acme", "shell") is False
+    assert p.check_tool_call("bob", "acme", "shell") is True
+
+
+def test_deny_blocks_tool_for_org() -> None:
+    p = _make_policy(policy=DEFAULT_POLICY + "p, *, evil-corp, shell, tool_call, deny\n")
+    assert p.check_tool_call("alice", "evil-corp", "shell") is False
+    assert p.check_tool_call("alice", "acme", "shell") is True
+
+
+def test_deny_blocks_task_for_user() -> None:
+    p = _make_policy(policy=DEFAULT_POLICY + "p, mallory, *, forge, task_create, deny\n")
+    assert p.check_task_creation("mallory", "acme", "forge") is False
+    assert p.check_task_creation("alice", "acme", "forge") is True
+
+
+def test_wildcard_matching() -> None:
+    assert _make_policy().check_tool_call("anyone", "any-org", "any-tool") is True
+
+
+def test_add_and_remove_policy() -> None:
+    p = _make_policy()
+    assert p.check_tool_call("alice", "acme", "danger") is True
+    p.add_policy("alice", "acme", "danger", "tool_call", "deny")
+    assert p.check_tool_call("alice", "acme", "danger") is False
+    p.remove_policy("alice", "acme", "danger", "tool_call", "deny")
+    assert p.check_tool_call("alice", "acme", "danger") is True
+
+
+def test_reload_policy() -> None:
+    tmp = tempfile.mkdtemp()
+    mp, pp = Path(tmp) / "model.conf", Path(tmp) / "policy.csv"
+    mp.write_text(MODEL_CONF)
+    pp.write_text(DEFAULT_POLICY)
+    p = CasbinToolPolicy(str(mp), str(pp))
+    assert p.check_tool_call("alice", "acme", "shell") is True
+    pp.write_text(DEFAULT_POLICY + "p, alice, *, shell, tool_call, deny\n")
+    p.reload_policy()
+    assert p.check_tool_call("alice", "acme", "shell") is False
+
+
+def test_protocol_compliance() -> None:
+    assert isinstance(_make_policy(), ToolPolicyProtocol)
+
+
+def test_fake_default_allows() -> None:
+    f = FakeToolPolicy()
+    assert f.check_tool_call("alice", "acme", "shell") is True
+    assert f.check_task_creation("alice", "acme", "forge") is True
+
+
+def test_fake_deny() -> None:
+    f = FakeToolPolicy()
+    f.deny_tool_call("alice", "acme", "shell")
+    assert f.check_tool_call("alice", "acme", "shell") is False
+    assert f.check_tool_call("bob", "acme", "shell") is True


### PR DESCRIPTION
## Summary

- Embeds Casbin (Apache 2.0) for tool-call and task-creation policy gates per ADR-K8S-019
- PERM model: `(sub, org, obj, act, eft)` with allow/deny effects
- Default policy: allow all for authenticated users
- `CasbinToolPolicy` + `ToolPolicyProtocol` + `FakeToolPolicy`
- Adds `casbin>=1.36.0` to dependencies
- 11 tests passing

Refs #959

## Test plan

- [x] 11/11 tests: allow, deny (user/org), wildcard, add/remove, reload, protocol compliance, fake