### PR TITLE
feat: Orchestrator execution engine — the real agent runtime

### DIFF
--- a/agents/mason/agent.yaml
+++ b/agents/mason/agent.yaml
@@ -8,7 +8,7 @@ description: >
   Learns from Auditor review feedback via RLHF.
 soul: SOUL.md
 reasoning:
-  strategy: react
+  strategy: builders_learning
   max_rounds: 50
   review_after_each: false
   phases:

--- a/src/stronghold/agents/mason_queue.py
+++ b/src/stronghold/agents/mason_queue.py
@@ -1,0 +1,112 @@
+"""Mason issue queue — tracks issues assigned to the builder agent.
+
+Simple in-memory queue. Stronghold dispatches issues here; the reactor
+trigger dequeues and routes them through the Conduit pipeline.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from enum import Enum
+
+logger = logging.getLogger("stronghold.agents.mason_queue")
+
+
+class IssueStatus(str, Enum):
+    QUEUED = "queued"
+    IN_PROGRESS = "in_progress"
+    COMPLETED = "completed"
+    FAILED = "failed"
+
+
+@dataclass
+class IssueRecord:
+    issue_number: int
+    title: str
+    owner: str = ""
+    repo: str = ""
+    status: IssueStatus = IssueStatus.QUEUED
+    error: str = ""
+    log: list[str] = field(default_factory=list)
+    queued_at: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
+    started_at: datetime | None = None
+    completed_at: datetime | None = None
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "issue_number": self.issue_number,
+            "title": self.title,
+            "owner": self.owner,
+            "repo": self.repo,
+            "status": self.status.value,
+            "error": self.error,
+            "log_lines": len(self.log),
+            "queued_at": self.queued_at.isoformat(),
+            "started_at": self.started_at.isoformat() if self.started_at else None,
+            "completed_at": self.completed_at.isoformat() if self.completed_at else None,
+        }
+
+
+class MasonQueue:
+    """In-memory issue queue for the Mason builder agent."""
+
+    def __init__(self) -> None:
+        self._issues: dict[int, IssueRecord] = {}
+
+    def assign(
+        self,
+        issue_number: int,
+        title: str,
+        owner: str = "",
+        repo: str = "",
+    ) -> IssueRecord:
+        record = IssueRecord(
+            issue_number=issue_number,
+            title=title,
+            owner=owner,
+            repo=repo,
+        )
+        self._issues[issue_number] = record
+        logger.info("Issue #%d queued: %s", issue_number, title)
+        return record
+
+    def start(self, issue_number: int) -> None:
+        record = self._issues.get(issue_number)
+        if record:
+            record.status = IssueStatus.IN_PROGRESS
+            record.started_at = datetime.now(timezone.utc)
+            logger.info("Issue #%d started", issue_number)
+
+    def complete(self, issue_number: int) -> None:
+        record = self._issues.get(issue_number)
+        if record:
+            record.status = IssueStatus.COMPLETED
+            record.completed_at = datetime.now(timezone.utc)
+            logger.info("Issue #%d completed", issue_number)
+
+    def fail(self, issue_number: int, error: str) -> None:
+        record = self._issues.get(issue_number)
+        if record:
+            record.status = IssueStatus.FAILED
+            record.error = error
+            record.completed_at = datetime.now(timezone.utc)
+            logger.warning("Issue #%d failed: %s", issue_number, error)
+
+    def add_log(self, issue_number: int, message: str) -> None:
+        record = self._issues.get(issue_number)
+        if record:
+            record.log.append(message)
+
+    def get(self, issue_number: int) -> IssueRecord | None:
+        return self._issues.get(issue_number)
+
+    def list_all(self) -> list[dict[str, object]]:
+        return [r.to_dict() for r in self._issues.values()]
+
+    def status(self) -> dict[str, object]:
+        counts = {"queued": 0, "in_progress": 0, "completed": 0, "failed": 0}
+        for r in self._issues.values():
+            counts[r.status.value] = counts.get(r.status.value, 0) + 1
+        return {"total": len(self._issues), **counts}

--- a/src/stronghold/agents/mason_queue.py
+++ b/src/stronghold/agents/mason_queue.py
@@ -8,13 +8,13 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass, field
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from enum import Enum
 
 logger = logging.getLogger("stronghold.agents.mason_queue")
 
 
-class IssueStatus(str, Enum):
+class IssueStatus(Enum):
     QUEUED = "queued"
     IN_PROGRESS = "in_progress"
     COMPLETED = "completed"
@@ -30,7 +30,7 @@ class IssueRecord:
     status: IssueStatus = IssueStatus.QUEUED
     error: str = ""
     log: list[str] = field(default_factory=list)
-    queued_at: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
+    queued_at: datetime = field(default_factory=lambda: datetime.now(UTC))
     started_at: datetime | None = None
     completed_at: datetime | None = None
 
@@ -76,14 +76,14 @@ class MasonQueue:
         record = self._issues.get(issue_number)
         if record:
             record.status = IssueStatus.IN_PROGRESS
-            record.started_at = datetime.now(timezone.utc)
+            record.started_at = datetime.now(UTC)
             logger.info("Issue #%d started", issue_number)
 
     def complete(self, issue_number: int) -> None:
         record = self._issues.get(issue_number)
         if record:
             record.status = IssueStatus.COMPLETED
-            record.completed_at = datetime.now(timezone.utc)
+            record.completed_at = datetime.now(UTC)
             logger.info("Issue #%d completed", issue_number)
 
     def fail(self, issue_number: int, error: str) -> None:
@@ -91,7 +91,7 @@ class MasonQueue:
         if record:
             record.status = IssueStatus.FAILED
             record.error = error
-            record.completed_at = datetime.now(timezone.utc)
+            record.completed_at = datetime.now(UTC)
             logger.warning("Issue #%d failed: %s", issue_number, error)
 
     def add_log(self, issue_number: int, message: str) -> None:

--- a/src/stronghold/api/app.py
+++ b/src/stronghold/api/app.py
@@ -29,13 +29,35 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
     container = await create_container(config)
     app.state.container = container
 
+    # Wire Mason queue + router
+    from stronghold.agents.mason_queue import MasonQueue  # noqa: PLC0415
+
+    mason_queue = MasonQueue()
+    container.mason_queue = mason_queue
+    configure_mason_router(
+        queue=mason_queue,
+        reactor=container.reactor,
+        container=container,
+    )
+
+    # Start the Orchestrator engine (agent execution)
+    from stronghold.orchestrator.engine import OrchestratorEngine  # noqa: PLC0415
+
+    orchestrator = OrchestratorEngine(container, max_concurrent=3)
+    app.state.orchestrator = orchestrator
+
     # Start the reactor loop (1000Hz, runs in background)
     disable_reactor = os.environ.get("STRONGHOLD_DISABLE_REACTOR_AUTOSTART") == "1"
     running_under_pytest = "PYTEST_CURRENT_TEST" in os.environ
     reactor_task: asyncio.Task[None] | None = None
+    orchestrator_started = False
     if not disable_reactor and not running_under_pytest:
         reactor_task = asyncio.create_task(container.reactor.start())
+        await orchestrator.start()
+        orchestrator_started = True
     yield
+    if orchestrator_started:
+        await orchestrator.stop()
     container.reactor.stop()
     if reactor_task is not None:
         reactor_task.cancel()
@@ -140,6 +162,8 @@ def create_app() -> FastAPI:
     from stronghold.api.routes.status import router as status_router
     from stronghold.api.routes.tasks import router as tasks_router
     from stronghold.api.routes.traces import router as traces_router
+    from stronghold.api.routes.mason import configure_mason_router, router as mason_router
+    from stronghold.orchestrator.routes import router as orchestrator_router
     from stronghold.api.routes.webhooks import router as webhooks_router
     from stronghold.prompts.routes import router as prompts_router
 
@@ -162,6 +186,8 @@ def create_app() -> FastAPI:
     app.include_router(webhooks_router)
     app.include_router(mcp_router)
     app.include_router(schedules_router)
+    app.include_router(mason_router)
+    app.include_router(orchestrator_router)
 
     # Dashboard — try multiple paths (installed package vs source layout)
     _dashboard_candidates = [

--- a/src/stronghold/api/app.py
+++ b/src/stronghold/api/app.py
@@ -31,6 +31,7 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
 
     # Wire Mason queue + router
     from stronghold.agents.mason_queue import MasonQueue  # noqa: PLC0415
+    from stronghold.api.routes.mason import configure_mason_router  # noqa: PLC0415
 
     mason_queue = MasonQueue()
     container.mason_queue = mason_queue
@@ -153,6 +154,7 @@ def create_app() -> FastAPI:
     from stronghold.api.routes.dashboard import router as dashboard_router
     from stronghold.api.routes.gate_endpoint import router as gate_router
     from stronghold.api.routes.marketplace import router as marketplace_router
+    from stronghold.api.routes.mason import router as mason_router
     from stronghold.api.routes.mcp import router as mcp_router
     from stronghold.api.routes.models import router as models_router
     from stronghold.api.routes.profile import router as profile_router
@@ -162,9 +164,8 @@ def create_app() -> FastAPI:
     from stronghold.api.routes.status import router as status_router
     from stronghold.api.routes.tasks import router as tasks_router
     from stronghold.api.routes.traces import router as traces_router
-    from stronghold.api.routes.mason import configure_mason_router, router as mason_router
-    from stronghold.orchestrator.routes import router as orchestrator_router
     from stronghold.api.routes.webhooks import router as webhooks_router
+    from stronghold.orchestrator.routes import router as orchestrator_router
     from stronghold.prompts.routes import router as prompts_router
 
     app.include_router(auth_router)  # BFF auth (must be before dashboard for /auth/* routes)

--- a/src/stronghold/container.py
+++ b/src/stronghold/container.py
@@ -76,6 +76,7 @@ class Container:
     skill_catalog: Any = None
     resource_catalog: Any = None
     vault_client: Any = None
+    mason_queue: Any = None
     agent_store: InMemoryAgentStore = field(default_factory=lambda: InMemoryAgentStore({}))
     rate_limiter: Any = field(default_factory=InMemoryRateLimiter)  # RateLimiter protocol
     reactor: Reactor = field(default_factory=Reactor)

--- a/src/stronghold/orchestrator/__init__.py
+++ b/src/stronghold/orchestrator/__init__.py
@@ -1,0 +1,6 @@
+"""Stronghold Orchestrator — agent execution engine.
+
+Replaces the Conductor stack. Dispatches work to agents based on
+triggers (webhook, cron, API, reactor events) and tracks execution
+through completion.
+"""

--- a/src/stronghold/orchestrator/engine.py
+++ b/src/stronghold/orchestrator/engine.py
@@ -96,7 +96,8 @@ class OrchestratorEngine:
     async def start(self) -> None:
         """Start worker tasks."""
         logger.info(
-            "Orchestrator started: max_concurrent=%d", self._max_concurrent,
+            "Orchestrator started: max_concurrent=%d",
+            self._max_concurrent,
         )
         for i in range(self._max_concurrent):
             task = asyncio.create_task(self._worker(i))
@@ -136,7 +137,10 @@ class OrchestratorEngine:
         self._queue.put_nowait((priority, work_id))
         logger.info(
             "Work dispatched: id=%s agent=%s trigger=%s tier=%s",
-            work_id, agent_name, trigger, priority_tier,
+            work_id,
+            agent_name,
+            trigger,
+            priority_tier,
         )
         return item
 
@@ -172,7 +176,8 @@ class OrchestratorEngine:
         while not self._shutdown:
             try:
                 priority, work_id = await asyncio.wait_for(
-                    self._queue.get(), timeout=1.0,
+                    self._queue.get(),
+                    timeout=1.0,
                 )
             except TimeoutError:
                 continue
@@ -188,7 +193,9 @@ class OrchestratorEngine:
 
             logger.info(
                 "Worker %d executing: id=%s agent=%s",
-                worker_id, work_id, item.agent_name,
+                worker_id,
+                work_id,
+                item.agent_name,
             )
 
             try:
@@ -218,7 +225,9 @@ class OrchestratorEngine:
                 )
                 logger.error(
                     "Work failed: id=%s agent=%s error=%s",
-                    work_id, item.agent_name, exc,
+                    work_id,
+                    item.agent_name,
+                    exc,
                 )
 
             finally:

--- a/src/stronghold/orchestrator/engine.py
+++ b/src/stronghold/orchestrator/engine.py
@@ -17,14 +17,14 @@ import asyncio
 import logging
 import traceback
 from dataclasses import dataclass, field
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from enum import Enum
 from typing import Any
 
 logger = logging.getLogger("stronghold.orchestrator.engine")
 
 
-class WorkStatus(str, Enum):
+class WorkStatus(Enum):
     QUEUED = "queued"
     RUNNING = "running"
     COMPLETED = "completed"
@@ -47,7 +47,7 @@ class WorkItem:
     result: dict[str, Any] | None = None
     error: str = ""
     log: list[str] = field(default_factory=list)
-    created_at: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
+    created_at: datetime = field(default_factory=lambda: datetime.now(UTC))
     started_at: datetime | None = None
     completed_at: datetime | None = None
 
@@ -174,7 +174,7 @@ class OrchestratorEngine:
                 priority, work_id = await asyncio.wait_for(
                     self._queue.get(), timeout=1.0,
                 )
-            except (TimeoutError, asyncio.TimeoutError):
+            except TimeoutError:
                 continue
 
             item = self._items.get(work_id)
@@ -183,7 +183,7 @@ class OrchestratorEngine:
 
             self._running.add(work_id)
             item.status = WorkStatus.RUNNING
-            item.started_at = datetime.now(timezone.utc)
+            item.started_at = datetime.now(UTC)
             item.log.append(f"Worker {worker_id} picked up work")
 
             logger.info(
@@ -195,7 +195,7 @@ class OrchestratorEngine:
                 result = await self._execute(item)
                 item.status = WorkStatus.COMPLETED
                 item.result = result
-                item.completed_at = datetime.now(timezone.utc)
+                item.completed_at = datetime.now(UTC)
                 item.log.append("Completed successfully")
 
                 # Emit completion event for downstream reactors
@@ -208,7 +208,7 @@ class OrchestratorEngine:
             except Exception as exc:
                 item.status = WorkStatus.FAILED
                 item.error = str(exc)
-                item.completed_at = datetime.now(timezone.utc)
+                item.completed_at = datetime.now(UTC)
                 item.log.append(f"Failed: {exc}")
                 item.log.append(traceback.format_exc())
 

--- a/src/stronghold/orchestrator/engine.py
+++ b/src/stronghold/orchestrator/engine.py
@@ -148,10 +148,10 @@ class OrchestratorEngine:
         return self._items.get(work_id)
 
     def list_items(self, status: WorkStatus | None = None) -> list[dict[str, object]]:
-        items = self._items.values()
+        all_items = list(self._items.values())
         if status:
-            items = [i for i in items if i.status == status]
-        return [i.to_dict() for i in items]
+            all_items = [i for i in all_items if i.status == status]
+        return [i.to_dict() for i in all_items]
 
     def cancel(self, work_id: str) -> bool:
         item = self._items.get(work_id)
@@ -252,7 +252,7 @@ class OrchestratorEngine:
     def _emit_event(self, name: str, data: dict[str, Any]) -> None:
         """Emit an event to the reactor for downstream processing."""
         try:
-            from stronghold.events import Event  # noqa: PLC0415
+            from stronghold.types.reactor import Event  # noqa: PLC0415
 
             event = Event(name=name, data=data)
             self._container.reactor.emit(event)

--- a/src/stronghold/orchestrator/engine.py
+++ b/src/stronghold/orchestrator/engine.py
@@ -1,0 +1,251 @@
+"""Orchestrator execution engine.
+
+The engine is the core loop that:
+1. Accepts work items (agent + task + trigger source)
+2. Queues them with priority (using the 6-tier system)
+3. Executes them through the Conduit pipeline with full governance
+4. Tracks state transitions (queued -> running -> done/failed)
+5. Emits events for downstream reactors (RLHF, audit, notifications)
+
+Any agent can be dispatched: Mason, Auditor, Ranger, or custom.
+Any trigger can fire: GitHub webhook, cron, API call, reactor event.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import traceback
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from enum import Enum
+from typing import Any
+
+logger = logging.getLogger("stronghold.orchestrator.engine")
+
+
+class WorkStatus(str, Enum):
+    QUEUED = "queued"
+    RUNNING = "running"
+    COMPLETED = "completed"
+    FAILED = "failed"
+    CANCELLED = "cancelled"
+
+
+@dataclass
+class WorkItem:
+    """A unit of work dispatched to an agent."""
+
+    id: str
+    agent_name: str
+    messages: list[dict[str, Any]]
+    trigger: str  # "api", "webhook", "cron", "reactor", "manual"
+    priority_tier: str = "P2"
+    intent_hint: str = ""
+    metadata: dict[str, Any] = field(default_factory=dict)
+    status: WorkStatus = WorkStatus.QUEUED
+    result: dict[str, Any] | None = None
+    error: str = ""
+    log: list[str] = field(default_factory=list)
+    created_at: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
+    started_at: datetime | None = None
+    completed_at: datetime | None = None
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "id": self.id,
+            "agent_name": self.agent_name,
+            "trigger": self.trigger,
+            "priority_tier": self.priority_tier,
+            "status": self.status.value,
+            "error": self.error,
+            "log_lines": len(self.log),
+            "created_at": self.created_at.isoformat(),
+            "started_at": self.started_at.isoformat() if self.started_at else None,
+            "completed_at": self.completed_at.isoformat() if self.completed_at else None,
+            "metadata": self.metadata,
+        }
+
+
+# Priority values — lower number = higher priority = runs first
+_TIER_PRIORITY = {"P0": 0, "P1": 1, "P2": 2, "P3": 3, "P4": 4, "P5": 5}
+
+
+class OrchestratorEngine:
+    """Agent execution engine.
+
+    Submit work items via dispatch(). The engine runs them through the
+    Conduit pipeline (container.route_request) with governance, tracking,
+    and event emission. Work items are priority-ordered by tier.
+    """
+
+    def __init__(
+        self,
+        container: Any,
+        *,
+        max_concurrent: int = 3,
+    ) -> None:
+        self._container = container
+        self._max_concurrent = max_concurrent
+        self._items: dict[str, WorkItem] = {}
+        self._queue: asyncio.PriorityQueue[tuple[int, str]] = asyncio.PriorityQueue()
+        self._running: set[str] = set()
+        self._workers: list[asyncio.Task[None]] = []
+        self._shutdown = False
+
+    async def start(self) -> None:
+        """Start worker tasks."""
+        logger.info(
+            "Orchestrator started: max_concurrent=%d", self._max_concurrent,
+        )
+        for i in range(self._max_concurrent):
+            task = asyncio.create_task(self._worker(i))
+            self._workers.append(task)
+
+    async def stop(self) -> None:
+        """Stop all workers gracefully."""
+        self._shutdown = True
+        for w in self._workers:
+            w.cancel()
+        self._workers.clear()
+        logger.info("Orchestrator stopped")
+
+    def dispatch(
+        self,
+        *,
+        work_id: str,
+        agent_name: str,
+        messages: list[dict[str, Any]],
+        trigger: str = "api",
+        priority_tier: str = "P2",
+        intent_hint: str = "",
+        metadata: dict[str, Any] | None = None,
+    ) -> WorkItem:
+        """Submit a work item for execution. Returns immediately."""
+        item = WorkItem(
+            id=work_id,
+            agent_name=agent_name,
+            messages=messages,
+            trigger=trigger,
+            priority_tier=priority_tier,
+            intent_hint=intent_hint,
+            metadata=metadata or {},
+        )
+        self._items[work_id] = item
+        priority = _TIER_PRIORITY.get(priority_tier, 2)
+        self._queue.put_nowait((priority, work_id))
+        logger.info(
+            "Work dispatched: id=%s agent=%s trigger=%s tier=%s",
+            work_id, agent_name, trigger, priority_tier,
+        )
+        return item
+
+    def get(self, work_id: str) -> WorkItem | None:
+        return self._items.get(work_id)
+
+    def list_items(self, status: WorkStatus | None = None) -> list[dict[str, object]]:
+        items = self._items.values()
+        if status:
+            items = [i for i in items if i.status == status]
+        return [i.to_dict() for i in items]
+
+    def cancel(self, work_id: str) -> bool:
+        item = self._items.get(work_id)
+        if item and item.status == WorkStatus.QUEUED:
+            item.status = WorkStatus.CANCELLED
+            return True
+        return False
+
+    def status(self) -> dict[str, object]:
+        counts: dict[str, int] = {}
+        for i in self._items.values():
+            counts[i.status.value] = counts.get(i.status.value, 0) + 1
+        return {
+            "total": len(self._items),
+            "running": len(self._running),
+            "max_concurrent": self._max_concurrent,
+            **counts,
+        }
+
+    async def _worker(self, worker_id: int) -> None:
+        """Worker loop — dequeue and execute work items."""
+        while not self._shutdown:
+            try:
+                priority, work_id = await asyncio.wait_for(
+                    self._queue.get(), timeout=1.0,
+                )
+            except (TimeoutError, asyncio.TimeoutError):
+                continue
+
+            item = self._items.get(work_id)
+            if item is None or item.status == WorkStatus.CANCELLED:
+                continue
+
+            self._running.add(work_id)
+            item.status = WorkStatus.RUNNING
+            item.started_at = datetime.now(timezone.utc)
+            item.log.append(f"Worker {worker_id} picked up work")
+
+            logger.info(
+                "Worker %d executing: id=%s agent=%s",
+                worker_id, work_id, item.agent_name,
+            )
+
+            try:
+                result = await self._execute(item)
+                item.status = WorkStatus.COMPLETED
+                item.result = result
+                item.completed_at = datetime.now(timezone.utc)
+                item.log.append("Completed successfully")
+
+                # Emit completion event for downstream reactors
+                self._emit_event(
+                    f"{item.agent_name}.work_complete",
+                    {"work_id": work_id, "agent": item.agent_name},
+                )
+                logger.info("Work completed: id=%s agent=%s", work_id, item.agent_name)
+
+            except Exception as exc:
+                item.status = WorkStatus.FAILED
+                item.error = str(exc)
+                item.completed_at = datetime.now(timezone.utc)
+                item.log.append(f"Failed: {exc}")
+                item.log.append(traceback.format_exc())
+
+                self._emit_event(
+                    f"{item.agent_name}.work_failed",
+                    {"work_id": work_id, "agent": item.agent_name, "error": str(exc)},
+                )
+                logger.error(
+                    "Work failed: id=%s agent=%s error=%s",
+                    work_id, item.agent_name, exc,
+                )
+
+            finally:
+                self._running.discard(work_id)
+
+    async def _execute(self, item: WorkItem) -> dict[str, Any]:
+        """Execute a work item through the Conduit pipeline.
+
+        This is where governance happens — the request flows through:
+        Warden scan -> Classify -> Route to agent -> Agent.handle() ->
+        Strategy.reason() with tools -> Sentinel post-call -> Response
+        """
+        from stronghold.types.auth import SYSTEM_AUTH  # noqa: PLC0415
+
+        result: dict[str, Any] = await self._container.route_request(
+            messages=item.messages,
+            auth=SYSTEM_AUTH,
+            intent_hint=item.intent_hint or item.agent_name,
+        )
+        return result
+
+    def _emit_event(self, name: str, data: dict[str, Any]) -> None:
+        """Emit an event to the reactor for downstream processing."""
+        try:
+            from stronghold.events import Event  # noqa: PLC0415
+
+            event = Event(name=name, data=data)
+            self._container.reactor.emit(event)
+        except Exception:
+            logger.debug("Event emission failed (reactor may not be running)", exc_info=True)

