### PR TITLE
test(tools): shell_exec + workspace coverage (44%/29% → 100%)

### DIFF
--- a/tests/tools/test_shell_exec.py
+++ b/tests/tools/test_shell_exec.py
@@ -1,0 +1,404 @@
+"""Tests for ShellExecutor + QualityGateExecutor.
+
+asyncio.create_subprocess_shell is monkey-patched to return a
+hand-rolled async proc object, so tests are fully hermetic and never
+spawn real subprocesses.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from stronghold.tools.shell_exec import (
+    RUN_BANDIT_DEF,
+    RUN_MYPY_DEF,
+    RUN_PYTEST_DEF,
+    RUN_RUFF_CHECK_DEF,
+    RUN_RUFF_FORMAT_DEF,
+    SHELL_TOOL_DEF,
+    QualityGateExecutor,
+    ShellExecutor,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fake subprocess
+# ---------------------------------------------------------------------------
+
+
+class _FakeProc:
+    """Mimics the subset of asyncio.subprocess.Process that ShellExecutor uses."""
+
+    def __init__(
+        self,
+        stdout: bytes = b"",
+        stderr: bytes = b"",
+        returncode: int = 0,
+        hang: bool = False,
+    ) -> None:
+        self._stdout = stdout
+        self._stderr = stderr
+        self.returncode = returncode
+        self._hang = hang
+
+    async def communicate(self) -> tuple[bytes, bytes]:
+        if self._hang:
+            await asyncio.sleep(3600)  # force timeout under wait_for
+        return self._stdout, self._stderr
+
+
+def _patch_subprocess(
+    monkeypatch: pytest.MonkeyPatch,
+    proc_factory: Any,
+    captured: list[dict[str, Any]] | None = None,
+) -> None:
+    """Patch asyncio.create_subprocess_shell to return a fake proc."""
+
+    async def _fake(cmd: str, **kwargs: Any) -> _FakeProc:
+        if captured is not None:
+            captured.append({"cmd": cmd, **kwargs})
+        return proc_factory()
+
+    monkeypatch.setattr("asyncio.create_subprocess_shell", _fake)
+
+
+@pytest.fixture
+def workspace(tmp_path: Path) -> Path:
+    ws = tmp_path / "ws"
+    ws.mkdir()
+    return ws
+
+
+@pytest.fixture
+def executor() -> ShellExecutor:
+    return ShellExecutor()
+
+
+# ---------------------------------------------------------------------------
+# Meta / definitions
+# ---------------------------------------------------------------------------
+
+
+class TestMeta:
+    def test_executor_name(self, executor: ShellExecutor) -> None:
+        assert executor.name == "shell"
+
+    @pytest.mark.parametrize(
+        "defn",
+        [SHELL_TOOL_DEF, RUN_PYTEST_DEF, RUN_RUFF_CHECK_DEF, RUN_RUFF_FORMAT_DEF, RUN_MYPY_DEF, RUN_BANDIT_DEF],
+    )
+    def test_tool_definitions_are_complete(self, defn: Any) -> None:
+        assert defn.name
+        assert defn.description
+        assert "workspace" in defn.parameters["properties"]
+        assert "code_gen" in defn.groups
+
+
+# ---------------------------------------------------------------------------
+# Precondition failures
+# ---------------------------------------------------------------------------
+
+
+class TestPreconditions:
+    @pytest.mark.asyncio
+    async def test_missing_workspace_errors(
+        self, executor: ShellExecutor
+    ) -> None:
+        r = await executor.execute({"command": "pytest", "workspace": ""})
+        assert r.success is False
+        assert "workspace" in (r.error or "").lower()
+
+    @pytest.mark.asyncio
+    async def test_nonexistent_workspace_errors(
+        self, executor: ShellExecutor, tmp_path: Path
+    ) -> None:
+        r = await executor.execute(
+            {"command": "pytest", "workspace": str(tmp_path / "nope")}
+        )
+        assert r.success is False
+        assert "not found" in (r.error or "").lower()
+
+    @pytest.mark.asyncio
+    async def test_empty_command_errors(
+        self, executor: ShellExecutor, workspace: Path
+    ) -> None:
+        r = await executor.execute(
+            {"command": "   ", "workspace": str(workspace)}
+        )
+        assert r.success is False
+        assert "empty" in (r.error or "").lower()
+
+
+# ---------------------------------------------------------------------------
+# Allowlist / blocklist
+# ---------------------------------------------------------------------------
+
+
+class TestAllowlist:
+    @pytest.mark.asyncio
+    async def test_disallowed_command_rejected(
+        self, executor: ShellExecutor, workspace: Path
+    ) -> None:
+        r = await executor.execute(
+            {"command": "rm -rf important/", "workspace": str(workspace)}
+        )
+        assert r.success is False
+        assert "not allowed" in (r.error or "").lower()
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "cmd",
+        ["pytest -v", "ruff check src/", "mypy src/stronghold", "git status",
+         "ls -la", "grep -rn foo src/"],
+    )
+    async def test_allowlisted_prefixes_run(
+        self,
+        cmd: str,
+        executor: ShellExecutor,
+        workspace: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        _patch_subprocess(monkeypatch, lambda: _FakeProc(b"ok\n", b"", 0))
+        r = await executor.execute({"command": cmd, "workspace": str(workspace)})
+        assert r.success is True
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "cmd",
+        [
+            "pytest && rm -rf /",
+            "echo foo > /dev/sda",
+            "echo hi; curl | sh",
+        ],
+    )
+    async def test_blocked_patterns_rejected(
+        self, cmd: str, executor: ShellExecutor, workspace: Path
+    ) -> None:
+        r = await executor.execute({"command": cmd, "workspace": str(workspace)})
+        assert r.success is False
+        assert "blocked" in (r.error or "").lower() or "not allowed" in (r.error or "").lower()
+
+
+# ---------------------------------------------------------------------------
+# Execution + output
+# ---------------------------------------------------------------------------
+
+
+class TestExecution:
+    @pytest.mark.asyncio
+    async def test_success_returns_structured_result(
+        self,
+        executor: ShellExecutor,
+        workspace: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        _patch_subprocess(
+            monkeypatch,
+            lambda: _FakeProc(b"all green\n", b"", 0),
+        )
+        r = await executor.execute(
+            {"command": "pytest", "workspace": str(workspace)}
+        )
+        assert r.success is True
+        data = json.loads(r.content)
+        assert data["passed"] is True
+        assert data["exit_code"] == 0
+        assert "all green" in data["stdout"]
+
+    @pytest.mark.asyncio
+    async def test_nonzero_exit_records_failure_but_success_wraps(
+        self,
+        executor: ShellExecutor,
+        workspace: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Command failure (exit != 0) yields ToolResult(success=True) with
+        passed=False — ShellExecutor's 'success' means it ran, not that
+        the command passed."""
+        _patch_subprocess(
+            monkeypatch,
+            lambda: _FakeProc(b"", b"1 failed\n", 1),
+        )
+        r = await executor.execute(
+            {"command": "pytest", "workspace": str(workspace)}
+        )
+        assert r.success is True
+        data = json.loads(r.content)
+        assert data["passed"] is False
+        assert data["exit_code"] == 1
+        assert "1 failed" in data["stderr"]
+
+    @pytest.mark.asyncio
+    async def test_long_stdout_truncated_to_3000(
+        self,
+        executor: ShellExecutor,
+        workspace: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Stdout is capped at the last 3000 chars to avoid blowing up
+        the ToolResult payload."""
+        big = ("x" * 5000).encode()
+        _patch_subprocess(monkeypatch, lambda: _FakeProc(big, b"", 0))
+        r = await executor.execute(
+            {"command": "pytest", "workspace": str(workspace)}
+        )
+        data = json.loads(r.content)
+        assert len(data["stdout"]) == 3000
+
+    @pytest.mark.asyncio
+    async def test_long_stderr_truncated_to_1000(
+        self,
+        executor: ShellExecutor,
+        workspace: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        big = ("y" * 5000).encode()
+        _patch_subprocess(monkeypatch, lambda: _FakeProc(b"", big, 1))
+        r = await executor.execute(
+            {"command": "pytest", "workspace": str(workspace)}
+        )
+        data = json.loads(r.content)
+        assert len(data["stderr"]) == 1000
+
+    @pytest.mark.asyncio
+    async def test_short_output_not_truncated(
+        self,
+        executor: ShellExecutor,
+        workspace: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        _patch_subprocess(monkeypatch, lambda: _FakeProc(b"short\n", b"warn\n", 0))
+        r = await executor.execute(
+            {"command": "pytest", "workspace": str(workspace)}
+        )
+        data = json.loads(r.content)
+        assert data["stdout"] == "short\n"
+        assert data["stderr"] == "warn\n"
+
+    @pytest.mark.asyncio
+    async def test_cwd_is_the_workspace(
+        self,
+        executor: ShellExecutor,
+        workspace: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        captured: list[dict[str, Any]] = []
+        _patch_subprocess(
+            monkeypatch, lambda: _FakeProc(b"", b"", 0), captured=captured
+        )
+        await executor.execute(
+            {"command": "pytest", "workspace": str(workspace)}
+        )
+        assert captured[0]["cwd"] == workspace
+
+
+# ---------------------------------------------------------------------------
+# Timeout / exception wrapper
+# ---------------------------------------------------------------------------
+
+
+class TestTimeout:
+    @pytest.mark.asyncio
+    @pytest.mark.filterwarnings("ignore::RuntimeWarning")
+    async def test_timeout_returns_error(
+        self,
+        executor: ShellExecutor,
+        workspace: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """asyncio.wait_for timeout surfaces as success=False."""
+        _patch_subprocess(monkeypatch, lambda: _FakeProc(b"", b"", 0))
+
+        async def _raise_timeout(awaitable: Any, *args: Any, **kwargs: Any) -> Any:
+            # Close the pending coroutine to avoid the RuntimeWarning, then
+            # raise TimeoutError the same way real wait_for would.
+            if hasattr(awaitable, "close"):
+                awaitable.close()
+            raise TimeoutError
+
+        monkeypatch.setattr("asyncio.wait_for", _raise_timeout)
+        r = await executor.execute(
+            {"command": "pytest", "workspace": str(workspace)}
+        )
+        assert r.success is False
+        assert "timed out" in (r.error or "").lower()
+
+    @pytest.mark.asyncio
+    async def test_generic_exception_wrapped_as_error(
+        self,
+        executor: ShellExecutor,
+        workspace: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        async def _boom(*args: Any, **kwargs: Any) -> Any:
+            raise RuntimeError("transport broke")
+
+        monkeypatch.setattr("asyncio.create_subprocess_shell", _boom)
+        r = await executor.execute(
+            {"command": "pytest", "workspace": str(workspace)}
+        )
+        assert r.success is False
+        assert "transport broke" in (r.error or "")
+
+
+# ---------------------------------------------------------------------------
+# QualityGateExecutor — thin adapter around ShellExecutor
+# ---------------------------------------------------------------------------
+
+
+class TestQualityGate:
+    @pytest.mark.asyncio
+    async def test_make_executor_runs_command_verbatim(
+        self,
+        executor: ShellExecutor,
+        workspace: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        captured: list[dict[str, Any]] = []
+        _patch_subprocess(
+            monkeypatch, lambda: _FakeProc(b"ok", b"", 0), captured=captured
+        )
+        gate = QualityGateExecutor(executor)
+        run_ruff = gate.make_executor("ruff check src/")
+        r = await run_ruff({"workspace": str(workspace)})
+        assert r.success is True
+        assert captured[0]["cmd"] == "ruff check src/"
+
+    @pytest.mark.asyncio
+    async def test_make_executor_substitutes_path_template(
+        self,
+        executor: ShellExecutor,
+        workspace: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        captured: list[dict[str, Any]] = []
+        _patch_subprocess(
+            monkeypatch, lambda: _FakeProc(b"ok", b"", 0), captured=captured
+        )
+        gate = QualityGateExecutor(executor)
+        run_pytest = gate.make_executor("pytest {path}")
+        await run_pytest({"workspace": str(workspace), "path": "tests/unit"})
+        assert captured[0]["cmd"] == "pytest tests/unit"
+
+    @pytest.mark.asyncio
+    async def test_make_executor_without_path_template_ignores_path_arg(
+        self,
+        executor: ShellExecutor,
+        workspace: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        captured: list[dict[str, Any]] = []
+        _patch_subprocess(
+            monkeypatch, lambda: _FakeProc(b"", b"", 0), captured=captured
+        )
+        gate = QualityGateExecutor(executor)
+        run_ruff = gate.make_executor("ruff check src/")
+        await run_ruff(
+            {"workspace": str(workspace), "path": "ignored-no-template"}
+        )
+        assert captured[0]["cmd"] == "ruff check src/"

--- a/tests/tools/test_workspace.py
+++ b/tests/tools/test_workspace.py
@@ -1,0 +1,552 @@
+"""Tests for WorkspaceManager — git clone + worktree management for Mason.
+
+All subprocess.run calls are intercepted by a hand-rolled fake so tests
+never touch real git or network. Uses tmp_path for the base dir via the
+STRONGHOLD_WORKSPACE env var so each test gets a fresh sandbox.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from stronghold.tools import workspace as workspace_module
+from stronghold.tools.workspace import WORKSPACE_TOOL_DEF, WorkspaceManager
+
+
+# ---------------------------------------------------------------------------
+# Fake subprocess.run
+# ---------------------------------------------------------------------------
+
+
+class _FakeResult:
+    """Minimal stand-in for subprocess.CompletedProcess."""
+
+    def __init__(
+        self, returncode: int = 0, stdout: str = "", stderr: str = ""
+    ) -> None:
+        self.returncode = returncode
+        self.stdout = stdout
+        self.stderr = stderr
+
+
+def _fake_runner(
+    responses: dict[tuple[str, ...], _FakeResult] | None = None,
+    default: _FakeResult | None = None,
+    captured: list[dict[str, Any]] | None = None,
+) -> Any:
+    """Build a subprocess.run replacement driven by a command-prefix map."""
+    default = default or _FakeResult()
+    responses = responses or {}
+
+    def _runner(cmd: list[str], **kwargs: Any) -> _FakeResult:
+        if captured is not None:
+            captured.append({"cmd": cmd, **kwargs})
+        key = tuple(cmd)
+        if key in responses:
+            return responses[key]
+        # Fall back to prefix matching (first N elements)
+        for rkey, rval in responses.items():
+            if cmd[: len(rkey)] == list(rkey):
+                return rval
+        return default
+
+    return _runner
+
+
+@pytest.fixture
+def wm_base(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Redirect the workspace base dir to tmp_path."""
+    base = tmp_path / "ws-base"
+    monkeypatch.setattr(workspace_module, "DEFAULT_WORKSPACE_ROOT", base)
+    return base
+
+
+@pytest.fixture
+def wm(wm_base: Path, monkeypatch: pytest.MonkeyPatch) -> WorkspaceManager:
+    """Build a WorkspaceManager with default (no-op) subprocess behavior."""
+    monkeypatch.setattr(subprocess, "run", _fake_runner())
+    return WorkspaceManager()
+
+
+# ---------------------------------------------------------------------------
+# Meta / base resolution
+# ---------------------------------------------------------------------------
+
+
+class TestMeta:
+    def test_executor_name(self, wm: WorkspaceManager) -> None:
+        assert wm.name == "workspace"
+
+    def test_tool_definition_has_all_actions(self) -> None:
+        actions = set(WORKSPACE_TOOL_DEF.parameters["properties"]["action"]["enum"])
+        assert actions == {"create", "status", "commit", "push", "cleanup"}
+
+    def test_resolves_base_dir_under_configured_root(
+        self, wm: WorkspaceManager, wm_base: Path
+    ) -> None:
+        assert wm._base == wm_base
+        assert wm_base.is_dir()
+
+
+class TestBaseDirFallback:
+    def test_falls_back_to_tempdir_when_primary_unwritable(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Simulate primary failing mkdir (OSError) and verify the
+        tempdir candidate is taken."""
+        primary = tmp_path / "primary"  # never created — we'll make it fail
+        fallback_dir = tmp_path / "fallback"
+        monkeypatch.setattr(workspace_module, "DEFAULT_WORKSPACE_ROOT", primary)
+
+        import tempfile
+
+        monkeypatch.setattr(tempfile, "gettempdir", lambda: str(fallback_dir))
+
+        original_mkdir = Path.mkdir
+
+        def mkdir_with_block(self: Path, *args: Any, **kwargs: Any) -> None:
+            if self == primary:
+                msg = "simulated ro fs"
+                raise OSError(msg)
+            return original_mkdir(self, *args, **kwargs)
+
+        monkeypatch.setattr(Path, "mkdir", mkdir_with_block)
+        monkeypatch.setattr(subprocess, "run", _fake_runner())
+
+        mgr = WorkspaceManager()
+        assert mgr._base == fallback_dir / "stronghold-workspace"
+        assert mgr._base.is_dir()
+
+    def test_raises_when_no_candidate_writable(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(
+            workspace_module,
+            "DEFAULT_WORKSPACE_ROOT",
+            tmp_path / "ro1",
+        )
+        import tempfile
+
+        monkeypatch.setattr(tempfile, "gettempdir", lambda: str(tmp_path / "ro2"))
+
+        def always_fail(self: Path, *args: Any, **kwargs: Any) -> None:
+            msg = "ro"
+            raise OSError(msg)
+
+        monkeypatch.setattr(Path, "mkdir", always_fail)
+        monkeypatch.setattr(subprocess, "run", _fake_runner())
+
+        with pytest.raises(RuntimeError, match="No writable workspace root"):
+            WorkspaceManager()
+
+
+# ---------------------------------------------------------------------------
+# execute() dispatch
+# ---------------------------------------------------------------------------
+
+
+class TestExecuteDispatch:
+    @pytest.mark.asyncio
+    async def test_unknown_action_returns_failure(
+        self, wm: WorkspaceManager
+    ) -> None:
+        r = await wm.execute({"action": "nuke"})
+        assert r.success is False
+        assert "unknown action" in (r.error or "").lower()
+
+    @pytest.mark.asyncio
+    async def test_handler_exception_wrapped_as_failure(
+        self, wm: WorkspaceManager, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Any exception from the action handler surfaces as
+        ToolResult(success=False, error=...) — not an unhandled raise."""
+
+        def boom(_args: dict[str, Any]) -> dict[str, str]:
+            msg = "handler exploded"
+            raise RuntimeError(msg)
+
+        monkeypatch.setattr(wm, "_create", boom)
+        r = await wm.execute({"action": "create"})
+        assert r.success is False
+        assert "handler exploded" in (r.error or "")
+
+
+# ---------------------------------------------------------------------------
+# _ensure_clone
+# ---------------------------------------------------------------------------
+
+
+class TestEnsureClone:
+    def test_uses_token_in_url_when_present(
+        self,
+        wm: WorkspaceManager,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setenv("GITHUB_TOKEN", "ghp_fake_token")
+        captured: list[dict[str, Any]] = []
+        monkeypatch.setattr(subprocess, "run", _fake_runner(captured=captured))
+        wm._ensure_clone("owner", "repo")
+        clone_cmd = next(
+            c for c in captured if c["cmd"][:2] == ["git", "clone"]
+        )
+        assert "x-access-token:ghp_fake_token" in clone_cmd["cmd"][-2]
+
+    def test_no_token_uses_public_url(
+        self,
+        wm: WorkspaceManager,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+        captured: list[dict[str, Any]] = []
+        monkeypatch.setattr(subprocess, "run", _fake_runner(captured=captured))
+        wm._ensure_clone("owner", "repo")
+        clone_cmd = next(
+            c for c in captured if c["cmd"][:2] == ["git", "clone"]
+        )
+        assert "x-access-token" not in clone_cmd["cmd"][-2]
+        assert "github.com/owner/repo" in clone_cmd["cmd"][-2]
+
+    def test_second_call_returns_cached_path_without_reclone(
+        self,
+        wm: WorkspaceManager,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        captured: list[dict[str, Any]] = []
+        monkeypatch.setattr(subprocess, "run", _fake_runner(captured=captured))
+        first = wm._ensure_clone("owner", "repo")
+        before_second = len(captured)
+        second = wm._ensure_clone("owner", "repo")
+        after_second = len(captured)
+        assert first == second
+        assert before_second == after_second, "second clone ran subprocess"
+
+    def test_existing_on_disk_repo_is_reused(
+        self,
+        wm: WorkspaceManager,
+        wm_base: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """If the repo dir already exists (leftover from a previous run),
+        _ensure_clone must not re-clone."""
+        (wm_base / "repos" / "repo").mkdir(parents=True)
+        captured: list[dict[str, Any]] = []
+        monkeypatch.setattr(subprocess, "run", _fake_runner(captured=captured))
+        path = wm._ensure_clone("owner", "repo")
+        assert path.exists()
+        # No git clone calls expected
+        assert not any(
+            c["cmd"][:2] == ["git", "clone"] for c in captured
+        )
+
+
+# ---------------------------------------------------------------------------
+# _create
+# ---------------------------------------------------------------------------
+
+
+class TestCreate:
+    @pytest.mark.asyncio
+    async def test_create_returns_branch_and_path(
+        self,
+        wm: WorkspaceManager,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setattr(subprocess, "run", _fake_runner())
+        r = await wm.execute(
+            {
+                "action": "create",
+                "owner": "acme",
+                "repo": "widgets",
+                "issue_number": 42,
+            }
+        )
+        assert r.success is True
+        payload = json.loads(r.content)
+        assert payload["status"] == "created"
+        assert payload["branch"] == "mason/42"
+        assert "mason-42" in payload["path"]
+
+    @pytest.mark.asyncio
+    async def test_create_with_existing_worktree_returns_exists(
+        self,
+        wm: WorkspaceManager,
+        wm_base: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        (wm_base / "worktrees" / "mason-99").mkdir(parents=True)
+        monkeypatch.setattr(subprocess, "run", _fake_runner())
+        r = await wm.execute(
+            {
+                "action": "create",
+                "owner": "acme",
+                "repo": "widgets",
+                "issue_number": 99,
+            }
+        )
+        payload = json.loads(r.content)
+        assert payload["status"] == "exists"
+
+    @pytest.mark.asyncio
+    async def test_create_honors_explicit_branch(
+        self,
+        wm: WorkspaceManager,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        r = await wm.execute(
+            {
+                "action": "create",
+                "owner": "acme",
+                "repo": "widgets",
+                "issue_number": 7,
+                "branch": "feat/custom-branch",
+            }
+        )
+        payload = json.loads(r.content)
+        assert payload["branch"] == "feat/custom-branch"
+
+
+# ---------------------------------------------------------------------------
+# _status / _commit / _push / _cleanup
+# ---------------------------------------------------------------------------
+
+
+class TestStatus:
+    @pytest.mark.asyncio
+    async def test_status_missing_worktree(
+        self, wm: WorkspaceManager
+    ) -> None:
+        r = await wm.execute({"action": "status", "issue_number": 101})
+        payload = json.loads(r.content)
+        assert payload["status"] == "not_found"
+
+    @pytest.mark.asyncio
+    async def test_status_with_changes_parsed(
+        self,
+        wm: WorkspaceManager,
+        wm_base: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        (wm_base / "worktrees" / "mason-5").mkdir(parents=True)
+        responses = {
+            ("git", "status", "--porcelain"): _FakeResult(
+                stdout=" M file.py\n?? newfile.py\n"
+            ),
+            ("git", "branch", "--show-current"): _FakeResult(stdout="mason/5\n"),
+        }
+        monkeypatch.setattr(subprocess, "run", _fake_runner(responses))
+        r = await wm.execute({"action": "status", "issue_number": 5})
+        payload = json.loads(r.content)
+        assert payload["status"] == "active"
+        assert payload["branch"] == "mason/5"
+        assert len(payload["changes"]) == 2
+
+    @pytest.mark.asyncio
+    async def test_status_with_clean_worktree(
+        self,
+        wm: WorkspaceManager,
+        wm_base: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        (wm_base / "worktrees" / "mason-6").mkdir(parents=True)
+        responses = {
+            ("git", "status", "--porcelain"): _FakeResult(stdout=""),
+            ("git", "branch", "--show-current"): _FakeResult(stdout="mason/6\n"),
+        }
+        monkeypatch.setattr(subprocess, "run", _fake_runner(responses))
+        r = await wm.execute({"action": "status", "issue_number": 6})
+        payload = json.loads(r.content)
+        assert payload["changes"] == []
+
+
+class TestCommit:
+    @pytest.mark.asyncio
+    async def test_commit_missing_worktree(
+        self, wm: WorkspaceManager
+    ) -> None:
+        r = await wm.execute({"action": "commit", "issue_number": 77})
+        payload = json.loads(r.content)
+        assert payload["status"] == "error"
+
+    @pytest.mark.asyncio
+    async def test_commit_returns_sha(
+        self,
+        wm: WorkspaceManager,
+        wm_base: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        (wm_base / "worktrees" / "mason-10").mkdir(parents=True)
+        responses = {
+            ("git", "rev-parse", "HEAD"): _FakeResult(stdout="abc123def\n"),
+        }
+        monkeypatch.setattr(subprocess, "run", _fake_runner(responses))
+        r = await wm.execute(
+            {
+                "action": "commit",
+                "issue_number": 10,
+                "message": "fix: update logic",
+            }
+        )
+        payload = json.loads(r.content)
+        assert payload["status"] == "committed"
+        assert payload["sha"] == "abc123def"
+
+
+class TestPush:
+    @pytest.mark.asyncio
+    async def test_push_missing_worktree(
+        self, wm: WorkspaceManager
+    ) -> None:
+        r = await wm.execute({"action": "push", "issue_number": 202})
+        payload = json.loads(r.content)
+        assert payload["status"] == "error"
+
+    @pytest.mark.asyncio
+    async def test_push_returns_branch(
+        self,
+        wm: WorkspaceManager,
+        wm_base: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        (wm_base / "worktrees" / "mason-3").mkdir(parents=True)
+        captured: list[dict[str, Any]] = []
+        responses = {
+            ("git", "branch", "--show-current"): _FakeResult(stdout="mason/3\n"),
+        }
+        monkeypatch.setattr(
+            subprocess, "run", _fake_runner(responses, captured=captured)
+        )
+        r = await wm.execute({"action": "push", "issue_number": 3})
+        payload = json.loads(r.content)
+        assert payload["status"] == "pushed"
+        assert payload["branch"] == "mason/3"
+        # Confirm push command ran
+        assert any(c["cmd"][:3] == ["git", "push", "-u"] for c in captured)
+
+
+class TestCleanup:
+    @pytest.mark.asyncio
+    async def test_cleanup_missing_worktree(
+        self, wm: WorkspaceManager
+    ) -> None:
+        r = await wm.execute({"action": "cleanup", "issue_number": 999})
+        payload = json.loads(r.content)
+        assert payload["status"] == "not_found"
+
+    @pytest.mark.asyncio
+    async def test_cleanup_removes_directory_via_git_worktree(
+        self,
+        wm: WorkspaceManager,
+        wm_base: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        # Seed a cached repo and a worktree
+        repo_dir = wm_base / "repos" / "widgets"
+        repo_dir.mkdir(parents=True)
+        wm._repos["acme/widgets"] = repo_dir
+        worktree_dir = wm_base / "worktrees" / "mason-11"
+        worktree_dir.mkdir(parents=True)
+
+        # Make git worktree remove actually delete the dir
+        def deleting_runner(cmd: list[str], **kwargs: Any) -> _FakeResult:
+            if cmd[:3] == ["git", "worktree"] and cmd[3] == "remove":
+                import shutil as _shutil
+
+                _shutil.rmtree(cmd[4], ignore_errors=True)
+            return _FakeResult()
+
+        monkeypatch.setattr(subprocess, "run", deleting_runner)
+        r = await wm.execute({"action": "cleanup", "issue_number": 11})
+        payload = json.loads(r.content)
+        assert payload["status"] == "cleaned"
+        assert not worktree_dir.exists()
+
+    @pytest.mark.asyncio
+    async def test_cleanup_falls_back_to_rmtree(
+        self,
+        wm: WorkspaceManager,
+        wm_base: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """When `git worktree remove` fails (raises), the fallback
+        `shutil.rmtree` path is taken."""
+        worktree_dir = wm_base / "worktrees" / "mason-20"
+        worktree_dir.mkdir(parents=True)
+        # No repos seeded → the for-loop over _repos.values() is empty,
+        # falling through to shutil.rmtree.
+        monkeypatch.setattr(subprocess, "run", _fake_runner())
+        r = await wm.execute({"action": "cleanup", "issue_number": 20})
+        payload = json.loads(r.content)
+        assert payload["status"] == "cleaned"
+        assert not worktree_dir.exists()
+
+    @pytest.mark.asyncio
+    async def test_cleanup_with_repo_but_git_remove_fails(
+        self,
+        wm: WorkspaceManager,
+        wm_base: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """If git worktree remove raises for the cached repo, the loop
+        continues and shutil.rmtree does the final cleanup."""
+        wm._repos["acme/widgets"] = wm_base / "repos" / "widgets"
+        (wm_base / "repos" / "widgets").mkdir(parents=True)
+        worktree_dir = wm_base / "worktrees" / "mason-21"
+        worktree_dir.mkdir(parents=True)
+
+        def always_fail_runner(cmd: list[str], **kwargs: Any) -> _FakeResult:
+            # _run() wraps non-zero return codes in RuntimeError
+            return _FakeResult(returncode=1, stderr="worktree remove failed")
+
+        monkeypatch.setattr(subprocess, "run", always_fail_runner)
+        r = await wm.execute({"action": "cleanup", "issue_number": 21})
+        payload = json.loads(r.content)
+        assert payload["status"] == "cleaned"
+        assert not worktree_dir.exists()
+
+
+# ---------------------------------------------------------------------------
+# _run helper — raise on non-zero exit
+# ---------------------------------------------------------------------------
+
+
+class TestRunHelper:
+    def test_run_raises_on_nonzero_exit(
+        self,
+        wm: WorkspaceManager,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        def fail_runner(cmd: list[str], **kwargs: Any) -> _FakeResult:
+            return _FakeResult(returncode=2, stderr="fatal: bad ref\n")
+
+        monkeypatch.setattr(subprocess, "run", fail_runner)
+        with pytest.raises(RuntimeError, match="fatal: bad ref"):
+            wm._run(["git", "fetch", "origin"])
+
+    def test_run_falls_back_to_stdout_on_empty_stderr(
+        self,
+        wm: WorkspaceManager,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        def fail_runner(cmd: list[str], **kwargs: Any) -> _FakeResult:
+            return _FakeResult(returncode=1, stdout="stdout error\n", stderr="")
+
+        monkeypatch.setattr(subprocess, "run", fail_runner)
+        with pytest.raises(RuntimeError, match="stdout error"):
+            wm._run(["git", "status"])
+
+    def test_run_returns_stdout_on_success(
+        self,
+        wm: WorkspaceManager,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setattr(
+            subprocess,
+            "run",
+            lambda cmd, **kw: _FakeResult(returncode=0, stdout="hello\n"),
+        )
+        assert wm._run(["echo", "hello"]) == "hello\n"


### PR DESCRIPTION
## Summary

Second chunk of bucket B. Both subprocess-backed tool modules go to 100% via hand-rolled async + sync subprocess fakes. Recovers **120 missed lines** toward the 95% repo gate.

## Coverage delta

| Module | Before | After |
|---|---|---|
| \`tools/shell_exec.py\` | 44% (61 stmts, 34 missed) | **100%** |
| \`tools/workspace.py\` | 29% (121 stmts, 86 missed) | **100%** |
| **Combined** | ~34% | **100%** (182 stmts, 0 missed) |

## What's tested

**shell_exec.py — 31 tests:**
- Meta: executor name + 6 tool definitions (shell + run_pytest + run_ruff_check + run_ruff_format + run_mypy + run_bandit)
- Preconditions: missing workspace, nonexistent workspace, empty command
- Allowlist: disallowed command rejected, 6 allowlisted prefixes run (pytest, ruff, mypy, git, ls, grep), 3 blocked patterns rejected (\`rm -rf /\`, \`> /dev/\`, \`curl | sh\`)
- Execution: structured success, non-zero exit \`success=True\` + \`passed=False\` (ran-vs-passed distinction), stdout truncation to 3000, stderr truncation to 1000, short output passthrough, \`cwd=workspace\`
- Timeout: \`wait_for TimeoutError\` → \`success=False\` with "timed out" error
- Generic exception wrapped
- \`QualityGateExecutor\`: verbatim command, \`{path}\` template substitution, path arg ignored when no placeholder

**workspace.py — 28 tests:**
- Meta, tool definition action enum, base dir resolution
- Base dir fallback: primary unwritable → tempdir candidate; all candidates fail → \`RuntimeError\`
- \`execute()\` dispatch: unknown action, handler exception wrapped
- \`_ensure_clone\`: \`GITHUB_TOKEN\` in URL, no-token public URL, second call cached, existing on-disk repo reused
- \`_create\`: new worktree, existing worktree returns \`"exists"\`, honors explicit branch
- \`_status\`: missing, with changes parsed, clean
- \`_commit\`: missing, returns sha
- \`_push\`: missing, returns branch, push cmd runs
- \`_cleanup\`: missing, git worktree remove path, \`shutil.rmtree\` fallback, failure-then-fallback
- \`_run\` helper: raises on non-zero, \`stdout\` fallback when \`stderr\` empty, returns \`stdout\` on success

## Test plan

- [x] \`PYTHONPATH=src pytest tests/tools/test_shell_exec.py tests/tools/test_workspace.py\` — 59 passed
- [x] 100% coverage on both modules, 0 missing lines
- [x] No production code modified, no new runtime dependencies
- [x] All fixtures hermetic — \`asyncio.create_subprocess_shell\` and \`subprocess.run\` monkey-patched, \`DEFAULT_WORKSPACE_ROOT\` redirected to \`tmp_path\`
- [x] 0 subprocess / network I/O

## Stacks on

- #1041 (coverage omit)
- #1042 (cache tests)
- #1043 (file_ops + scanner)

Remaining in bucket B: \`tools/github.py\` (30 missed, already 76%) and \`quota/coins.py\` (129 missed, the biggest).