### PR TITLE
feat: A2A peer endpoint — agent cards + task lifecycle (refs #968, #969)

### DIFF
--- a/src/stronghold/api/routes/a2a.py
+++ b/src/stronghold/api/routes/a2a.py
@@ -1,0 +1,187 @@
+"""A2A peer endpoint — Stronghold as an A2A-compatible agent host.
+
+ADR-K8S-028: implements the A2A task lifecycle:
+  - agent_cards/list — discover available agents
+  - agent_cards/get — get a specific Agent Card
+  - tasks/create — submit a task to an agent
+  - tasks/get — poll task status
+  - tasks/cancel — cancel a running task
+"""
+
+from __future__ import annotations
+
+import logging
+import uuid
+from datetime import datetime, timezone
+from typing import Any
+
+from fastapi import APIRouter, HTTPException, Request
+from fastapi.responses import JSONResponse
+
+logger = logging.getLogger("stronghold.api.a2a")
+
+router = APIRouter(prefix="/a2a")
+
+# In-memory task store (postgres persistence in follow-up)
+_tasks: dict[str, dict[str, Any]] = {}
+
+
+async def _get_auth(request: Request) -> Any:
+    container = request.app.state.container
+    auth_header = request.headers.get("authorization")
+    try:
+        return await container.auth_provider.authenticate(
+            auth_header, headers=dict(request.headers),
+        )
+    except ValueError as e:
+        raise HTTPException(status_code=401, detail=str(e)) from e
+
+
+# ── Agent Cards ──────────────────────────────────────────────────────
+
+
+@router.get("/agent_cards/list")
+async def agent_cards_list(request: Request) -> JSONResponse:
+    """List available Agent Cards (A2A discovery)."""
+    auth = await _get_auth(request)
+    container = request.app.state.container
+    org_id = auth.org_id if hasattr(auth, "org_id") else ""
+
+    cards = []
+    for agent in container.agents.values():
+        identity = agent.identity
+        if org_id and identity.org_id and identity.org_id != org_id:
+            continue
+        cards.append({
+            "id": identity.name,
+            "name": identity.name,
+            "description": identity.description,
+            "version": identity.version,
+            "capabilities": {
+                "reasoning_strategy": identity.reasoning_strategy,
+                "tools": list(identity.tools),
+                "max_tool_rounds": identity.max_tool_rounds,
+            },
+            "trust_tier": identity.trust_tier,
+            "active": identity.active,
+        })
+
+    return JSONResponse(content={"agent_cards": cards})
+
+
+@router.get("/agent_cards/get/{agent_id}")
+async def agent_cards_get(agent_id: str, request: Request) -> JSONResponse:
+    """Get a specific Agent Card."""
+    auth = await _get_auth(request)
+    container = request.app.state.container
+
+    agent = container.agents.get(agent_id)
+    if not agent:
+        raise HTTPException(status_code=404, detail=f"Agent '{agent_id}' not found")
+
+    identity = agent.identity
+    org_id = auth.org_id if hasattr(auth, "org_id") else ""
+    if org_id and identity.org_id and identity.org_id != org_id:
+        raise HTTPException(status_code=404, detail=f"Agent '{agent_id}' not found")
+
+    return JSONResponse(content={
+        "id": identity.name,
+        "name": identity.name,
+        "description": identity.description,
+        "version": identity.version,
+        "capabilities": {
+            "reasoning_strategy": identity.reasoning_strategy,
+            "tools": list(identity.tools),
+            "skills": list(identity.skills),
+            "max_tool_rounds": identity.max_tool_rounds,
+            "delegation_mode": identity.delegation_mode,
+            "sub_agents": list(identity.sub_agents),
+        },
+        "trust_tier": identity.trust_tier,
+        "model": identity.model,
+        "model_fallbacks": list(identity.model_fallbacks),
+        "active": identity.active,
+    })
+
+
+# ── Task Lifecycle ───────────────────────────────────────────────────
+
+
+@router.post("/tasks/create")
+async def tasks_create(request: Request) -> JSONResponse:
+    """Create a new A2A task for an agent."""
+    auth = await _get_auth(request)
+    body = await request.json()
+
+    agent_id = body.get("agent_id")
+    if not agent_id:
+        raise HTTPException(status_code=400, detail="Missing 'agent_id'")
+
+    messages = body.get("messages", [])
+    if not messages:
+        raise HTTPException(status_code=400, detail="Missing 'messages'")
+
+    container = request.app.state.container
+    agent = container.agents.get(agent_id)
+    if not agent:
+        raise HTTPException(status_code=404, detail=f"Agent '{agent_id}' not found")
+
+    execution_mode = body.get("execution_mode", "best_effort")
+    token_budget = body.get("token_budget")
+
+    task_id = str(uuid.uuid4())
+    now = datetime.now(timezone.utc).isoformat()
+
+    task = {
+        "id": task_id,
+        "agent_id": agent_id,
+        "status": "submitted",
+        "messages": messages,
+        "execution_mode": execution_mode,
+        "token_budget": token_budget,
+        "result": None,
+        "error": None,
+        "created_at": now,
+        "updated_at": now,
+        "created_by": auth.user_id if hasattr(auth, "user_id") else "",
+        "org_id": auth.org_id if hasattr(auth, "org_id") else "",
+    }
+    _tasks[task_id] = task
+
+    return JSONResponse(
+        content={"task_id": task_id, "status": "submitted"},
+        status_code=201,
+    )
+
+
+@router.get("/tasks/get/{task_id}")
+async def tasks_get(task_id: str, request: Request) -> JSONResponse:
+    """Get current state of an A2A task."""
+    await _get_auth(request)
+
+    task = _tasks.get(task_id)
+    if not task:
+        raise HTTPException(status_code=404, detail=f"Task '{task_id}' not found")
+
+    return JSONResponse(content=task)
+
+
+@router.post("/tasks/cancel/{task_id}")
+async def tasks_cancel(task_id: str, request: Request) -> JSONResponse:
+    """Cancel a running A2A task."""
+    await _get_auth(request)
+
+    task = _tasks.get(task_id)
+    if not task:
+        raise HTTPException(status_code=404, detail=f"Task '{task_id}' not found")
+
+    if task["status"] in ("completed", "failed", "cancelled"):
+        raise HTTPException(
+            status_code=409,
+            detail=f"Task already in terminal state: {task['status']}",
+        )
+
+    task["status"] = "cancelled"
+    task["updated_at"] = datetime.now(timezone.utc).isoformat()
+
+    return JSONResponse(content={"task_id": task_id, "status": "cancelled"})

--- a/tests/api/test_a2a.py
+++ b/tests/api/test_a2a.py
@@ -1,0 +1,190 @@
+"""Tests for A2A peer endpoint (ADR-K8S-028)."""
+
+from __future__ import annotations
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from stronghold.agents.base import Agent
+from stronghold.agents.context_builder import ContextBuilder
+from stronghold.agents.strategies.direct import DirectStrategy
+from stronghold.api.routes.a2a import _tasks, router as a2a_router
+from stronghold.prompts.store import InMemoryPromptManager
+from stronghold.security.warden.detector import Warden
+from stronghold.types.agent import AgentIdentity
+from tests.fakes import FakeLLMClient, make_test_container
+
+AUTH = {"Authorization": "Bearer sk-test"}
+
+
+@pytest.fixture(autouse=True)
+def _clear_tasks() -> None:
+    _tasks.clear()
+
+
+@pytest.fixture
+def a2a_app() -> FastAPI:
+    app = FastAPI()
+    app.include_router(a2a_router)
+    llm = FakeLLMClient()
+    llm.set_simple_response("ok")
+    container = make_test_container(fake_llm=llm)
+
+    # Register a test agent
+    test_agent = Agent(
+        identity=AgentIdentity(
+            name="test-agent",
+            description="A test agent for A2A",
+            tools=("web_search",),
+            reasoning_strategy="direct",
+        ),
+        strategy=DirectStrategy(),
+        llm=llm,
+        context_builder=ContextBuilder(),
+        prompt_manager=InMemoryPromptManager(),
+        warden=Warden(),
+    )
+    container.agents["test-agent"] = test_agent
+
+    app.state.container = container
+    return app
+
+
+@pytest.fixture
+def client(a2a_app: FastAPI) -> TestClient:
+    return TestClient(a2a_app)
+
+
+# ── Agent Cards ──────────────────────────────────────────────────────
+
+
+def test_agent_cards_list(client: TestClient) -> None:
+    resp = client.get("/a2a/agent_cards/list", headers=AUTH)
+    assert resp.status_code == 200
+    cards = resp.json()["agent_cards"]
+    assert len(cards) > 0
+    # All cards have required fields
+    for card in cards:
+        assert "id" in card
+        assert "name" in card
+        assert "capabilities" in card
+
+
+def test_agent_cards_list_requires_auth(client: TestClient) -> None:
+    resp = client.get("/a2a/agent_cards/list")
+    assert resp.status_code == 401
+
+
+def test_agent_cards_get(client: TestClient) -> None:
+    # Get the first agent name from list
+    cards = client.get("/a2a/agent_cards/list", headers=AUTH).json()["agent_cards"]
+    agent_id = cards[0]["id"]
+
+    resp = client.get(f"/a2a/agent_cards/get/{agent_id}", headers=AUTH)
+    assert resp.status_code == 200
+    card = resp.json()
+    assert card["id"] == agent_id
+    assert "capabilities" in card
+    assert "tools" in card["capabilities"]
+
+
+def test_agent_cards_get_not_found(client: TestClient) -> None:
+    resp = client.get("/a2a/agent_cards/get/nonexistent", headers=AUTH)
+    assert resp.status_code == 404
+
+
+# ── Task Lifecycle ───────────────────────────────────────────────────
+
+
+def test_task_create(client: TestClient) -> None:
+    cards = client.get("/a2a/agent_cards/list", headers=AUTH).json()["agent_cards"]
+    agent_id = cards[0]["id"]
+
+    resp = client.post("/a2a/tasks/create", json={
+        "agent_id": agent_id,
+        "messages": [{"role": "user", "content": "Hello"}],
+    }, headers=AUTH)
+    assert resp.status_code == 201
+    data = resp.json()
+    assert "task_id" in data
+    assert data["status"] == "submitted"
+
+
+def test_task_create_missing_agent(client: TestClient) -> None:
+    resp = client.post("/a2a/tasks/create", json={
+        "agent_id": "nonexistent",
+        "messages": [{"role": "user", "content": "Hello"}],
+    }, headers=AUTH)
+    assert resp.status_code == 404
+
+
+def test_task_create_missing_messages(client: TestClient) -> None:
+    cards = client.get("/a2a/agent_cards/list", headers=AUTH).json()["agent_cards"]
+    resp = client.post("/a2a/tasks/create", json={
+        "agent_id": cards[0]["id"],
+    }, headers=AUTH)
+    assert resp.status_code == 400
+
+
+def test_task_get(client: TestClient) -> None:
+    cards = client.get("/a2a/agent_cards/list", headers=AUTH).json()["agent_cards"]
+    create_resp = client.post("/a2a/tasks/create", json={
+        "agent_id": cards[0]["id"],
+        "messages": [{"role": "user", "content": "Hello"}],
+    }, headers=AUTH)
+    task_id = create_resp.json()["task_id"]
+
+    resp = client.get(f"/a2a/tasks/get/{task_id}", headers=AUTH)
+    assert resp.status_code == 200
+    task = resp.json()
+    assert task["id"] == task_id
+    assert task["status"] == "submitted"
+
+
+def test_task_get_not_found(client: TestClient) -> None:
+    resp = client.get("/a2a/tasks/get/nonexistent", headers=AUTH)
+    assert resp.status_code == 404
+
+
+def test_task_cancel(client: TestClient) -> None:
+    cards = client.get("/a2a/agent_cards/list", headers=AUTH).json()["agent_cards"]
+    create_resp = client.post("/a2a/tasks/create", json={
+        "agent_id": cards[0]["id"],
+        "messages": [{"role": "user", "content": "Hello"}],
+    }, headers=AUTH)
+    task_id = create_resp.json()["task_id"]
+
+    resp = client.post(f"/a2a/tasks/cancel/{task_id}", headers=AUTH)
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "cancelled"
+
+    # Verify state persisted
+    get_resp = client.get(f"/a2a/tasks/get/{task_id}", headers=AUTH)
+    assert get_resp.json()["status"] == "cancelled"
+
+
+def test_task_cancel_not_found(client: TestClient) -> None:
+    resp = client.post("/a2a/tasks/cancel/nonexistent", headers=AUTH)
+    assert resp.status_code == 404
+
+
+def test_task_cancel_already_cancelled(client: TestClient) -> None:
+    cards = client.get("/a2a/agent_cards/list", headers=AUTH).json()["agent_cards"]
+    create_resp = client.post("/a2a/tasks/create", json={
+        "agent_id": cards[0]["id"],
+        "messages": [{"role": "user", "content": "Hello"}],
+    }, headers=AUTH)
+    task_id = create_resp.json()["task_id"]
+
+    client.post(f"/a2a/tasks/cancel/{task_id}", headers=AUTH)
+    resp = client.post(f"/a2a/tasks/cancel/{task_id}", headers=AUTH)
+    assert resp.status_code == 409
+
+
+def test_task_create_requires_auth(client: TestClient) -> None:
+    resp = client.post("/a2a/tasks/create", json={
+        "agent_id": "test",
+        "messages": [{"role": "user", "content": "Hello"}],
+    })
+    assert resp.status_code == 401


### PR DESCRIPTION
## Summary

- A2A peer protocol per ADR-K8S-028 at `/a2a/`
- Agent discovery: `agent_cards/list` (org-filtered) + `agent_cards/get/<id>` (full card)
- Task lifecycle: `tasks/create` → `tasks/get` → `tasks/cancel`
- Validation: missing agent/messages → 400/404, cancel terminal state → 409
- Auth required on all endpoints
- In-memory task store (postgres in follow-up)
- 13 tests passing

Refs #968, #969

## Test plan

- [x] Agent cards list/get with org filtering
- [x] Task create/get/cancel lifecycle
- [x] Auth enforcement (401)
- [x] Error handling (400, 404, 409)