--- a/src/stronghold/orchestrator/routes.py
+++ b/src/stronghold/orchestrator/routes.py
@@ -1,0 +1,167 @@
+"""Orchestrator API — dispatch work to any agent, track execution.
+
+POST /v1/stronghold/orchestrator/dispatch  — submit work to an agent
+GET  /v1/stronghold/orchestrator/queue     — list all work items
+GET  /v1/stronghold/orchestrator/status    — engine status summary
+GET  /v1/stronghold/orchestrator/{id}      — get work item details
+POST /v1/stronghold/orchestrator/{id}/cancel — cancel queued work
+POST /v1/stronghold/orchestrator/github-issue — assign a GitHub issue to an agent
+"""
+
+from __future__ import annotations
+
+import uuid
+from typing import Any
+
+from fastapi import APIRouter, HTTPException, Request
+from fastapi.responses import JSONResponse
+
+router = APIRouter(prefix="/v1/stronghold/orchestrator", tags=["orchestrator"])
+
+
+def _engine(request: Request) -> Any:
+    engine = getattr(request.app.state, "orchestrator", None)
+    if engine is None:
+        raise HTTPException(503, "Orchestrator not initialized")
+    return engine
+
+
+@router.post("/dispatch")
+async def dispatch_work(request: Request) -> JSONResponse:
+    """Dispatch work to any agent.
+
+    Body:
+        agent_name: str — which agent handles this (mason, auditor, ranger, etc.)
+        messages: list[dict] — the conversation messages
+        trigger: str — what caused this dispatch (api, webhook, cron, reactor)
+        priority_tier: str — P0-P5 priority
+        intent_hint: str — optional intent hint for the classifier
+        metadata: dict — arbitrary metadata (issue_number, pr_url, etc.)
+    """
+    engine = _engine(request)
+    body = await request.json()
+
+    agent_name = body.get("agent_name", "")
+    if not agent_name:
+        raise HTTPException(400, "agent_name required")
+
+    messages = body.get("messages", [])
+    if not messages:
+        raise HTTPException(400, "messages required")
+
+    # Verify agent exists
+    container = request.app.state.container
+    if agent_name not in container.agents:
+        available = list(container.agents.keys())
+        raise HTTPException(
+            404,
+            f"Agent '{agent_name}' not found. Available: {available}",
+        )
+
+    work_id = body.get("id", str(uuid.uuid4())[:12])
+    item = engine.dispatch(
+        work_id=work_id,
+        agent_name=agent_name,
+        messages=messages,
+        trigger=body.get("trigger", "api"),
+        priority_tier=body.get("priority_tier", "P2"),
+        intent_hint=body.get("intent_hint", ""),
+        metadata=body.get("metadata", {}),
+    )
+    return JSONResponse(item.to_dict(), status_code=202)
+
+
+@router.post("/github-issue")
+async def dispatch_github_issue(request: Request) -> JSONResponse:
+    """Shortcut: assign a GitHub issue to an agent (default: mason).
+
+    Body:
+        issue_number: int
+        title: str
+        owner: str — repo owner
+        repo: str — repo name
+        agent_name: str — default "mason"
+        priority_tier: str — default "P5" (builder tier)
+    """
+    engine = _engine(request)
+    body = await request.json()
+
+    issue_number = body.get("issue_number", 0)
+    if not issue_number:
+        raise HTTPException(400, "issue_number required")
+
+    title = body.get("title", f"Issue #{issue_number}")
+    owner = body.get("owner", "Agent-StrongHold")
+    repo = body.get("repo", "stronghold")
+    agent_name = body.get("agent_name", "mason")
+
+    work_id = f"gh-{issue_number}"
+    content = (
+        f"Implement GitHub issue #{issue_number}: {title}\n\n"
+        f"Repository: {owner}/{repo}\n"
+        f"Read the issue at: https://github.com/{owner}/{repo}/issues/{issue_number}\n\n"
+        f"Follow your SOUL.md pipeline. Create a focused PR when done."
+    )
+
+    item = engine.dispatch(
+        work_id=work_id,
+        agent_name=agent_name,
+        messages=[{"role": "user", "content": content}],
+        trigger=body.get("trigger", "api"),
+        priority_tier=body.get("priority_tier", "P5"),
+        intent_hint="code_gen",
+        metadata={
+            "issue_number": issue_number,
+            "title": title,
+            "owner": owner,
+            "repo": repo,
+        },
+    )
+    return JSONResponse(item.to_dict(), status_code=202)
+
+
+@router.get("/queue")
+async def list_queue(request: Request) -> JSONResponse:
+    """List all work items, optionally filtered by status."""
+    engine = _engine(request)
+    status_filter = request.query_params.get("status")
+    if status_filter:
+        from stronghold.orchestrator.engine import WorkStatus  # noqa: PLC0415
+        try:
+            ws = WorkStatus(status_filter)
+        except ValueError:
+            raise HTTPException(400, f"Invalid status: {status_filter}")
+        items = engine.list_items(status=ws)
+    else:
+        items = engine.list_items()
+    return JSONResponse({"items": items, "count": len(items)})
+
+
+@router.get("/status")
+async def engine_status(request: Request) -> JSONResponse:
+    """Get orchestrator engine status summary."""
+    engine = _engine(request)
+    return JSONResponse(engine.status())
+
+
+@router.get("/{work_id}")
+async def get_work_item(work_id: str, request: Request) -> JSONResponse:
+    """Get details of a specific work item."""
+    engine = _engine(request)
+    item = engine.get(work_id)
+    if item is None:
+        raise HTTPException(404, f"Work item not found: {work_id}")
+    result = item.to_dict()
+    result["log"] = item.log
+    result["result"] = item.result
+    return JSONResponse(result)
+
+
+@router.post("/{work_id}/cancel")
+async def cancel_work(work_id: str, request: Request) -> JSONResponse:
+    """Cancel a queued work item."""
+    engine = _engine(request)
+    cancelled = engine.cancel(work_id)
+    if not cancelled:
+        raise HTTPException(400, "Can only cancel queued items")
+    return JSONResponse({"cancelled": True, "work_id": work_id})

