### PR TITLE
feat(mcp): MCP server endpoint — tools, prompts, resources (#963)

### DIFF
--- a/src/stronghold/agents/catalog.py
+++ b/src/stronghold/agents/catalog.py
@@ -1,0 +1,136 @@
+"""Agent Catalog — A2A Agent Card registry with multi-tenant cascade.
+
+ADR-K8S-027: agents registered as Agent Cards with version, tenant scope,
+trust tier, and priority tier. Cascade resolution: user > tenant > builtin.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from typing import Any
+
+from stronghold.types.agent import AgentIdentity
+
+logger = logging.getLogger("stronghold.agents.catalog")
+
+_SCOPE_PRIORITY = {"builtin": 0, "tenant": 1, "user": 2}
+
+
+@dataclass(frozen=True)
+class AgentCard:
+    """A2A Agent Card — portable agent description."""
+
+    id: str
+    name: str
+    description: str = ""
+    version: str = "1.0.0"
+    reasoning_strategy: str = "direct"
+    tools: tuple[str, ...] = ()
+    skills: tuple[str, ...] = ()
+    trust_tier: str = "t2"
+    priority_tier: str = "P2"
+    max_tool_rounds: int = 3
+    delegation_mode: str = "none"
+    sub_agents: tuple[str, ...] = ()
+    model: str = "auto"
+    model_fallbacks: tuple[str, ...] = ()
+    active: bool = True
+    scope: str = "builtin"
+    tenant_id: str = ""
+    user_id: str = ""
+
+    @classmethod
+    def from_identity(cls, identity: AgentIdentity, scope: str = "builtin",
+                      tenant_id: str = "", user_id: str = "") -> AgentCard:
+        return cls(
+            id=identity.name,
+            name=identity.name,
+            description=identity.description,
+            version=identity.version,
+            reasoning_strategy=identity.reasoning_strategy,
+            tools=identity.tools,
+            skills=identity.skills,
+            trust_tier=identity.trust_tier,
+            priority_tier=getattr(identity, "priority_tier", "P2"),
+            max_tool_rounds=identity.max_tool_rounds,
+            delegation_mode=identity.delegation_mode,
+            sub_agents=identity.sub_agents,
+            model=identity.model,
+            model_fallbacks=identity.model_fallbacks,
+            active=identity.active,
+            scope=scope,
+            tenant_id=tenant_id,
+            user_id=user_id,
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "id": self.id,
+            "name": self.name,
+            "description": self.description,
+            "version": self.version,
+            "capabilities": {
+                "reasoning_strategy": self.reasoning_strategy,
+                "tools": list(self.tools),
+                "skills": list(self.skills),
+                "max_tool_rounds": self.max_tool_rounds,
+                "delegation_mode": self.delegation_mode,
+                "sub_agents": list(self.sub_agents),
+            },
+            "trust_tier": self.trust_tier,
+            "priority_tier": self.priority_tier,
+            "model": self.model,
+            "active": self.active,
+        }
+
+
+class AgentCatalog:
+    """Multi-tenant agent catalog with cascade resolution."""
+
+    def __init__(self) -> None:
+        self._cards: list[AgentCard] = []
+
+    def register(self, card: AgentCard) -> None:
+        self._cards.append(card)
+
+    def resolve(self, agent_id: str, tenant_id: str = "", user_id: str = "") -> AgentCard | None:
+        candidates: list[AgentCard] = []
+        for card in self._cards:
+            if card.id != agent_id:
+                continue
+            if card.scope == "user" and card.user_id == user_id and user_id:
+                candidates.append(card)
+            elif card.scope == "tenant" and card.tenant_id == tenant_id and tenant_id:
+                candidates.append(card)
+            elif card.scope == "builtin":
+                candidates.append(card)
+        if not candidates:
+            return None
+        candidates.sort(key=lambda c: _SCOPE_PRIORITY.get(c.scope, 0), reverse=True)
+        return candidates[0]
+
+    def list_agents(self, tenant_id: str = "", user_id: str = "") -> list[AgentCard]:
+        seen: dict[str, AgentCard] = {}
+        for card in self._cards:
+            visible = False
+            if card.scope == "builtin":
+                visible = True
+            elif card.scope == "tenant" and card.tenant_id == tenant_id and tenant_id:
+                visible = True
+            elif card.scope == "user" and card.user_id == user_id and user_id:
+                visible = True
+            if not visible:
+                continue
+            existing = seen.get(card.id)
+            if existing is None or _SCOPE_PRIORITY.get(card.scope, 0) > _SCOPE_PRIORITY.get(
+                existing.scope, 0
+            ):
+                seen[card.id] = card
+        return sorted(seen.values(), key=lambda c: c.name)
+
+    def list_by_trust_tier(self, tier: str, **kwargs: str) -> list[AgentCard]:
+        return [c for c in self.list_agents(**kwargs) if c.trust_tier == tier]
+
+    def list_by_priority_tier(self, tier: str, **kwargs: str) -> list[AgentCard]:
+        return [c for c in self.list_agents(**kwargs) if c.priority_tier == tier]

--- a/src/stronghold/security/task_policy.py
+++ b/src/stronghold/security/task_policy.py
@@ -1,0 +1,106 @@
+"""Task acceptance policy — Casbin gate for A2A task creation.
+
+ADR-K8S-030: policy surface at the A2A boundary for task creation
+gating with budget enforcement integrated with six-tier priorities.
+
+Evaluates: (user, org, agent, "task_create") → allow/deny
+Budget rules: (user, org, budget_tier, "budget") → allow/deny
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Protocol, runtime_checkable
+
+logger = logging.getLogger("stronghold.security.task_policy")
+
+
+@runtime_checkable
+class TaskAcceptancePolicy(Protocol):
+    """Protocol for task creation policy enforcement."""
+
+    def check_task_creation(
+        self, user_id: str, org_id: str, agent_name: str,
+    ) -> bool: ...
+
+    def check_budget(
+        self, user_id: str, org_id: str, priority_tier: str,
+        token_budget: float | None, cost_budget: float | None,
+        wall_clock_seconds: float | None,
+    ) -> bool: ...
+
+
+class InMemoryTaskAcceptancePolicy:
+    """In-memory task acceptance policy with configurable limits.
+
+    Default: allow all task creation, enforce budget limits per priority tier.
+    """
+
+    def __init__(self) -> None:
+        self._denied_agents: set[tuple[str, str, str]] = set()  # (user, org, agent)
+        self._budget_limits: dict[str, dict[str, float]] = {
+            # Default per-tier budget limits
+            "P0": {"max_tokens": 100_000, "max_cost": 10.0, "max_seconds": 300},
+            "P1": {"max_tokens": 50_000, "max_cost": 5.0, "max_seconds": 600},
+            "P2": {"max_tokens": 200_000, "max_cost": 20.0, "max_seconds": 3600},
+            "P3": {"max_tokens": 100_000, "max_cost": 10.0, "max_seconds": 1800},
+            "P4": {"max_tokens": 500_000, "max_cost": 50.0, "max_seconds": 7200},
+            "P5": {"max_tokens": 1_000_000, "max_cost": 100.0, "max_seconds": 14400},
+        }
+
+    def deny_agent(self, user_id: str, org_id: str, agent_name: str) -> None:
+        self._denied_agents.add((user_id, org_id, agent_name))
+
+    def set_budget_limit(self, tier: str, max_tokens: float | None = None,
+                         max_cost: float | None = None, max_seconds: float | None = None) -> None:
+        limits = self._budget_limits.setdefault(tier, {})
+        if max_tokens is not None:
+            limits["max_tokens"] = max_tokens
+        if max_cost is not None:
+            limits["max_cost"] = max_cost
+        if max_seconds is not None:
+            limits["max_seconds"] = max_seconds
+
+    def check_task_creation(
+        self, user_id: str, org_id: str, agent_name: str,
+    ) -> bool:
+        if (user_id, org_id, agent_name) in self._denied_agents:
+            logger.warning(
+                "Task creation DENIED: user=%s org=%s agent=%s",
+                user_id, org_id, agent_name,
+            )
+            return False
+        return True
+
+    def check_budget(
+        self, user_id: str, org_id: str, priority_tier: str,
+        token_budget: float | None = None,
+        cost_budget: float | None = None,
+        wall_clock_seconds: float | None = None,
+    ) -> bool:
+        limits = self._budget_limits.get(priority_tier, {})
+        if not limits:
+            return True
+
+        if token_budget is not None and token_budget > limits.get("max_tokens", float("inf")):
+            logger.warning(
+                "Budget DENIED: user=%s org=%s tier=%s tokens=%s > max=%s",
+                user_id, org_id, priority_tier, token_budget, limits["max_tokens"],
+            )
+            return False
+
+        if cost_budget is not None and cost_budget > limits.get("max_cost", float("inf")):
+            logger.warning(
+                "Budget DENIED: user=%s org=%s tier=%s cost=%s > max=%s",
+                user_id, org_id, priority_tier, cost_budget, limits["max_cost"],
+            )
+            return False
+
+        if wall_clock_seconds is not None and wall_clock_seconds > limits.get("max_seconds", float("inf")):
+            logger.warning(
+                "Budget DENIED: user=%s org=%s tier=%s seconds=%s > max=%s",
+                user_id, org_id, priority_tier, wall_clock_seconds, limits["max_seconds"],
+            )
+            return False
+
+        return True

--- a/tests/agents/test_agent_catalog.py
+++ b/tests/agents/test_agent_catalog.py
@@ -1,0 +1,104 @@
+"""Tests for AgentCatalog (ADR-K8S-027)."""
+
+from __future__ import annotations
+
+from stronghold.agents.catalog import AgentCard, AgentCatalog
+from stronghold.types.agent import AgentIdentity
+
+
+def _card(name: str, scope: str = "builtin", tenant_id: str = "", user_id: str = "",
+          trust_tier: str = "t1", priority_tier: str = "P2") -> AgentCard:
+    return AgentCard(
+        id=name, name=name, description=f"{name} agent",
+        scope=scope, tenant_id=tenant_id, user_id=user_id,
+        trust_tier=trust_tier, priority_tier=priority_tier,
+    )
+
+
+def test_register_and_resolve() -> None:
+    cat = AgentCatalog()
+    cat.register(_card("ranger"))
+    result = cat.resolve("ranger")
+    assert result is not None
+    assert result.name == "ranger"
+
+
+def test_resolve_unknown() -> None:
+    assert AgentCatalog().resolve("nonexistent") is None
+
+
+def test_tenant_override() -> None:
+    cat = AgentCatalog()
+    cat.register(_card("ranger", scope="builtin"))
+    cat.register(_card("ranger", scope="tenant", tenant_id="acme"))
+    result = cat.resolve("ranger", tenant_id="acme")
+    assert result is not None
+    assert result.scope == "tenant"
+
+
+def test_user_override() -> None:
+    cat = AgentCatalog()
+    cat.register(_card("ranger", scope="builtin"))
+    cat.register(_card("ranger", scope="tenant", tenant_id="acme"))
+    cat.register(_card("ranger", scope="user", user_id="alice"))
+    result = cat.resolve("ranger", user_id="alice")
+    assert result is not None
+    assert result.scope == "user"
+
+
+def test_list_agents_cascaded() -> None:
+    cat = AgentCatalog()
+    cat.register(_card("ranger"))
+    cat.register(_card("scribe"))
+    cat.register(_card("scribe", scope="tenant", tenant_id="acme"))
+    agents = cat.list_agents(tenant_id="acme")
+    names = [a.name for a in agents]
+    assert sorted(names) == ["ranger", "scribe"]
+    scribe = next(a for a in agents if a.name == "scribe")
+    assert scribe.scope == "tenant"
+
+
+def test_tenant_isolation() -> None:
+    cat = AgentCatalog()
+    cat.register(_card("secret-agent", scope="tenant", tenant_id="acme"))
+    assert cat.resolve("secret-agent", tenant_id="evil") is None
+
+
+def test_list_by_trust_tier() -> None:
+    cat = AgentCatalog()
+    cat.register(_card("arbiter", trust_tier="t0"))
+    cat.register(_card("ranger", trust_tier="t1"))
+    cat.register(_card("custom", trust_tier="t2"))
+    assert len(cat.list_by_trust_tier("t0")) == 1
+    assert len(cat.list_by_trust_tier("t1")) == 1
+
+
+def test_list_by_priority_tier() -> None:
+    cat = AgentCatalog()
+    cat.register(_card("arbiter", priority_tier="P1"))
+    cat.register(_card("mason", priority_tier="P5"))
+    cat.register(_card("ranger", priority_tier="P1"))
+    assert len(cat.list_by_priority_tier("P1")) == 2
+    assert len(cat.list_by_priority_tier("P5")) == 1
+
+
+def test_from_identity() -> None:
+    identity = AgentIdentity(
+        name="artificer", version="2.0.0", description="Code agent",
+        tools=("shell", "git"), trust_tier="t1",
+    )
+    card = AgentCard.from_identity(identity)
+    assert card.id == "artificer"
+    assert card.version == "2.0.0"
+    assert card.tools == ("shell", "git")
+    assert card.trust_tier == "t1"
+    assert card.scope == "builtin"
+
+
+def test_to_dict() -> None:
+    card = _card("ranger", trust_tier="t1", priority_tier="P1")
+    d = card.to_dict()
+    assert d["id"] == "ranger"
+    assert d["trust_tier"] == "t1"
+    assert d["priority_tier"] == "P1"
+    assert "tools" in d["capabilities"]

--- a/tests/security/test_task_policy.py
+++ b/tests/security/test_task_policy.py
@@ -1,0 +1,74 @@
+"""Tests for TaskAcceptancePolicy (ADR-K8S-030)."""
+
+from __future__ import annotations
+
+from stronghold.security.task_policy import (
+    InMemoryTaskAcceptancePolicy,
+    TaskAcceptancePolicy,
+)
+
+
+def test_default_allows_task_creation() -> None:
+    p = InMemoryTaskAcceptancePolicy()
+    assert p.check_task_creation("alice", "acme", "artificer") is True
+
+
+def test_deny_agent_blocks() -> None:
+    p = InMemoryTaskAcceptancePolicy()
+    p.deny_agent("mallory", "acme", "forge")
+    assert p.check_task_creation("mallory", "acme", "forge") is False
+    assert p.check_task_creation("alice", "acme", "forge") is True
+
+
+def test_budget_within_limits() -> None:
+    p = InMemoryTaskAcceptancePolicy()
+    assert p.check_budget("alice", "acme", "P2", token_budget=10_000) is True
+    assert p.check_budget("alice", "acme", "P2", cost_budget=5.0) is True
+    assert p.check_budget("alice", "acme", "P2", wall_clock_seconds=1800) is True
+
+
+def test_budget_exceeds_token_limit() -> None:
+    p = InMemoryTaskAcceptancePolicy()
+    # P0 default max_tokens is 100_000
+    assert p.check_budget("alice", "acme", "P0", token_budget=200_000) is False
+
+
+def test_budget_exceeds_cost_limit() -> None:
+    p = InMemoryTaskAcceptancePolicy()
+    # P1 default max_cost is 5.0
+    assert p.check_budget("alice", "acme", "P1", cost_budget=50.0) is False
+
+
+def test_budget_exceeds_wall_clock() -> None:
+    p = InMemoryTaskAcceptancePolicy()
+    # P0 default max_seconds is 300
+    assert p.check_budget("alice", "acme", "P0", wall_clock_seconds=600) is False
+
+
+def test_budget_none_values_pass() -> None:
+    p = InMemoryTaskAcceptancePolicy()
+    assert p.check_budget("alice", "acme", "P2") is True
+
+
+def test_budget_unknown_tier_passes() -> None:
+    p = InMemoryTaskAcceptancePolicy()
+    assert p.check_budget("alice", "acme", "P99", token_budget=999_999) is True
+
+
+def test_custom_budget_limit() -> None:
+    p = InMemoryTaskAcceptancePolicy()
+    p.set_budget_limit("P5", max_tokens=100)
+    assert p.check_budget("alice", "acme", "P5", token_budget=50) is True
+    assert p.check_budget("alice", "acme", "P5", token_budget=200) is False
+
+
+def test_protocol_compliance() -> None:
+    p = InMemoryTaskAcceptancePolicy()
+    assert isinstance(p, TaskAcceptancePolicy)
+
+
+def test_all_tiers_have_defaults() -> None:
+    p = InMemoryTaskAcceptancePolicy()
+    for tier in ("P0", "P1", "P2", "P3", "P4", "P5"):
+        # All tiers should have default limits
+        assert p.check_budget("alice", "acme", tier, token_budget=1) is True


### PR DESCRIPTION
## Summary
- Stronghold as MCP server (ADR-K8S-020 Role 1)
- 6 JSON-RPC endpoints: tools/list, tools/call, prompts/list, prompts/get, resources/list, resources/read
- Full governance integration: Casbin tool policy, tool dispatcher, vault credential injection
- Falls back to legacy `InMemoryToolRegistry` when catalogs aren't wired

## Test plan
- [x] 10/10 tests pass (all 6 endpoints covered)
- [x] Policy filtering verified (tools/list and tools/call)
- [x] 404 handling for unknown tools, prompts, resources

Closes #963