### PR TITLE
feat(persistence): VaultClient protocol + FakeVaultClient + 14 tests (#958)

### DIFF
--- a/src/stronghold/protocols/vault.py
+++ b/src/stronghold/protocols/vault.py
@@ -1,0 +1,86 @@
+"""Per-user credential vault protocol (ADR-K8S-018).
+
+VaultClient manages per-user secrets in a path-based store (OpenBao/Vault).
+Path convention: ``users/{org_id}/{user_id}/{service}/{key}``
+
+Unlike SecretBackend (which resolves config-time references), VaultClient
+is the runtime interface for tool executors that need per-user credentials
+to act on behalf of individual users (GitHub PATs, JIRA tokens, etc.).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Protocol, runtime_checkable
+
+
+@dataclass(frozen=True)
+class VaultSecret:
+    """A secret value with metadata."""
+
+    value: str
+    service: str
+    key: str
+    version: int | None = None
+
+
+@runtime_checkable
+class VaultClient(Protocol):
+    """Per-user credential vault for tool executors."""
+
+    async def get_user_secret(
+        self, org_id: str, user_id: str, service: str, key: str,
+    ) -> VaultSecret:
+        """Read a per-user secret.
+
+        Raises:
+            LookupError: Secret does not exist at this path.
+            PermissionError: Caller not authorized for this user/org path.
+        """
+        ...
+
+    async def put_user_secret(
+        self, org_id: str, user_id: str, service: str, key: str, value: str,
+    ) -> VaultSecret:
+        """Write or update a per-user secret.
+
+        Returns the written secret with updated version.
+
+        Raises:
+            PermissionError: Caller not authorized.
+        """
+        ...
+
+    async def delete_user_secret(
+        self, org_id: str, user_id: str, service: str, key: str,
+    ) -> None:
+        """Delete a per-user secret.
+
+        Idempotent — deleting a non-existent secret is not an error.
+
+        Raises:
+            PermissionError: Caller not authorized.
+        """
+        ...
+
+    async def list_user_services(
+        self, org_id: str, user_id: str,
+    ) -> list[str]:
+        """List services that have stored secrets for this user.
+
+        Returns an empty list if the user has no secrets.
+        """
+        ...
+
+    async def revoke_user(
+        self, org_id: str, user_id: str,
+    ) -> int:
+        """Revoke all secrets for a user (e.g., on offboarding).
+
+        Returns the count of secrets deleted.
+        """
+        ...
+
+    async def close(self) -> None:
+        """Release connections. Idempotent."""
+        ...

--- a/tests/fakes.py
+++ b/tests/fakes.py
@@ -503,6 +503,76 @@ class FakeToolPolicy:
     ) -> bool:
         self.task_checks.append((user_id, org_id, agent_name))
         return (user_id, org_id, agent_name) not in self._denied_tasks
+class FakeVaultClient:
+    """In-memory vault for tests (ADR-K8S-018).
+
+    Stores secrets as ``{org_id}/{user_id}/{service}/{key}`` -> value.
+    """
+
+    def __init__(self) -> None:
+        self._store: dict[str, str] = {}
+        self._version: dict[str, int] = {}
+
+    def _path(self, org_id: str, user_id: str, service: str, key: str) -> str:
+        return f"{org_id}/{user_id}/{service}/{key}"
+
+    async def get_user_secret(
+        self, org_id: str, user_id: str, service: str, key: str,
+    ) -> Any:
+        from stronghold.protocols.vault import VaultSecret
+
+        path = self._path(org_id, user_id, service, key)
+        if path not in self._store:
+            raise LookupError(f"No secret at {path}")
+        return VaultSecret(
+            value=self._store[path],
+            service=service,
+            key=key,
+            version=self._version.get(path),
+        )
+
+    async def put_user_secret(
+        self, org_id: str, user_id: str, service: str, key: str, value: str,
+    ) -> Any:
+        from stronghold.protocols.vault import VaultSecret
+
+        path = self._path(org_id, user_id, service, key)
+        ver = self._version.get(path, 0) + 1
+        self._store[path] = value
+        self._version[path] = ver
+        return VaultSecret(value=value, service=service, key=key, version=ver)
+
+    async def delete_user_secret(
+        self, org_id: str, user_id: str, service: str, key: str,
+    ) -> None:
+        path = self._path(org_id, user_id, service, key)
+        self._store.pop(path, None)
+        self._version.pop(path, None)
+
+    async def list_user_services(
+        self, org_id: str, user_id: str,
+    ) -> list[str]:
+        prefix = f"{org_id}/{user_id}/"
+        services = set()
+        for k in self._store:
+            if k.startswith(prefix):
+                parts = k[len(prefix):].split("/")
+                if parts:
+                    services.add(parts[0])
+        return sorted(services)
+
+    async def revoke_user(
+        self, org_id: str, user_id: str,
+    ) -> int:
+        prefix = f"{org_id}/{user_id}/"
+        to_delete = [k for k in self._store if k.startswith(prefix)]
+        for k in to_delete:
+            del self._store[k]
+            self._version.pop(k, None)
+        return len(to_delete)
+
+    async def close(self) -> None:
+        pass
 
 
 # ── Test container factory ───────────────────────────────────────────

--- a/tests/security/test_vault_client.py
+++ b/tests/security/test_vault_client.py
@@ -1,0 +1,109 @@
+"""Tests for the VaultClient protocol and FakeVaultClient (ADR-K8S-018)."""
+
+from __future__ import annotations
+
+import pytest
+
+from stronghold.protocols.vault import VaultClient, VaultSecret
+from tests.fakes import FakeVaultClient
+
+
+class TestFakeVaultClientProtocol:
+    def test_satisfies_protocol(self) -> None:
+        assert isinstance(FakeVaultClient(), VaultClient)
+
+
+class TestPutAndGet:
+    async def test_put_then_get(self) -> None:
+        vault = FakeVaultClient()
+        result = await vault.put_user_secret("acme", "alice", "github", "pat", "ghp_test")
+        assert isinstance(result, VaultSecret)
+        assert result.service == "github"
+        assert result.key == "pat"
+        assert result.version == 1
+
+        got = await vault.get_user_secret("acme", "alice", "github", "pat")
+        assert got.value == "ghp_test"
+
+    async def test_put_stores_value(self) -> None:
+        vault = FakeVaultClient()
+        await vault.put_user_secret("acme", "alice", "github", "pat", "ghp_abc123")
+        got = await vault.get_user_secret("acme", "alice", "github", "pat")
+        assert got.value == "ghp_abc123"
+
+    async def test_put_increments_version(self) -> None:
+        vault = FakeVaultClient()
+        r1 = await vault.put_user_secret("acme", "alice", "github", "pat", "v1")
+        r2 = await vault.put_user_secret("acme", "alice", "github", "pat", "v2")
+        assert r1.version == 1
+        assert r2.version == 2
+
+    async def test_get_nonexistent_raises_lookup(self) -> None:
+        vault = FakeVaultClient()
+        with pytest.raises(LookupError):
+            await vault.get_user_secret("acme", "alice", "github", "pat")
+
+
+class TestDelete:
+    async def test_delete_removes_secret(self) -> None:
+        vault = FakeVaultClient()
+        await vault.put_user_secret("acme", "alice", "github", "pat", "ghp_abc")
+        await vault.delete_user_secret("acme", "alice", "github", "pat")
+        with pytest.raises(LookupError):
+            await vault.get_user_secret("acme", "alice", "github", "pat")
+
+    async def test_delete_nonexistent_is_idempotent(self) -> None:
+        vault = FakeVaultClient()
+        await vault.delete_user_secret("acme", "alice", "github", "pat")
+
+
+class TestListServices:
+    async def test_empty_user(self) -> None:
+        vault = FakeVaultClient()
+        assert await vault.list_user_services("acme", "alice") == []
+
+    async def test_lists_unique_services(self) -> None:
+        vault = FakeVaultClient()
+        await vault.put_user_secret("acme", "alice", "github", "pat", "g1")
+        await vault.put_user_secret("acme", "alice", "github", "token", "g2")
+        await vault.put_user_secret("acme", "alice", "jira", "api_key", "j1")
+        services = await vault.list_user_services("acme", "alice")
+        assert services == ["github", "jira"]
+
+    async def test_other_user_not_visible(self) -> None:
+        vault = FakeVaultClient()
+        await vault.put_user_secret("acme", "alice", "github", "pat", "g1")
+        assert await vault.list_user_services("acme", "bob") == []
+
+
+class TestRevokeUser:
+    async def test_revoke_deletes_all(self) -> None:
+        vault = FakeVaultClient()
+        await vault.put_user_secret("acme", "alice", "github", "pat", "g1")
+        await vault.put_user_secret("acme", "alice", "jira", "key", "j1")
+        count = await vault.revoke_user("acme", "alice")
+        assert count == 2
+        assert await vault.list_user_services("acme", "alice") == []
+
+    async def test_revoke_empty_returns_zero(self) -> None:
+        vault = FakeVaultClient()
+        assert await vault.revoke_user("acme", "alice") == 0
+
+    async def test_revoke_does_not_affect_other_users(self) -> None:
+        vault = FakeVaultClient()
+        await vault.put_user_secret("acme", "alice", "github", "pat", "a")
+        await vault.put_user_secret("acme", "bob", "github", "pat", "b")
+        await vault.revoke_user("acme", "alice")
+        got = await vault.get_user_secret("acme", "bob", "github", "pat")
+        assert got.value == "b"
+
+
+class TestTenantIsolation:
+    async def test_different_orgs_isolated(self) -> None:
+        vault = FakeVaultClient()
+        await vault.put_user_secret("acme", "alice", "github", "pat", "acme_token")
+        await vault.put_user_secret("evil", "alice", "github", "pat", "evil_token")
+        acme = await vault.get_user_secret("acme", "alice", "github", "pat")
+        evil = await vault.get_user_secret("evil", "alice", "github", "pat")
+        assert acme.value == "acme_token"
+        assert evil.value == "evil_token"


### PR DESCRIPTION
## Summary
- `VaultClient` protocol for per-user credential storage (ADR-K8S-018)
- `VaultSecret` dataclass with value, service, key, version
- `FakeVaultClient` in `tests/fakes.py` — dict-backed test double
- Path convention: `{org_id}/{user_id}/{service}/{key}`
- Operations: get, put, delete, list_services, revoke_user (offboarding), close

## Test plan
- [x] 14/14 new tests pass
- [x] Protocol compliance verified (`isinstance(FakeVaultClient(), VaultClient)`)
- [x] Tenant isolation, version tracking, idempotent delete tested

Closes #958