### PR TITLE
chore(coverage): omit Protocol declarations + worker entry point

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,7 +85,18 @@ markers = [
 
 [tool.coverage.run]
 source = ["stronghold"]
-omit = ["src/stronghold/persistence/pg_*.py"]
+omit = [
+  # Postgres persistence uses asyncpg + live schemas; tested via e2e, not unit.
+  "src/stronghold/persistence/pg_*.py",
+  # Protocol definitions: typing.Protocol interface declarations whose method
+  # bodies are `...` / signature stubs and never execute. Concrete impls have
+  # their own coverage. Including these files inflates the miss count with
+  # ~180 lines of unreachable type-check-only declarations.
+  "src/stronghold/protocols/*.py",
+  # CLI entry point: `asyncio.run(main())` wrapper for the worker pod. Tested
+  # by launching the worker in integration, not by pytest. No business logic.
+  "src/stronghold/worker_main.py",
+]
 
 [tool.coverage.report]
 fail_under = 95


### PR DESCRIPTION
## Summary

Drops ~1.76 points of pure-artifact coverage gap by omitting code with no business logic to test.

## The change

\`pyproject.toml\` — \`tool.coverage.run.omit\` now excludes:

- \`src/stronghold/protocols/*.py\` — seven \`typing.Protocol\` interface files (memory, tools, skills, tracing, agents, feedback, embeddings). Method bodies are \`...\` signature stubs; concrete implementations carry the actual tests.
- \`src/stronghold/worker_main.py\` — the CLI entry point (\`asyncio.run(main())\`), exercised by integration launches not pytest.

## Measured impact

| | stmts | miss | cover |
|---|---|---|---|
| before | 11999 | 1973 | 83.58% |
| after | 11617 | 1703 | **85.34%** |

\`fail_under = 95\` is unchanged. This removes dead weight from the denominator so the remaining ~9.7-point gap (Mason tool layer + api/routes/mason.py + cache layer) is visible for focused follow-up work.

## Test plan

- [x] \`pytest tests/ --cov=stronghold\` on full suite (3299 passed, same 6 unrelated pre-existing failures in test_issue_620.py)
- [x] Confirmed \`stmts\` dropped from 11999 → 11617 (382 lines removed)
- [x] Confirmed no concrete implementation of any Protocol was affected