--- a/src/stronghold/orchestrator/routes.py
+++ b/src/stronghold/orchestrator/routes.py
@@ -129,8 +129,8 @@ async def list_queue(request: Request) -> JSONResponse:
         from stronghold.orchestrator.engine import WorkStatus  # noqa: PLC0415
         try:
             ws = WorkStatus(status_filter)
-        except ValueError:
-            raise HTTPException(400, f"Invalid status: {status_filter}")
+        except ValueError as exc:
+            raise HTTPException(400, f"Invalid status: {status_filter}") from exc
         items = engine.list_items(status=ws)
     else:
         items = engine.list_items()

--- a/src/stronghold/orchestrator/routes.py
+++ b/src/stronghold/orchestrator/routes.py
@@ -127,6 +127,7 @@ async def list_queue(request: Request) -> JSONResponse:
     status_filter = request.query_params.get("status")
     if status_filter:
         from stronghold.orchestrator.engine import WorkStatus  # noqa: PLC0415
+
         try:
             ws = WorkStatus(status_filter)
         except ValueError as exc:

--- a/tests/orchestrator/test_engine.py
+++ b/tests/orchestrator/test_engine.py
@@ -1,0 +1,206 @@
+"""Tests for the Orchestrator execution engine."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+from unittest.mock import AsyncMock
+
+import pytest
+
+from stronghold.orchestrator.engine import OrchestratorEngine, WorkItem, WorkStatus
+
+
+class FakeContainer:
+    """Minimal container stub for orchestrator tests."""
+
+    def __init__(self, response: dict[str, Any] | None = None, fail: bool = False) -> None:
+        self._response = response or {"content": "done"}
+        self._fail = fail
+        self.calls: list[dict[str, Any]] = []
+        self.agents = {"mason": True, "auditor": True, "ranger": True}
+        self.reactor = FakeReactor()
+
+    async def route_request(
+        self,
+        messages: list[dict[str, Any]],
+        *,
+        auth: Any = None,
+        session_id: str | None = None,
+        intent_hint: str = "",
+        status_callback: Any = None,
+    ) -> dict[str, Any]:
+        self.calls.append({
+            "messages": messages,
+            "intent_hint": intent_hint,
+        })
+        if self._fail:
+            raise RuntimeError("agent execution failed")
+        return self._response
+
+
+class FakeReactor:
+    def __init__(self) -> None:
+        self.events: list[Any] = []
+
+    def emit(self, event: Any) -> None:
+        self.events.append(event)
+
+
+class TestDispatch:
+    def test_dispatch_creates_work_item(self) -> None:
+        engine = OrchestratorEngine(FakeContainer())
+        item = engine.dispatch(
+            work_id="test-1",
+            agent_name="mason",
+            messages=[{"role": "user", "content": "implement #42"}],
+            trigger="api",
+            priority_tier="P5",
+        )
+        assert item.id == "test-1"
+        assert item.agent_name == "mason"
+        assert item.status == WorkStatus.QUEUED
+        assert item.trigger == "api"
+        assert item.priority_tier == "P5"
+
+    def test_dispatch_metadata(self) -> None:
+        engine = OrchestratorEngine(FakeContainer())
+        item = engine.dispatch(
+            work_id="gh-42",
+            agent_name="mason",
+            messages=[{"role": "user", "content": "fix it"}],
+            metadata={"issue_number": 42, "repo": "stronghold"},
+        )
+        assert item.metadata["issue_number"] == 42
+
+    def test_list_items(self) -> None:
+        engine = OrchestratorEngine(FakeContainer())
+        engine.dispatch(work_id="a", agent_name="mason", messages=[{"role": "user", "content": "a"}])
+        engine.dispatch(work_id="b", agent_name="auditor", messages=[{"role": "user", "content": "b"}])
+        items = engine.list_items()
+        assert len(items) == 2
+
+    def test_cancel_queued(self) -> None:
+        engine = OrchestratorEngine(FakeContainer())
+        engine.dispatch(work_id="c", agent_name="mason", messages=[{"role": "user", "content": "c"}])
+        assert engine.cancel("c") is True
+        assert engine.get("c").status == WorkStatus.CANCELLED
+
+    def test_status(self) -> None:
+        engine = OrchestratorEngine(FakeContainer())
+        engine.dispatch(work_id="d", agent_name="mason", messages=[{"role": "user", "content": "d"}])
+        s = engine.status()
+        assert s["total"] == 1
+        assert s["queued"] == 1
+
+
+class TestExecution:
+    async def test_worker_executes_and_completes(self) -> None:
+        container = FakeContainer(response={"content": "PR created"})
+        engine = OrchestratorEngine(container, max_concurrent=1)
+        await engine.start()
+
+        engine.dispatch(
+            work_id="exec-1",
+            agent_name="mason",
+            messages=[{"role": "user", "content": "implement #42"}],
+            intent_hint="code_gen",
+        )
+
+        # Wait for execution
+        for _ in range(50):
+            item = engine.get("exec-1")
+            if item and item.status in (WorkStatus.COMPLETED, WorkStatus.FAILED):
+                break
+            await asyncio.sleep(0.05)
+
+        await engine.stop()
+
+        item = engine.get("exec-1")
+        assert item is not None
+        assert item.status == WorkStatus.COMPLETED
+        assert item.result == {"content": "PR created"}
+        assert len(container.calls) == 1
+        assert container.calls[0]["intent_hint"] == "code_gen"
+
+    async def test_worker_handles_failure(self) -> None:
+        container = FakeContainer(fail=True)
+        engine = OrchestratorEngine(container, max_concurrent=1)
+        await engine.start()
+
+        engine.dispatch(
+            work_id="fail-1",
+            agent_name="mason",
+            messages=[{"role": "user", "content": "this will fail"}],
+        )
+
+        for _ in range(50):
+            item = engine.get("fail-1")
+            if item and item.status in (WorkStatus.COMPLETED, WorkStatus.FAILED):
+                break
+            await asyncio.sleep(0.05)
+
+        await engine.stop()
+
+        item = engine.get("fail-1")
+        assert item is not None
+        assert item.status == WorkStatus.FAILED
+        assert "agent execution failed" in item.error
+
+    async def test_priority_ordering(self) -> None:
+        container = FakeContainer()
+        engine = OrchestratorEngine(container, max_concurrent=1)
+        # Don't start workers yet — queue items first
+        engine.dispatch(
+            work_id="low", agent_name="mason",
+            messages=[{"role": "user", "content": "low"}],
+            priority_tier="P5",
+        )
+        engine.dispatch(
+            work_id="high", agent_name="mason",
+            messages=[{"role": "user", "content": "high"}],
+            priority_tier="P0",
+        )
+
+        await engine.start()
+
+        for _ in range(50):
+            high = engine.get("high")
+            if high and high.status == WorkStatus.COMPLETED:
+                break
+            await asyncio.sleep(0.05)
+
+        await engine.stop()
+
+        # High priority should have been picked up first
+        assert container.calls[0]["messages"][0]["content"] == "high"
+
+    async def test_cancelled_item_skipped(self) -> None:
+        container = FakeContainer()
+        engine = OrchestratorEngine(container, max_concurrent=1)
+        engine.dispatch(
+            work_id="cancel-me", agent_name="mason",
+            messages=[{"role": "user", "content": "nope"}],
+        )
+        engine.cancel("cancel-me")
+        await engine.start()
+        await asyncio.sleep(0.2)
+        await engine.stop()
+        assert len(container.calls) == 0
+
+    async def test_emits_completion_event(self) -> None:
+        container = FakeContainer()
+        engine = OrchestratorEngine(container, max_concurrent=1)
+        await engine.start()
+        engine.dispatch(
+            work_id="evt-1", agent_name="mason",
+            messages=[{"role": "user", "content": "go"}],
+        )
+        for _ in range(50):
+            item = engine.get("evt-1")
+            if item and item.status == WorkStatus.COMPLETED:
+                break
+            await asyncio.sleep(0.05)
+        await engine.stop()
+        assert len(container.reactor.events) >= 1
+        assert container.reactor.events[0].name == "mason.work_complete"


### PR DESCRIPTION
## What this is

The engine that was never built. Stronghold can now actually execute its own agents through its own governance layer.

## What was broken

Mason was fake. The `mason/XXX` branches were Claude Code worktree agents, not Stronghold dispatching work. The mason router was never mounted. The MasonQueue class didn't exist. configure_mason_router was never called. The strategy in agent.yaml was wrong.

## What this fixes

**OrchestratorEngine** — priority-queued agent execution through the full Conduit pipeline:
- Any agent can be dispatched (mason, auditor, ranger, or custom)
- Any trigger can fire (API, webhook, cron, reactor event)
- Full governance on every execution (Warden, Sentinel, tool policy, audit)
- 6-tier priority ordering (P0 chat-critical through P5 builders)
- Concurrent workers (default 3)
- Event emission for downstream reactors

**API**: dispatch, github-issue, queue, status, details, cancel

**Fixed**: Mason router mounted, MasonQueue created, configure_mason_router called, strategy mismatch fixed (react -> builders_learning)

## Test plan
- [x] 10/10 engine tests pass
- [x] Dispatch, priority, execution, failure, cancellation, events all verified

Refs #64