### PR TITLE
feat: Tool Catalog with decorator API and cascade loader (refs #960)

### DIFF
--- a/src/stronghold/tools/catalog.py
+++ b/src/stronghold/tools/catalog.py
@@ -1,0 +1,105 @@
+"""Tool Catalog — registry with multi-tenant cascade and semver versioning.
+
+ADR-K8S-021: tools registered as catalog entries with scope (builtin > tenant > user).
+Resolution cascades from user to tenant to builtin, highest-priority wins.
+Customer plugins discovered via 'stronghold.tools' entry-point group.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from importlib.metadata import entry_points
+from typing import Any, Callable
+
+from stronghold.types.tool import ToolDefinition
+
+logger = logging.getLogger("stronghold.tools.catalog")
+
+# Scope priority: higher number = higher priority in cascade
+_SCOPE_PRIORITY = {"builtin": 0, "tenant": 1, "user": 2}
+
+
+@dataclass(frozen=True)
+class CatalogEntry:
+    """A tool registered in the catalog with scope and version metadata."""
+
+    definition: ToolDefinition
+    version: str = "1.0.0"
+    scope: str = "builtin"  # "builtin" | "tenant" | "user"
+    tenant_id: str = ""
+    user_id: str = ""
+
+
+class ToolCatalog:
+    """Multi-tenant tool catalog with cascade resolution."""
+
+    def __init__(self) -> None:
+        self._entries: list[CatalogEntry] = []
+
+    def register(self, entry: CatalogEntry) -> None:
+        """Register a tool in the catalog."""
+        self._entries.append(entry)
+
+    def resolve(
+        self, tool_name: str, tenant_id: str = "", user_id: str = "",
+    ) -> CatalogEntry | None:
+        """Resolve a tool by name with cascade: user > tenant > builtin."""
+        candidates: list[CatalogEntry] = []
+        for entry in self._entries:
+            if entry.definition.name != tool_name:
+                continue
+            if entry.scope == "user" and entry.user_id == user_id and user_id:
+                candidates.append(entry)
+            elif entry.scope == "tenant" and entry.tenant_id == tenant_id and tenant_id:
+                candidates.append(entry)
+            elif entry.scope == "builtin":
+                candidates.append(entry)
+
+        if not candidates:
+            return None
+
+        # Sort by scope priority descending — highest wins
+        candidates.sort(key=lambda e: _SCOPE_PRIORITY.get(e.scope, 0), reverse=True)
+        return candidates[0]
+
+    def list_tools(
+        self, tenant_id: str = "", user_id: str = "",
+    ) -> list[CatalogEntry]:
+        """Return all tools visible to this tenant/user, deduplicated by name (cascade)."""
+        seen: dict[str, CatalogEntry] = {}
+        for entry in self._entries:
+            name = entry.definition.name
+            visible = False
+            if entry.scope == "builtin":
+                visible = True
+            elif entry.scope == "tenant" and entry.tenant_id == tenant_id and tenant_id:
+                visible = True
+            elif entry.scope == "user" and entry.user_id == user_id and user_id:
+                visible = True
+
+            if not visible:
+                continue
+
+            existing = seen.get(name)
+            if existing is None or _SCOPE_PRIORITY.get(entry.scope, 0) > _SCOPE_PRIORITY.get(
+                existing.scope, 0
+            ):
+                seen[name] = entry
+
+        return sorted(seen.values(), key=lambda e: e.definition.name)
+
+    def load_plugins(self) -> None:
+        """Discover tools from 'stronghold.tools' entry-point group."""
+        eps = entry_points()
+        group = eps.get("stronghold.tools", []) if isinstance(eps, dict) else eps.select(
+            group="stronghold.tools"
+        )
+        for ep in group:
+            try:
+                tool_fn = ep.load()
+                if hasattr(tool_fn, "_catalog_entry"):
+                    self.register(tool_fn._catalog_entry)
+                    logger.info("Loaded plugin tool: %s", ep.name)
+            except Exception:
+                logger.warning("Failed to load plugin tool: %s", ep.name, exc_info=True)

--- a/src/stronghold/tools/decorator.py
+++ b/src/stronghold/tools/decorator.py
@@ -1,0 +1,67 @@
+"""@tool decorator for registering functions as Stronghold tools."""
+
+from __future__ import annotations
+
+import inspect
+from typing import Any, Callable
+
+from stronghold.tools.catalog import CatalogEntry
+from stronghold.types.tool import ToolDefinition
+
+_REGISTERED_TOOLS: list[CatalogEntry] = []
+
+
+def tool(
+    name: str,
+    *,
+    version: str = "1.0.0",
+    description: str = "",
+    required_permissions: list[str] | None = None,
+) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
+    """Decorator to register a function as a Stronghold tool."""
+
+    def wrapper(fn: Callable[..., Any]) -> Callable[..., Any]:
+        # Build parameters from function signature
+        sig = inspect.signature(fn)
+        properties: dict[str, Any] = {}
+        required: list[str] = []
+        for param_name, param in sig.parameters.items():
+            if param_name == "self":
+                continue
+            prop: dict[str, str] = {"type": "string"}
+            if param.annotation != inspect.Parameter.empty:
+                # Resolve string annotations from __future__ annotations
+                ann = param.annotation
+                hints = inspect.get_annotations(fn, eval_str=True)
+                resolved = hints.get(param_name, ann)
+                if resolved is int:
+                    prop = {"type": "integer"}
+                elif resolved is float:
+                    prop = {"type": "number"}
+                elif resolved is bool:
+                    prop = {"type": "boolean"}
+            properties[param_name] = prop
+            if param.default is inspect.Parameter.empty:
+                required.append(param_name)
+
+        definition = ToolDefinition(
+            name=name,
+            description=description or fn.__doc__ or "",
+            parameters={
+                "type": "object",
+                "properties": properties,
+                "required": required,
+            },
+        )
+
+        entry = CatalogEntry(definition=definition, version=version, scope="builtin")
+        fn._catalog_entry = entry  # type: ignore[attr-defined]
+        _REGISTERED_TOOLS.append(entry)
+        return fn
+
+    return wrapper
+
+
+def get_decorated_tools() -> list[CatalogEntry]:
+    """Return all tools registered via the @tool decorator."""
+    return list(_REGISTERED_TOOLS)

--- a/tests/tools/test_catalog.py
+++ b/tests/tools/test_catalog.py
@@ -1,0 +1,114 @@
+"""Tests for ToolCatalog (ADR-K8S-021)."""
+
+from __future__ import annotations
+
+from stronghold.tools.catalog import CatalogEntry, ToolCatalog
+from stronghold.tools.decorator import get_decorated_tools, tool
+from stronghold.types.tool import ToolDefinition
+
+
+def _entry(name: str, scope: str = "builtin", tenant_id: str = "", user_id: str = "", version: str = "1.0.0") -> CatalogEntry:
+    return CatalogEntry(
+        definition=ToolDefinition(name=name),
+        version=version,
+        scope=scope,
+        tenant_id=tenant_id,
+        user_id=user_id,
+    )
+
+
+def test_register_and_resolve_builtin() -> None:
+    cat = ToolCatalog()
+    cat.register(_entry("web_search"))
+    result = cat.resolve("web_search")
+    assert result is not None
+    assert result.definition.name == "web_search"
+
+
+def test_resolve_unknown_returns_none() -> None:
+    cat = ToolCatalog()
+    assert cat.resolve("nonexistent") is None
+
+
+def test_tenant_override_shadows_builtin() -> None:
+    cat = ToolCatalog()
+    cat.register(_entry("shell", scope="builtin"))
+    cat.register(_entry("shell", scope="tenant", tenant_id="acme"))
+    result = cat.resolve("shell", tenant_id="acme")
+    assert result is not None
+    assert result.scope == "tenant"
+    assert result.tenant_id == "acme"
+
+
+def test_user_override_shadows_tenant() -> None:
+    cat = ToolCatalog()
+    cat.register(_entry("shell", scope="builtin"))
+    cat.register(_entry("shell", scope="tenant", tenant_id="acme"))
+    cat.register(_entry("shell", scope="user", tenant_id="acme", user_id="alice"))
+    result = cat.resolve("shell", tenant_id="acme", user_id="alice")
+    assert result is not None
+    assert result.scope == "user"
+    assert result.user_id == "alice"
+
+
+def test_list_tools_cascaded_dedup() -> None:
+    cat = ToolCatalog()
+    cat.register(_entry("web_search", scope="builtin"))
+    cat.register(_entry("shell", scope="builtin"))
+    cat.register(_entry("shell", scope="tenant", tenant_id="acme"))
+    tools = cat.list_tools(tenant_id="acme")
+    names = [t.definition.name for t in tools]
+    assert sorted(names) == ["shell", "web_search"]
+    shell_entry = next(t for t in tools if t.definition.name == "shell")
+    assert shell_entry.scope == "tenant"
+
+
+def test_list_tools_user_scope() -> None:
+    cat = ToolCatalog()
+    cat.register(_entry("shell", scope="builtin"))
+    cat.register(_entry("shell", scope="user", user_id="alice"))
+    tools = cat.list_tools(user_id="alice")
+    assert len(tools) == 1
+    assert tools[0].scope == "user"
+
+
+def test_semver_stored() -> None:
+    cat = ToolCatalog()
+    cat.register(_entry("my_tool", version="2.1.0"))
+    result = cat.resolve("my_tool")
+    assert result is not None
+    assert result.version == "2.1.0"
+
+
+def test_tenant_tool_not_visible_to_other_tenant() -> None:
+    cat = ToolCatalog()
+    cat.register(_entry("secret_tool", scope="tenant", tenant_id="acme"))
+    result = cat.resolve("secret_tool", tenant_id="other-corp")
+    assert result is None
+
+
+def test_tool_decorator_registers() -> None:
+    initial_count = len(get_decorated_tools())
+
+    @tool("test_ping", version="1.0.0", description="Test ping tool")
+    def ping(target: str) -> str:
+        return f"pong {target}"
+
+    tools = get_decorated_tools()
+    assert len(tools) == initial_count + 1
+    latest = tools[-1]
+    assert latest.definition.name == "test_ping"
+    assert latest.version == "1.0.0"
+    assert "target" in latest.definition.parameters.get("properties", {})
+
+
+def test_tool_decorator_infers_types() -> None:
+    @tool("typed_tool")
+    def typed(count: int, rate: float, active: bool) -> None:
+        pass
+
+    entry = typed._catalog_entry
+    props = entry.definition.parameters["properties"]
+    assert props["count"]["type"] == "integer"
+    assert props["rate"]["type"] == "number"
+    assert props["active"]["type"] == "boolean"


### PR DESCRIPTION
## Summary

- Multi-tenant `ToolCatalog` with cascade resolution: user > tenant > builtin (per ADR-K8S-021)
- `@tool` decorator for registering functions with auto-inferred parameter schemas
- Semver versioning per catalog entry
- Customer plugin discovery via `stronghold.tools` entry-point group
- `CatalogEntry` dataclass with scope, tenant_id, user_id
- 10 tests passing

Refs #960

## Test plan

- [x] Register and resolve builtin tool
- [x] Tenant override shadows builtin
- [x] User override shadows tenant
- [x] list_tools returns cascaded, deduplicated set
- [x] Semver stored and retrievable
- [x] Unknown tool returns None
- [x] Tenant isolation (tool not visible to other tenant)
- [x] @tool decorator registers + infers types