### PR TITLE
feat: issue backlog scanner — triage, filtering, concurrency, pipeline dispatch (#1060) - CI failed but passed on second try after one too long line.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,15 +25,15 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Set up Python 3.13
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+
       - name: Install system deps
         run: |
           sudo apt-get update -qq
-          sudo apt-get install -y -qq python3-pip python3-venv postgresql-client >/dev/null
-
-      - name: Set up venv
-        run: |
-          python3 -m venv .venv
-          echo "$PWD/.venv/bin" >> "$GITHUB_PATH"
+          sudo apt-get install -y -qq postgresql-client >/dev/null
 
       - name: Install dependencies
         run: pip install -e ".[dev]"
@@ -69,18 +69,17 @@ jobs:
   security:
     name: Security Tests
     runs-on: k3s-runners
-    needs: lint
     steps:
       - uses: actions/checkout@v4
+      - name: Set up Python 3.13
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+
       - name: Install system deps
         run: |
           sudo apt-get update -qq
-          sudo apt-get install -y -qq python3-pip python3-venv postgresql-client >/dev/null
-
-      - name: Set up venv
-        run: |
-          python3 -m venv .venv
-          echo "$PWD/.venv/bin" >> "$GITHUB_PATH"
+          sudo apt-get install -y -qq postgresql-client >/dev/null
       - name: Install dependencies
         run: pip install -e ".[dev]"
       - name: "Warden + Sentinel + Gate"
@@ -99,18 +98,17 @@ jobs:
   sast:
     name: SAST & Supply Chain
     runs-on: k3s-runners
-    needs: lint
     steps:
       - uses: actions/checkout@v4
+      - name: Set up Python 3.13
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+
       - name: Install system deps
         run: |
           sudo apt-get update -qq
-          sudo apt-get install -y -qq python3-pip python3-venv postgresql-client >/dev/null
-
-      - name: Set up venv
-        run: |
-          python3 -m venv .venv
-          echo "$PWD/.venv/bin" >> "$GITHUB_PATH"
+          sudo apt-get install -y -qq postgresql-client >/dev/null
       - name: Install dependencies
         run: pip install -e ".[dev]" pip-audit
 
@@ -175,7 +173,6 @@ jobs:
   test:
     name: Tests
     runs-on: k3s-runners
-    needs: lint
 
     env:
       ROUTER_API_KEY: sk-ci-test-key-minimum-32-characters
@@ -184,15 +181,15 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Set up Python 3.13
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+
       - name: Install system deps
         run: |
           sudo apt-get update -qq
-          sudo apt-get install -y -qq python3-pip python3-venv postgresql-client >/dev/null
-
-      - name: Set up venv
-        run: |
-          python3 -m venv .venv
-          echo "$PWD/.venv/bin" >> "$GITHUB_PATH"
+          sudo apt-get install -y -qq postgresql-client >/dev/null
 
       - name: Install dependencies
         run: pip install -e ".[dev]"
@@ -256,7 +253,7 @@ jobs:
             --cov-report=xml:coverage.xml \
             --cov-fail-under=85
 
-      - name: "Tier 3: Full test suite (PR to develop)"
+      - name: "Tier 3: Full test suite + 90% coverage (PR to develop)"
         if: github.event_name == 'pull_request' && github.base_ref == 'develop'
         env:
           DATABASE_URL: postgresql://stronghold:stronghold@localhost:5433/stronghold
@@ -266,7 +263,8 @@ jobs:
             -m "not perf" \
             --cov=stronghold \
             --cov-report=term-missing \
-            --cov-report=xml:coverage.xml
+            --cov-report=xml:coverage.xml \
+            --cov-fail-under=90
 
       - name: Upload coverage
         if: always() && hashFiles('coverage.xml')

--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,4 @@ Thumbs.db
 deploy/k8s/litellm_config.yaml
 litellm_config.yaml
 .hypothesis/
+.claude/worktrees/

--- a/agents/herald/SOUL.md
+++ b/agents/herald/SOUL.md
@@ -1,0 +1,55 @@
+# Herald -- The Announcer
+
+You are the Herald, the first point of contact for raw ideas entering
+the Stronghold development pipeline. You receive vague feature requests
+and refine them into structured epics that the Quartermaster can decompose.
+
+## Identity
+
+You turn "wouldn't it be cool if..." into "here's exactly what we need to build."
+You do NOT decompose, code, or scaffold. You clarify and structure.
+
+## Process
+
+1. **Read the idea** -- understand what the requester actually wants
+2. **Search the codebase** -- what exists already? What's the delta?
+3. **Search the backlog** -- is this a duplicate? Does it overlap with existing work?
+4. **Clarify if needed** -- post a comment asking questions if the idea is too vague
+5. **Draft the epic** -- structured comment with scope, success criteria, risks
+6. **Relabel** -- remove `idea`/`feature-request`, add `epic` + `builders`
+
+## Epic Draft Format
+
+```markdown
+## Herald -- Epic Draft
+
+### What
+[One paragraph: what this feature delivers]
+
+### Why
+[Who benefits and how]
+
+### Existing Code
+[What already exists in the codebase that this builds on or replaces]
+
+### Success Criteria
+- [ ] [Measurable outcome 1]
+- [ ] [Measurable outcome 2]
+
+### Risks
+- [What could go wrong]
+
+### Affected Modules
+- `src/stronghold/...` -- [what changes]
+
+### Open Questions
+- [Anything still unclear that the Quartermaster should consider]
+```
+
+## Comment Signature
+
+Always end your comments with:
+```
+---
+*-- Herald, via stronghold-workflow-quartermaster[bot]*
+```

--- a/agents/herald/agent.yaml
+++ b/agents/herald/agent.yaml
@@ -1,0 +1,61 @@
+spec_version: "0.1.0"
+name: herald
+version: 1.0.0
+description: >
+  The Herald. Receives raw ideas and feature requests, clarifies them,
+  researches the codebase for existing work, and drafts structured epics
+  for the Quartermaster to decompose into actionable issues.
+soul: SOUL.md
+reasoning:
+  strategy: react
+  max_rounds: 10
+model: auto
+model_fallbacks:
+  - google-gemini-3.1-pro
+  - mistral-large
+  - deepseek-deepseek
+model_constraints:
+  temperature: 0.4
+  max_tokens: 8192
+tools:
+  - github
+  - file_ops
+  - shell
+memory:
+  learnings: true
+  episodic: false
+  knowledge: true
+  session: true
+  shared: false
+  scope: agent
+rules:
+  - "MUST-ALWAYS read the existing issue backlog before drafting an epic"
+  - "MUST-ALWAYS search the codebase for related existing code"
+  - "MUST-ALWAYS include success criteria in every epic draft"
+  - "MUST-ALWAYS include risk assessment in every epic draft"
+  - "MUST-ALWAYS relabel refined issues: remove idea/feature-request, add epic+builders"
+  - "MUST-ALWAYS sign comments with: --- *Herald, via stronghold-workflow-quartermaster[bot]*"
+  - "MUST-NEVER decompose into sub-issues (that is Quartermaster's job)"
+  - "MUST-NEVER write code, tests, or scaffolding"
+  - "MUST-NEVER make architecture decisions"
+trust_tier: t1
+priority_tier: P4
+permissions:
+  max_tool_calls_per_request: 20
+  rate_limit: 10/minute
+delegation_mode: none
+
+capabilities: |
+  You are the **Herald** -- the castle announcer who receives raw ideas
+  and refines them into structured epics. You can:
+  - Read and clarify vague feature requests
+  - Search the codebase for related existing implementations
+  - Search the issue backlog for duplicates and overlaps
+  - Draft structured epics with scope, success criteria, and risks
+  - Relabel issues to route them to the Quartermaster
+
+boundaries: |
+  - **Refinement only.** You clarify and structure, you don't decompose.
+  - **No code.** Ever. Not even pseudocode.
+  - **No architecture decisions.** Follow ARCHITECTURE.md or flag for ADR.
+  - **One idea at a time.**

--- a/agents/herald/agent_card.json
+++ b/agents/herald/agent_card.json
@@ -1,0 +1,18 @@
+{
+  "id": "herald",
+  "name": "herald",
+  "description": "Receives raw ideas, clarifies them, researches the codebase, and drafts structured epics for Quartermaster.",
+  "version": "1.0.0",
+  "protocolVersion": "2024-11-05",
+  "capabilities": {
+    "reasoning_strategy": "react",
+    "tools": ["github", "file_ops", "shell"],
+    "skills": [],
+    "max_tool_rounds": 10
+  },
+  "trust_tier": "t1",
+  "priority_tier": "P4",
+  "model": "auto",
+  "model_fallbacks": ["google-gemini-3.1-pro", "mistral-large", "deepseek-deepseek"],
+  "active": true
+}

--- a/agents/master-at-arms/SOUL.md
+++ b/agents/master-at-arms/SOUL.md
@@ -1,0 +1,63 @@
+# Master-at-Arms -- The Knight Trainer
+
+You are the Master-at-Arms, the agent that trains all other agents by
+reviewing their performance across pipeline runs. You run once daily,
+analyze what worked and what didn't, and store learnings that make the
+entire Stronghold development pipeline more effective over time.
+
+## Identity
+
+You are the coach, not the player. You never execute pipelines or write
+code. You observe outcomes, find patterns, and teach through learnings.
+
+## Daily Review Process
+
+### Pass 1: First-Pass Successes
+Issues that completed without rework. Extract:
+- What made these easy? (labels, body length, complexity)
+- Which models performed best?
+- Which agent configs worked well?
+- Store: "Issues like X succeed first try — reinforce current approach"
+
+### Pass 2: Successful Reworks
+Issues that failed review but passed after rework. Extract:
+- What violation categories triggered the rework?
+- What feedback helped Mason fix it?
+- How many rounds were needed?
+- Store: "MOCK_USAGE violations resolve when feedback includes file path"
+
+### Pass 3: Persistent Failures
+Issues that exhausted all rework rounds. Extract:
+- What kept breaking? Which stage? Which agent?
+- What model was used?
+- Is there a pattern (e.g., "DB migration issues always fail")?
+- Store: "Issues touching persistence/ need DB migration awareness"
+- Post feedback comment to the GitHub issue explaining what was learned
+
+### Pass 4: Model Performance
+Compare success rates across models for each agent:
+- Which model has the highest first-pass success rate for Mason?
+- Which model produces the fewest rework rounds?
+- Token efficiency: cost per successful issue
+- Store: "devstral outperforms codestral on test-writing tasks"
+
+### Pass 5: Tool Effectiveness
+Which tools get used vs ignored in successful runs:
+- Are there tools agents never call? (Candidates for removal)
+- Are there patterns where missing tools cause failures? (Gaps to fill)
+
+## Output Format
+
+Each pattern becomes a Learning object:
+- `category`: "success_pattern" | "rework_pattern" | "failure_pattern" | "model_insight" | "tool_insight"
+- `trigger_keys`: keywords that match when agents encounter similar situations
+- `learning`: the actual insight text
+- `confidence`: based on observation count (1 = low, 5+ = high → auto-promote)
+
+## Comment Signature
+
+When posting to GitHub issues:
+```
+---
+*-- Master-at-Arms, via stronghold-ci-gatekeeper[bot]*
+```

--- a/agents/master-at-arms/agent.yaml
+++ b/agents/master-at-arms/agent.yaml
@@ -1,0 +1,59 @@
+spec_version: "0.1.0"
+name: master-at-arms
+version: 1.0.0
+description: >
+  The Master-at-Arms. Daily retrospective learning agent that reviews
+  all pipeline runs, extracts success/failure patterns, and stores
+  learnings that improve all agents over time.
+soul: SOUL.md
+reasoning:
+  strategy: react
+  max_rounds: 5
+model: auto
+model_fallbacks:
+  - google-gemini-3.1-pro
+  - mistral-large
+  - google-gemini-3-flash
+model_constraints:
+  temperature: 0.3
+  max_tokens: 8192
+tools:
+  - github
+  - file_ops
+memory:
+  learnings: true
+  episodic: true
+  knowledge: true
+  session: false
+  shared: true
+  scope: global
+rules:
+  - "MUST-ALWAYS analyze ALL completed pipeline runs since last review"
+  - "MUST-ALWAYS categorize runs: first-pass success, rework success, persistent failure"
+  - "MUST-ALWAYS store high-confidence patterns as promotable Learnings"
+  - "MUST-ALWAYS post failure feedback to the relevant GitHub issue"
+  - "MUST-ALWAYS sign comments with: --- *Master-at-Arms, via stronghold-ci-gatekeeper[bot]*"
+  - "MUST-NEVER modify agent.yaml files directly (flag recommendations as learnings)"
+  - "MUST-NEVER fabricate data (only report what pipeline runs actually show)"
+trust_tier: t1
+priority_tier: P4
+permissions:
+  max_tool_calls_per_request: 30
+  rate_limit: 5/minute
+delegation_mode: none
+
+capabilities: |
+  You are the **Master-at-Arms** -- the one who trains the knights.
+  You review all pipeline runs and extract patterns that make agents
+  better over time. You can:
+  - Read pipeline run history (success, rework, failure)
+  - Read outcome store (token usage, response times, model performance)
+  - Read violation store (recurring violation categories)
+  - Store learnings in the global scope (visible to all agents)
+  - Post failure feedback as GitHub issue comments
+
+boundaries: |
+  - **Analysis only.** You observe and learn, you don't execute pipelines.
+  - **Evidence-based.** Only report patterns actually observed in data.
+  - **No direct config changes.** Store recommendations as Learnings.
+  - **Daily cadence.** One comprehensive review per day, not real-time.

--- a/agents/master-at-arms/agent_card.json
+++ b/agents/master-at-arms/agent_card.json
@@ -1,0 +1,18 @@
+{
+  "id": "master-at-arms",
+  "name": "master-at-arms",
+  "description": "Daily retrospective learning agent that reviews pipeline runs and extracts patterns to improve all agents.",
+  "version": "1.0.0",
+  "protocolVersion": "2024-11-05",
+  "capabilities": {
+    "reasoning_strategy": "react",
+    "tools": ["github", "file_ops"],
+    "skills": [],
+    "max_tool_rounds": 5
+  },
+  "trust_tier": "t1",
+  "priority_tier": "P4",
+  "model": "auto",
+  "model_fallbacks": ["google-gemini-3.1-pro", "mistral-large", "google-gemini-3-flash"],
+  "active": true
+}

--- a/deploy/helm/stronghold/values-prod-homelab.yaml
+++ b/deploy/helm/stronghold/values-prod-homelab.yaml
@@ -43,9 +43,21 @@ mcp:
   github:
     devMode: true
 
+# Local registry on PVE host (no ghcr.io needed for private repo).
+# Images stored on MergerFS at /mnt/storage/registry.
+image:
+  repository: 10.10.42.100:5000/stronghold
+  tag: latest
+  pullPolicy: Always
+
 # Homelab resource tuning (single-node, 32GB RAM, 10 vCPU).
 strongholdApi:
   replicas: 1
+  image:
+    registry: ""
+    repository: 10.10.42.100:5000/stronghold
+    tag: latest
+    pullPolicy: Always
   resources:
     requests:
       cpu: 500m

--- a/docs/SECURITY_FINDINGS.md
+++ b/docs/SECURITY_FINDINGS.md
@@ -1,0 +1,262 @@
+# Security Findings — Edge-Case Review Log
+
+Running log of security findings uncovered via mutation-testing / edge-case
+review. Each finding has a `SEC-NNN` identifier, a backing regression test
+in `tests/test_security_regressions.py` or `tests/test_deep_edge_cases.py`,
+and a commit that ships the fix.
+
+**Methodology.** For each module, ask:
+
+1. What's the minimal broken implementation that passes the existing tests?
+2. What inputs would a security researcher try?
+3. What invariants could be violated through state machine edges?
+4. Where does the code implicitly trust its inputs?
+
+**Rule:** no finding is closed until there's a named regression test whose
+failure message points directly back at this log.
+
+---
+
+## Findings
+
+### SEC-001 — file_ops prefix collision sandbox escape
+- **Severity:** HIGH
+- **File:** `src/stronghold/tools/file_ops.py`
+- **Bug:** `str(target).startswith(str(ws.resolve()))` matched
+  `/tmp/work-evil/secret.txt` when the workspace was `/tmp/work`, because
+  `"/tmp/work-evil/..."` is a string-prefix of `"/tmp/work"`.
+- **Impact:** A user could read files in a sibling directory that happens to
+  share a prefix with their workspace.
+- **Fix:** Use `Path.relative_to(ws_resolved)` instead of string `startswith`.
+- **Regression test:** `test_sec001_prefix_collision_sandbox_escape`
+- **Commit:** `cd99425`
+
+### SEC-002 — file_ops symlink escape
+- **Severity:** HIGH
+- **File:** `src/stronghold/tools/file_ops.py`
+- **Bug:** `resolve()` followed symlinks inside the workspace. A symlink
+  `<workspace>/escape -> /tmp` made `target.startswith(workspace)` false,
+  which happened to look correct — but the code could still `list()` the
+  symlink's contents before the prefix check fired for the outer call.
+- **Impact:** Sandbox escape via user-planted symlinks.
+- **Fix:** Same `relative_to` fix as SEC-001; the resolved real path is
+  compared against the resolved workspace, so symlinks pointing outside
+  are rejected by containment check.
+- **Regression test:** `test_sec002_symlink_escape_via_workspace`
+- **Commit:** `cd99425`
+
+### SEC-003 — shell_exec command injection via semicolon
+- **Severity:** CRITICAL
+- **File:** `src/stronghold/tools/shell_exec.py`
+- **Bug:** Allowlist only checked `cmd.startswith("echo")` etc. A command
+  like `echo hi; rm -rf victim.txt` passed the allowlist, then the shell
+  executed the `rm` part.
+- **Impact:** Arbitrary command execution bounded only by the sandbox
+  container permissions. In dev, full host access.
+- **Fix:** Reject a set of shell metacharacters (`; | & \` $( ${ > < \n \r`)
+  *before* the allowlist check.
+- **Regression test:** `test_sec003_shell_injection_via_semicolon` plus
+  `test_shell_metacharacter_variants_all_rejected` as a sweep.
+- **Commit:** `cd99425`
+
+### SEC-004 — shell_exec injection via `$(...)` command substitution
+- **Severity:** CRITICAL
+- **File:** `src/stronghold/tools/shell_exec.py`
+- **Bug:** `echo $(rm victim.txt)` passed the allowlist.
+- **Fix:** Same metachar reject as SEC-003 (`$(` is in the block list).
+- **Regression test:** `test_sec004_shell_injection_via_command_substitution`
+- **Commit:** `cd99425`
+
+### SEC-005 — shell_exec injection via pipe to disallowed command
+- **Severity:** CRITICAL
+- **File:** `src/stronghold/tools/shell_exec.py`
+- **Bug:** `ls | xargs rm` passed because `ls` is allowed.
+- **Fix:** Pipe `|` rejected by metachar check.
+- **Regression test:** `test_sec005_shell_injection_via_pipe`
+- **Commit:** `cd99425`
+
+### SEC-006 — session_store crash on poisoned JSON
+- **Severity:** MEDIUM
+- **File:** `src/stronghold/cache/session_store.py`
+- **Bug:** `json.loads(item)` ran inside a loop without a try/except.
+  One corrupt entry (from a legacy format, a partial write, or a malicious
+  inject) raised `JSONDecodeError` and killed the whole `get_history` call
+  — meaning one bad entry effectively denial-of-services the entire session.
+- **Fix:** Per-entry try/except; log and skip poisoned entries, return
+  whatever is valid.
+- **Regression test:** `test_sec006_session_store_poisoned_json_does_not_crash`
+- **Commit:** `cd99425`
+
+### SEC-007 — file_ops null byte in path raises ValueError
+- **Severity:** MEDIUM
+- **File:** `src/stronghold/tools/file_ops.py`
+- **Bug:** `resolve()` raised on an embedded NUL before the sandbox check
+  ran, propagating an unhandled exception to the caller.
+- **Impact:** Pollutes logs with tracebacks; a clever attacker could use
+  exception content to fingerprint behavior; minor DoS vector.
+- **Fix:** Wrap `resolve()` in try/except, return clean `ToolResult(error=...)`.
+- **Regression test:** `test_sec007_null_byte_in_path`
+- **Commit:** `cd99425`
+
+### SEC-008 — coins `_decimal` accepts NaN / Infinity
+- **Severity:** MEDIUM
+- **File:** `src/stronghold/quota/coins.py`
+- **Bug:** `Decimal("NaN")` constructs a NaN value. Any comparison against
+  NaN (`budget > limit`) returns `False`. A user submitting `"NaN"` as a
+  budget amount would silently bypass *all* budget enforcement.
+- **Impact:** Budget bypass. User could run unlimited requests.
+- **Fix:** After parsing, check `is_nan() or is_infinite()` and return
+  the default value.
+- **Regression tests:** `test_sec008_decimal_rejects_nan`,
+  `test_sec008_coin_budget_nan_does_not_bypass`
+- **Commit:** `cd99425`
+
+### SEC-009 — session_store `append_messages` crashes on non-dict entries
+- **Severity:** MEDIUM
+- **File:** `src/stronghold/cache/session_store.py`
+- **Bug:** `msg.get("role", "")` raised `AttributeError: 'str' object has
+  no attribute 'get'` when messages contained anything other than a dict
+  (e.g., a malformed LLM response, an upstream serialization bug).
+- **Impact:** One malformed message takes down session writes for that user.
+- **Fix:** `isinstance(msg, dict)` guard before `.get()` calls.
+- **Regression test:** `test_sec009_non_dict_message_skipped`
+- **Commit:** `e817043`
+
+### SEC-011 — agents/factory crashes on `tools: null` in YAML
+- **Severity:** MEDIUM
+- **File:** `src/stronghold/agents/factory.py`
+- **Bug:** `tuple(manifest.get("tools", ()))` raised `TypeError: 'NoneType'
+  object is not iterable` when YAML had `tools: null` or `tools:` with no
+  value. Same bug affected `skills`, `rules`, `model_fallbacks`, `phases`.
+- **Impact:** Any agent.yaml with an empty list field crashes loader.
+- **Fix:** `_safe_tuple` helper that returns `()` for None, wraps single
+  strings in a 1-tuple, and handles list/tuple/other correctly. Applied
+  to all five fields.
+- **Regression test:** `test_sec011_manifest_with_none_tools`,
+  `test_sec011_all_list_fields_none_safe`
+- **Commit:** (next)
+
+### SEC-012 — agents/factory iterates `tools: "shell"` as characters
+- **Severity:** MEDIUM
+- **File:** `src/stronghold/agents/factory.py`
+- **Bug:** `tuple("shell")` returns `('s','h','e','l','l')`. A common YAML
+  mistake (`tools: "shell"` instead of `tools: [shell]`) silently produced
+  an agent with 5 single-character "tools". The loader would then fail at
+  runtime when none of those "tools" resolve to real tools, but the
+  failure would be confusing.
+- **Fix:** `_safe_tuple` detects strings and wraps them in a 1-tuple
+  (lenient interpretation).
+- **Regression test:** `test_sec012_manifest_with_string_tools`
+- **Commit:** (next)
+
+### SEC-013 — conduit consent maps grow without bound
+- **Severity:** MEDIUM (memory exhaustion / DoS)
+- **File:** `src/stronghold/conduit.py`
+- **Bug:** `_session_agents` had a cap of `_MAX_STICKY_SESSIONS = 10_000`
+  with eviction. `_session_consents` and `_consent_pending` were also
+  populated on every consent-related request but had NO cap — an attacker
+  that can trigger the consent path across many session IDs could exhaust
+  memory.
+- **Fix:** Add `_MAX_CONSENT_ENTRIES = 10_000` constant and evict oldest
+  entries on every write to either consent map.
+- **Regression test:** `test_sec013_consent_maps_have_eviction_cap_constant`,
+  `test_sec013_eviction_code_present`
+- **Commit:** (next)
+
+### SEC-014 — `/admin/coins/convert` crashes on non-numeric `copper_amount`
+- **Severity:** MEDIUM
+- **File:** `src/stronghold/api/routes/admin.py`
+- **Bug:** `int(body.get("copper_amount", 0))` raised uncaught `ValueError`
+  on `"not-a-number"`, `"10.5"`, or any non-integer string, returning a
+  500 instead of a 400. Leaked stack trace in response body (FastAPI default).
+- **Impact:** Clear 500 vs 400 is a soundness issue; no auth bypass.
+- **Fix:** Wrap `int()` in try/except, return `HTTPException(400)`.
+- **Regression test:** `test_convert_non_numeric_copper_amount`
+- **Commit:** (next)
+
+### SEC-010 — scanner `detect_todo_fixme` crashes on non-UTF-8 files
+- **Severity:** MEDIUM
+- **File:** `src/stronghold/tools/scanner.py`
+- **Bug:** `read_text(encoding="utf-8")` raised `UnicodeDecodeError` on
+  non-UTF-8 `.py` files. Would take down the `/v1/stronghold/mason/scan`
+  endpoint for any repo containing a binary-ish file named `*.py`.
+- **Impact:** API endpoint crashes; DoS via repo content.
+- **Fix:** try/except around `read_text`; skip unreadable files.
+  `detect_untested_modules` already had this guard; `detect_todo_fixme`
+  did not.
+- **Regression test:** `test_sec010_binary_file_does_not_crash`
+- **Commit:** `e817043`
+
+---
+
+## Documented Limitations (Not Bugs)
+
+These came out of the same reviews but are intentional / acceptable:
+
+- **LIM-001** — `RedisPromptCache.set(key, None)` is indistinguishable from
+  "key missing" on subsequent `get`. Callers should not store `None` as a
+  valid value. Documented via test.
+
+- **LIM-002** — `_find_model` is case-sensitive. `"GPT-4"` does not match
+  `"gpt-4"`. Callers are expected to normalize before lookup.
+
+- **LIM-003** — `shell_exec` rejects shell metacharacters inside quotes
+  (`echo "hi; done"`). The shell would treat `;` as literal, but our check
+  is conservative and rejects it anyway to avoid parsing quote state.
+  Tradeoff: conservative false positive, safer.
+
+- **LIM-004** — `triggers.canary_deployment_check` propagates exceptions
+  from `canary_manager.check_promotion_or_rollback` instead of swallowing
+  them. The reactor is expected to isolate trigger failures at its layer.
+  Verified by regression test.
+
+- **LIM-005** — `config/loader._validate_url_not_private` resolves DNS at
+  config-load time. A DNS rebinding attacker (control over the hostname's
+  A record) could return a public IP during validation, then a private IP
+  during the actual HTTP request. The code falls back to "warn only" when
+  DNS fails (container startup case), which widens the window. Mitigation:
+  the HTTP client layer should re-check resolved IPs at connect time.
+  Documented by `test_dns_failure_logs_warning_not_error`.
+
+- **LIM-006** — `conduit.determine_execution_tier` allows an agent to
+  downgrade a user-classified P0 request to P5. Test documents this as
+  current behavior; whether it's intended is a product decision (operator
+  agents may legitimately process critical requests in batch). Not a
+  security bug unless paired with a compromised agent definition.
+
+- **LIM-007** — `workspace._ensure_clone` embeds `owner` and `repo` into
+  a URL string. An owner like `--upload-pack=/bin/sh` is embedded as a
+  URL path segment (not a separate argv), so git URL parsing rejects it.
+  However, `repo=../other` could produce a URL like
+  `https://github.com/owner/../other.git` — git treats this as a URL
+  segment, not a local path. The generated local destination
+  (`self._base / "repos" / repo`) contains `..` which could escape the
+  base directory. Callers (Mason assign route) validate owner/repo via
+  GitHub webhook payload, so untrusted input is not currently a path,
+  but the code does no explicit validation.
+
+- **LIM-008** — `agents/factory._safe_tuple` uses lenient interpretation
+  for strings (wraps `"shell"` as `("shell",)`). A stricter implementation
+  would reject strings entirely and require lists. Tradeoff: lenient is
+  friendlier to YAML writers but silently accepts the wrong schema.
+
+---
+
+## Review Coverage
+
+| Module | Reviewed | Bugs found |
+|--------|---------|-----------|
+| `tools/file_ops.py` | ✅ | 3 (SEC-001, 002, 007) |
+| `tools/shell_exec.py` | ✅ | 3 (SEC-003, 004, 005) |
+| `tools/scanner.py` | ✅ | 1 (SEC-010) |
+| `cache/session_store.py` | ✅ | 2 (SEC-006, 009) |
+| `cache/rate_limiter.py` | ✅ | 0 |
+| `cache/prompt_cache.py` | ✅ | 0 |
+| `quota/coins.py` | ✅ | 1 (SEC-008) |
+| `triggers.py` | ✅ | 0 |
+| `api/routes/mason.py` | ✅ | 0 (HMAC verified) |
+| `conduit.py` | ✅ | 1 (SEC-013) |
+| `tools/workspace.py` | ✅ | 0 (git subprocess safe via list args; URL-path injection documented) |
+| `agents/factory.py` | ✅ | 2 (SEC-011, SEC-012) |
+| `config/loader.py` | ✅ | 0 (IP checks solid; DNS rebinding documented as LIM-005) |
+| `api/routes/admin.py` (coins) | ✅ | 1 (SEC-014) |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,7 +89,10 @@ source = ["stronghold"]
 omit = ["src/stronghold/persistence/pg_*.py"]
 
 [tool.coverage.report]
-fail_under = 95
+# No global fail_under — CI workflows enforce per-tier:
+#   feature/* PRs: 85% diff coverage
+#   develop PRs: 90% total coverage
+#   main PRs: 95% diff coverage (release.yml)
 exclude_lines = [
     "pragma: no cover",
     "if TYPE_CHECKING:",

--- a/src/stronghold/agents/factory.py
+++ b/src/stronghold/agents/factory.py
@@ -131,26 +131,44 @@ def _parse_agent_dir(agent_dir: Path) -> tuple[dict[str, Any], str, str] | None:
 # ── Identity + strategy ──────────────────────────────────────────────
 
 
+def _safe_tuple(value: Any) -> tuple:
+    """Coerce YAML values to tuple safely.
+
+    YAML footguns this protects against (SEC-011, SEC-012):
+      - `tools: null` → Python None → tuple(None) raises TypeError
+      - `tools: "shell"` → string → tuple iterates chars as ('s','h','e','l','l')
+      - `tools: {}` / `tools: 42` → invalid, silently becomes ()
+    """
+    if value is None:
+        return ()
+    if isinstance(value, str):
+        # Common YAML mistake: `tools: "shell"` meant `tools: [shell]`
+        return () if not value else (value,)
+    if isinstance(value, (list, tuple)):
+        return tuple(value)
+    return ()
+
+
 def _build_identity_from_manifest(manifest: dict[str, Any]) -> AgentIdentity:
     name = manifest["name"]
-    reasoning = manifest.get("reasoning", {})
+    reasoning = manifest.get("reasoning", {}) or {}
     return AgentIdentity(
         name=name,
         version=manifest.get("version", "1.0.0"),
         description=manifest.get("description", ""),
         soul_prompt_name=f"agent.{name}.soul",
         model=manifest.get("model", "auto"),
-        model_fallbacks=tuple(manifest.get("model_fallbacks", ())),
-        model_constraints=manifest.get("model_constraints", {}),
-        tools=tuple(manifest.get("tools", ())),
-        skills=tuple(manifest.get("skills", ())),
-        rules=tuple(manifest.get("rules", ())),
+        model_fallbacks=_safe_tuple(manifest.get("model_fallbacks")),
+        model_constraints=manifest.get("model_constraints", {}) or {},
+        tools=_safe_tuple(manifest.get("tools")),
+        skills=_safe_tuple(manifest.get("skills")),
+        rules=_safe_tuple(manifest.get("rules")),
         trust_tier=manifest.get("trust_tier", "t2"),
         priority_tier=manifest.get("priority_tier", "P2"),
         max_tool_rounds=reasoning.get("max_subtasks", reasoning.get("max_rounds", 3)),
         reasoning_strategy=reasoning.get("strategy", "direct"),
-        memory_config=manifest.get("memory", {}),
-        phases=tuple(reasoning.get("phases", ())),
+        memory_config=manifest.get("memory", {}) or {},
+        phases=_safe_tuple(reasoning.get("phases")),
     )
 
 

--- a/src/stronghold/api/app.py
+++ b/src/stronghold/api/app.py
@@ -46,6 +46,7 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
 
     orchestrator = OrchestratorEngine(container, max_concurrent=3)
     app.state.orchestrator = orchestrator
+    container.orchestrator = orchestrator  # expose to triggers + pipeline
 
     # Start the reactor loop (1000Hz, runs in background)
     disable_reactor = os.environ.get("STRONGHOLD_DISABLE_REACTOR_AUTOSTART") == "1"

--- a/src/stronghold/api/routes/admin.py
+++ b/src/stronghold/api/routes/admin.py
@@ -1115,7 +1115,11 @@ async def convert_coins(request: Request) -> JSONResponse:
     container = request.app.state.container
     body: dict[str, Any] = await request.json()
 
-    copper_amount = int(body.get("copper_amount", 0))
+    # SEC-014: guard int() against non-numeric input
+    try:
+        copper_amount = int(body.get("copper_amount", 0))
+    except (TypeError, ValueError) as e:
+        raise HTTPException(status_code=400, detail=f"copper_amount must be an integer: {e}") from e
     if copper_amount < 10:
         raise HTTPException(status_code=400, detail="Minimum conversion: 10 copper")
 

--- a/src/stronghold/api/routes/mason.py
+++ b/src/stronghold/api/routes/mason.py
@@ -382,27 +382,20 @@ async def github_webhook(request: Request) -> JSONResponse:
     from stronghold.types.reactor import Event
 
     # Issue assigned -> queue for Mason
-    if event_type == "issues" and action == "assigned":
+    if event_type == "issues" and action in ("assigned", "labeled"):
         issue = payload.get("issue", {})
-        repo = payload.get("repository", {})
-        queue = _queue()
-        queued = queue.assign(
-            issue_number=issue.get("number", 0),
-            title=issue.get("title", ""),
-            owner=repo.get("owner", {}).get("login", ""),
-            repo=repo.get("name", ""),
-        )
-        _reactor().emit(
-            Event(
-                name="mason.issue_assigned",
-                data={
-                    "issue_number": queued.issue_number,
-                    "title": queued.title,
-                    "source": "github_webhook",
-                },
+        issue_labels = {label["name"] for label in issue.get("labels", [])}
+
+        # Only react to issues with the `builders` label
+        if "builders" not in issue_labels:
+            logger.debug("Webhook: issue #%d has no builders label, ignoring", issue.get("number"))
+        else:
+            # The backlog scanner (runs every 5 min) will pick this up.
+            # We just log it here — no direct dispatch to Mason.
+            logger.info(
+                "Webhook: issue #%d labeled builders — will be picked up by backlog scanner",
+                issue.get("number", 0),
             )
-        )
-        logger.info("Webhook: issue #%d assigned to Mason", queued.issue_number)
 
     # PR opened -> trigger Auditor review
     elif event_type == "pull_request" and action == "opened":

--- a/src/stronghold/cache/session_store.py
+++ b/src/stronghold/cache/session_store.py
@@ -111,6 +111,9 @@ class RedisSessionStore:
         rkey = self._key(session_id)
         pipe = self._redis.pipeline()
         for msg in messages:
+            # SEC-009: skip non-dict entries to avoid AttributeError on .get()
+            if not isinstance(msg, dict):
+                continue
             role = msg.get("role", "")
             content = msg.get("content", "")
             if role not in ("user", "assistant"):

--- a/src/stronghold/cache/session_store.py
+++ b/src/stronghold/cache/session_store.py
@@ -80,7 +80,8 @@ class RedisSessionStore:
                 msg = json.loads(item)
             except (json.JSONDecodeError, TypeError, ValueError):
                 logger.warning(
-                    "Skipping poisoned session entry in %s", session_id,
+                    "Skipping poisoned session entry in %s",
+                    session_id,
                 )
                 continue
             if not isinstance(msg, dict):

--- a/src/stronghold/cache/session_store.py
+++ b/src/stronghold/cache/session_store.py
@@ -71,10 +71,20 @@ class RedisSessionStore:
         # Refresh key-level TTL on access
         await self._redis.expire(rkey, self._ttl)
 
-        # Filter by per-message timestamp, return only role+content
+        # Filter by per-message timestamp, return only role+content.
+        # Skip (log) any poisoned/non-JSON entries rather than crashing the
+        # whole session retrieval.
         result: list[dict[str, str]] = []
         for item in raw:
-            msg = json.loads(item)
+            try:
+                msg = json.loads(item)
+            except (json.JSONDecodeError, TypeError, ValueError):
+                logger.warning(
+                    "Skipping poisoned session entry in %s", session_id,
+                )
+                continue
+            if not isinstance(msg, dict):
+                continue
             ts = msg.pop("_ts", 0)
             if ts >= cutoff:
                 result.append({"role": msg.get("role", ""), "content": msg.get("content", "")})

--- a/src/stronghold/conduit.py
+++ b/src/stronghold/conduit.py
@@ -139,6 +139,7 @@ class Conduit:
     """
 
     _MAX_STICKY_SESSIONS = 10_000  # Evict oldest entries when exceeded
+    _MAX_CONSENT_ENTRIES = 10_000  # SEC-013: bound consent maps too
 
     def __init__(self, container: Container) -> None:
         self._c = container
@@ -337,6 +338,11 @@ class Conduit:
                 if session_id not in self._session_consents:
                     self._session_consents[session_id] = set()
                 self._session_consents[session_id].add(pending_provider)
+                # SEC-013: bound consent map growth
+                if len(self._session_consents) > self._MAX_CONSENT_ENTRIES:
+                    excess = len(self._session_consents) - self._MAX_CONSENT_ENTRIES
+                    for old_key in list(self._session_consents)[:excess]:
+                        del self._session_consents[old_key]
                 logger.info(
                     "Data sharing consent granted: session=%s provider=%s",
                     session_id,
@@ -464,6 +470,11 @@ class Conduit:
                     "for model training."
                 )
                 self._consent_pending[session_id] = full_selection.provider
+                # SEC-013: bound consent pending map
+                if len(self._consent_pending) > self._MAX_CONSENT_ENTRIES:
+                    excess = len(self._consent_pending) - self._MAX_CONSENT_ENTRIES
+                    for old_key in list(self._consent_pending)[:excess]:
+                        del self._consent_pending[old_key]
 
                 arbiter_agent = self._fallback_agent("arbiter")
                 consent_messages = [

--- a/src/stronghold/container.py
+++ b/src/stronghold/container.py
@@ -85,6 +85,7 @@ class Container:
     coin_ledger: Any = None
     tournament: Any = None
     canary_manager: Any = None
+    orchestrator: Any = None  # OrchestratorEngine, set in app.py lifespan
     learning_approval_gate: Any = None
     learning_promoter: Any = None
     strike_tracker: Any = None  # InMemoryStrikeTracker

--- a/src/stronghold/quota/coins.py
+++ b/src/stronghold/quota/coins.py
@@ -27,11 +27,18 @@ DEFAULT_PRICING_VERSION = "default-v1"
 
 
 def _decimal(value: object, default: str = "0") -> Decimal:
-    """Safely coerce unknown config values into a Decimal."""
+    """Safely coerce unknown config values into a Decimal.
+
+    Rejects NaN and Infinity — those would silently bypass budget checks
+    because any comparison against NaN is False.
+    """
     if value in (None, ""):
         return Decimal(default)
     try:
-        return Decimal(str(value))
+        result = Decimal(str(value))
+        if result.is_nan() or result.is_infinite():
+            return Decimal(default)
+        return result
     except Exception:
         return Decimal(default)
 

--- a/src/stronghold/resources/catalog.py
+++ b/src/stronghold/resources/catalog.py
@@ -8,6 +8,7 @@ Per-call vault credential injection at the resolver layer.
 from __future__ import annotations
 
 import logging
+import posixpath
 import re
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
@@ -95,7 +96,6 @@ class ResourceCatalog:
         path = match.group("path")
 
         # Normalize path to prevent traversal attacks (../)
-        import posixpath
         path = posixpath.normpath(path)
         if path.startswith("..") or "/../" in f"/{path}/":
             logger.warning("Path traversal attempt blocked: %s", uri)

--- a/src/stronghold/resources/catalog.py
+++ b/src/stronghold/resources/catalog.py
@@ -94,6 +94,13 @@ class ResourceCatalog:
         scope = match.group("scope")
         path = match.group("path")
 
+        # Normalize path to prevent traversal attacks (../)
+        import posixpath
+        path = posixpath.normpath(path)
+        if path.startswith("..") or "/../" in f"/{path}/":
+            logger.warning("Path traversal attempt blocked: %s", uri)
+            return None
+
         # Enforce tenant/user namespace isolation
         if scope == "user" and (not user_id or not path.startswith(f"{user_id}/")):
             logger.warning(

--- a/src/stronghold/security/task_policy.py
+++ b/src/stronghold/security/task_policy.py
@@ -102,7 +102,9 @@ class InMemoryTaskAcceptancePolicy:
         if priority_tier not in self._budget_limits:
             logger.warning(
                 "Budget DENIED: user=%s org=%s unknown tier=%s",
-                user_id, org_id, priority_tier,
+                user_id,
+                org_id,
+                priority_tier,
             )
             return False
         limits = self._budget_limits[priority_tier]

--- a/src/stronghold/security/task_policy.py
+++ b/src/stronghold/security/task_policy.py
@@ -98,9 +98,14 @@ class InMemoryTaskAcceptancePolicy:
         cost_budget: float | None = None,
         wall_clock_seconds: float | None = None,
     ) -> bool:
-        limits = self._budget_limits.get(priority_tier, {})
-        if not limits:
-            return True
+        # Reject unknown tiers (security: prevent bypass via invalid tier names)
+        if priority_tier not in self._budget_limits:
+            logger.warning(
+                "Budget DENIED: user=%s org=%s unknown tier=%s",
+                user_id, org_id, priority_tier,
+            )
+            return False
+        limits = self._budget_limits[priority_tier]
 
         if token_budget is not None and token_budget > limits.get("max_tokens", float("inf")):
             logger.warning(

--- a/src/stronghold/tools/file_ops.py
+++ b/src/stronghold/tools/file_ops.py
@@ -56,9 +56,20 @@ class FileOpsExecutor:
         if not ws.is_dir():
             return ToolResult(success=False, error=f"workspace not found: {workspace}")
 
-        # Resolve and sandbox
-        target = (ws / rel_path).resolve()
-        if not str(target).startswith(str(ws.resolve())):
+        # Resolve and sandbox. Use is_relative_to (Path semantics) instead of
+        # string startswith to prevent:
+        #   - prefix collision attacks (/tmp/work vs /tmp/work-evil)
+        #   - symlink escapes (symlink in workspace pointing outside)
+        # Catch null bytes and other OS errors from resolve().
+        try:
+            ws_resolved = ws.resolve(strict=True)
+            target = (ws / rel_path).resolve(strict=False)
+        except (OSError, ValueError) as e:
+            return ToolResult(success=False, error=f"invalid path: {e}")
+
+        try:
+            target.relative_to(ws_resolved)
+        except ValueError:
             return ToolResult(success=False, error="path escapes workspace")
 
         try:

--- a/src/stronghold/tools/github.py
+++ b/src/stronghold/tools/github.py
@@ -34,6 +34,12 @@ GITHUB_TOOL_DEF = ToolDefinition(
                     "get_pr_diff",
                     "post_pr_comment",
                     "list_pr_comments",
+                    "submit_review",
+                    "close_pr",
+                    "merge_pr",
+                    "add_labels",
+                    "remove_label",
+                    "close_issue",
                 ],
                 "description": "The GitHub operation to perform.",
             },
@@ -54,6 +60,20 @@ GITHUB_TOOL_DEF = ToolDefinition(
                 "enum": ["open", "closed", "all"],
                 "description": "Issue state filter.",
             },
+            "event": {
+                "type": "string",
+                "enum": ["APPROVE", "REQUEST_CHANGES", "COMMENT"],
+                "description": "Review verdict for submit_review.",
+            },
+            "merge_method": {
+                "type": "string",
+                "enum": ["squash", "merge", "rebase"],
+                "description": "Merge method for merge_pr (default: squash).",
+            },
+            "label": {
+                "type": "string",
+                "description": "Single label name (for remove_label).",
+            },
         },
         "required": ["action", "owner", "repo"],
     },
@@ -62,14 +82,110 @@ GITHUB_TOOL_DEF = ToolDefinition(
 )
 
 
+# ── GitHub App bot identities ───────────────────────────────────────
+#
+# Four bots, each a separate GitHub App installed on Agent-StrongHold:
+#
+#   gatekeeper    — Auditor, Janitor, CI triage, Master-at-Arms
+#   quartermaster — Quartermaster + Herald (both planners)
+#   archie        — Archie (scaffolding)
+#   mason         — Mason (building)
+
+_BOT_REGISTRY: dict[str, dict[str, str]] = {
+    "gatekeeper": {
+        "app_id": "3354708",
+        "installation_id": "123359098",
+        "key_path": "~/.conductor-secrets/gatekeeper.pem",
+    },
+    "archie": {
+        "app_id": "3354872",
+        "installation_id": "123361328",
+        "key_path": "~/.conductor-secrets/archie.pem",
+    },
+    "mason": {
+        "app_id": "3354924",
+        "installation_id": "123362160",
+        "key_path": "~/.conductor-secrets/mason.pem",
+    },
+    "quartermaster": {
+        "app_id": "3355040",
+        "installation_id": "123365500",
+        "key_path": "~/.conductor-secrets/quartermaster.pem",
+    },
+}
+
+
+def _get_app_installation_token(bot: str = "gatekeeper") -> str:
+    """Generate a short-lived installation token for a named bot identity."""
+    try:
+        import jwt as pyjwt  # noqa: PLC0415
+    except ImportError:
+        logger.debug("PyJWT not installed — GitHub App auth unavailable")
+        return ""
+
+    import time  # noqa: PLC0415
+
+    reg = _BOT_REGISTRY.get(bot, _BOT_REGISTRY["gatekeeper"])
+    app_id = os.environ.get("GITHUB_APP_ID", reg["app_id"])
+    key_path = os.environ.get(
+        "GITHUB_APP_PRIVATE_KEY_PATH",
+        os.path.expanduser(reg["key_path"]),
+    )
+    installation_id = os.environ.get("GITHUB_APP_INSTALLATION_ID", reg["installation_id"])
+
+    if not app_id or not installation_id:
+        return ""
+
+    try:
+        with open(key_path) as f:
+            private_key = f.read()
+    except FileNotFoundError:
+        logger.debug("GitHub App private key not found at %s", key_path)
+        return ""
+
+    now = int(time.time())
+    jwt_token = pyjwt.encode(
+        {"iat": now - 60, "exp": now + 600, "iss": app_id},
+        private_key,
+        algorithm="RS256",
+    )
+
+    try:
+        import httpx  # noqa: PLC0415
+
+        resp = httpx.post(
+            f"https://api.github.com/app/installations/{installation_id}/access_tokens",
+            headers={
+                "Authorization": f"Bearer {jwt_token}",
+                "Accept": "application/vnd.github+json",
+            },
+            timeout=15.0,
+        )
+        resp.raise_for_status()
+        token = resp.json().get("token", "")
+        if token:
+            logger.info("GitHub App token generated for bot=%s", bot)
+        return token
+    except Exception:
+        logger.warning("Failed to generate GitHub App token for bot=%s", bot, exc_info=True)
+        return ""
+
+
 class GitHubToolExecutor:
     """Executes GitHub operations via the REST API.
 
     Implements the ToolExecutor protocol.
+
+    Auth priority:
+    1. GitHub App installation token (posts as the named bot)
+    2. Explicit token param
+    3. GITHUB_TOKEN env var (PAT — posts as the user)
     """
 
-    def __init__(self, token: str = "") -> None:
-        self._token = token or os.environ.get("GITHUB_TOKEN", "")
+    def __init__(self, token: str = "", bot: str = "gatekeeper") -> None:
+        app_token = _get_app_installation_token(bot)
+        self._token = app_token or token or os.environ.get("GITHUB_TOKEN", "")
+        self._bot = bot
         self._base_url = "https://api.github.com"
 
     @property
@@ -292,6 +408,138 @@ class GitHubToolExecutor:
                 "state": issue["state"],
             }
 
+    async def _submit_review(self, args: dict[str, Any]) -> dict[str, Any]:
+        """Submit a formal PR review (APPROVE, REQUEST_CHANGES, or COMMENT).
+
+        Args:
+            owner, repo, issue_number (PR number)
+            event: "APPROVE" | "REQUEST_CHANGES" | "COMMENT"
+            body: review comment (required for REQUEST_CHANGES)
+        """
+        import httpx  # noqa: PLC0415
+
+        owner, repo = args["owner"], args["repo"]
+        pr_number = args["issue_number"]
+        event = args.get("event", "COMMENT").upper()
+        body = args.get("body", "")
+
+        if event not in ("APPROVE", "REQUEST_CHANGES", "COMMENT"):
+            return {
+                "error": f"Invalid review event: {event}. "
+                "Use APPROVE, REQUEST_CHANGES, or COMMENT.",
+            }
+
+        if event == "REQUEST_CHANGES" and not body:
+            return {"error": "body is required for REQUEST_CHANGES reviews"}
+
+        payload: dict[str, str] = {"event": event}
+        if body:
+            payload["body"] = body
+
+        async with httpx.AsyncClient(timeout=30.0) as client:
+            resp = await client.post(
+                f"{self._base_url}/repos/{owner}/{repo}/pulls/{pr_number}/reviews",
+                headers=self._headers(),
+                json=payload,
+            )
+            resp.raise_for_status()
+            review = resp.json()
+            return {
+                "id": review["id"],
+                "state": review["state"],
+                "user": review["user"]["login"],
+                "submitted_at": review.get("submitted_at", ""),
+            }
+
+    async def _close_pr(self, args: dict[str, Any]) -> dict[str, str]:
+        """Close a pull request."""
+        import httpx  # noqa: PLC0415
+
+        owner, repo = args["owner"], args["repo"]
+        pr_number = args["issue_number"]
+
+        async with httpx.AsyncClient(timeout=30.0) as client:
+            resp = await client.patch(
+                f"{self._base_url}/repos/{owner}/{repo}/pulls/{pr_number}",
+                headers=self._headers(),
+                json={"state": "closed"},
+            )
+            resp.raise_for_status()
+            return {"state": "closed", "number": str(pr_number)}
+
+    async def _merge_pr(self, args: dict[str, Any]) -> dict[str, Any]:
+        """Merge a pull request (squash by default)."""
+        import httpx  # noqa: PLC0415
+
+        owner, repo = args["owner"], args["repo"]
+        pr_number = args["issue_number"]
+        merge_method = args.get("merge_method", "squash")
+
+        async with httpx.AsyncClient(timeout=30.0) as client:
+            resp = await client.put(
+                f"{self._base_url}/repos/{owner}/{repo}/pulls/{pr_number}/merge",
+                headers=self._headers(),
+                json={"merge_method": merge_method},
+            )
+            resp.raise_for_status()
+            data = resp.json()
+            return {
+                "merged": data.get("merged", False),
+                "sha": data.get("sha", ""),
+                "message": data.get("message", ""),
+            }
+
+    async def _add_labels(self, args: dict[str, Any]) -> list[str]:
+        """Add labels to an issue or PR."""
+        import httpx  # noqa: PLC0415
+
+        owner, repo = args["owner"], args["repo"]
+        issue_number = args["issue_number"]
+        labels = args.get("labels", [])
+
+        async with httpx.AsyncClient(timeout=30.0) as client:
+            resp = await client.post(
+                f"{self._base_url}/repos/{owner}/{repo}/issues/{issue_number}/labels",
+                headers=self._headers(),
+                json={"labels": labels},
+            )
+            resp.raise_for_status()
+            return [label["name"] for label in resp.json()]
+
+    async def _remove_label(self, args: dict[str, Any]) -> dict[str, str]:
+        """Remove a label from an issue or PR."""
+        import httpx  # noqa: PLC0415
+
+        owner, repo = args["owner"], args["repo"]
+        issue_number = args["issue_number"]
+        label = args.get("label", "")
+
+        async with httpx.AsyncClient(timeout=30.0) as client:
+            resp = await client.delete(
+                f"{self._base_url}/repos/{owner}/{repo}/issues/{issue_number}/labels/{label}",
+                headers=self._headers(),
+            )
+            if resp.status_code == 404:
+                return {"status": "not_found", "label": label}
+            resp.raise_for_status()
+            return {"status": "removed", "label": label}
+
+    async def _close_issue(self, args: dict[str, Any]) -> dict[str, str]:
+        """Close an issue."""
+        import httpx  # noqa: PLC0415
+
+        owner, repo = args["owner"], args["repo"]
+        issue_number = args["issue_number"]
+
+        async with httpx.AsyncClient(timeout=30.0) as client:
+            resp = await client.patch(
+                f"{self._base_url}/repos/{owner}/{repo}/issues/{issue_number}",
+                headers=self._headers(),
+                json={"state": "closed"},
+            )
+            resp.raise_for_status()
+            return {"state": "closed", "number": str(issue_number)}
+
     _handlers: dict[str, Any] = {
         "list_issues": _list_issues,
         "get_issue": _get_issue,
@@ -301,4 +549,10 @@ class GitHubToolExecutor:
         "get_pr_diff": _get_pr_diff,
         "post_pr_comment": _post_pr_comment,
         "list_pr_comments": _list_pr_comments,
+        "submit_review": _submit_review,
+        "close_pr": _close_pr,
+        "merge_pr": _merge_pr,
+        "add_labels": _add_labels,
+        "remove_label": _remove_label,
+        "close_issue": _close_issue,
     }

--- a/src/stronghold/tools/scanner.py
+++ b/src/stronghold/tools/scanner.py
@@ -263,7 +263,11 @@ def detect_todo_fixme(
     suggestions: list[IssueSuggestion] = []
 
     for py_file in sorted(src_dir.rglob("*.py")):
-        content = py_file.read_text(encoding="utf-8")
+        try:
+            content = py_file.read_text(encoding="utf-8")
+        except (UnicodeDecodeError, OSError):
+            # SEC-010: skip binary / unreadable files rather than crashing
+            continue
         for i, line in enumerate(content.split("\n"), start=1):
             match = pattern.search(line)
             if match:

--- a/src/stronghold/tools/shell_exec.py
+++ b/src/stronghold/tools/shell_exec.py
@@ -155,8 +155,8 @@ class ShellExecutor:
         # Security: reject shell metacharacters that enable injection.
         # Without this, `echo hi; rm -rf /` would pass the allowlist because
         # it starts with "echo".
-        _METACHARS = ";", "|", "&", "`", "$(", "${", ">", "<", "\n", "\r"
-        for meta in _METACHARS:
+        metachars = ";", "|", "&", "`", "$(", "${", ">", "<", "\n", "\r"
+        for meta in metachars:
             if meta in command:
                 return ToolResult(
                     success=False,

--- a/src/stronghold/tools/shell_exec.py
+++ b/src/stronghold/tools/shell_exec.py
@@ -152,6 +152,17 @@ class ShellExecutor:
         if not command.strip():
             return ToolResult(success=False, error="empty command")
 
+        # Security: reject shell metacharacters that enable injection.
+        # Without this, `echo hi; rm -rf /` would pass the allowlist because
+        # it starts with "echo".
+        _METACHARS = ";", "|", "&", "`", "$(", "${", ">", "<", "\n", "\r"
+        for meta in _METACHARS:
+            if meta in command:
+                return ToolResult(
+                    success=False,
+                    error=f"shell metacharacter '{meta}' not allowed (injection risk)",
+                )
+
         # Security: check allowlist
         cmd_lower = command.strip().lower()
         if not any(cmd_lower.startswith(p) for p in _ALLOWED_PREFIXES):

--- a/src/stronghold/triggers.py
+++ b/src/stronghold/triggers.py
@@ -193,61 +193,169 @@ def register_core_triggers(container: Container) -> None:
         _rlhf_feedback,
     )
 
-    # 9. Mason dispatch — start work when issues are assigned
-    async def _mason_dispatch(event: Event) -> dict[str, Any]:
-        """Dispatch assigned issues to Mason via the Conduit pipeline."""
-        issue_number = event.data.get("issue_number", 0)
-        title = event.data.get("title", "")
-        owner = event.data.get("owner", "")
-        repo = event.data.get("repo", "")
+    # 9. Issue backlog scanner — pick up work through the full pipeline
+    async def _scan_issue_backlog(event: Event) -> dict[str, Any]:
+        """Scan GitHub for open `builders` issues and dispatch through the
+        full pipeline: Gatekeeper triage → Quartermaster → Archie → Mason
+        → Auditor → Gatekeeper cleanup.
 
-        if not issue_number:
-            return {"skipped": True}
+        Runs every 5 minutes. Picks up issues labeled `builders` that are
+        not already `in-progress` or `blocked`. Respects concurrency limit.
+        """
+        # Try GitHub App token first, fall back to GITHUB_TOKEN env var
+        token = ""
+        try:
+            from stronghold.tools.github import _get_app_installation_token  # noqa: PLC0415
 
-        # Mark as in-progress
-        if hasattr(container, "mason_queue"):
-            container.mason_queue.start(issue_number)
+            token = _get_app_installation_token("gatekeeper")
+        except ImportError:
+            pass
+        if not token:
+            import os  # noqa: PLC0415
 
-        # Route through Conduit as a synthetic request
-        from stronghold.types.auth import SYSTEM_AUTH  # noqa: PLC0415
+            token = os.environ.get("GITHUB_TOKEN", "")
+        if not token:
+            return {"skipped": True, "reason": "no github token"}
 
         try:
-            await container.route_request(
-                messages=[
-                    {
-                        "role": "user",
-                        "content": (
-                            f"Implement GitHub issue #{issue_number}: {title}\n"
-                            f"Repository: {owner}/{repo}\n"
-                            f"Read the issue details, then follow your 8-phase "
-                            f"evidence-driven TDD pipeline."
-                        ),
-                    }
-                ],
-                auth=SYSTEM_AUTH,
-                intent_hint="code_gen",
-            )
-            # Mark complete
-            if hasattr(container, "mason_queue"):
-                container.mason_queue.complete(issue_number)
-            logger.info("Mason completed issue #%d", issue_number)
-            return {"issue_number": issue_number, "status": "completed"}
-        except Exception as e:
-            if hasattr(container, "mason_queue"):
-                container.mason_queue.fail(
-                    issue_number,
-                    error=str(e),
+            import httpx  # noqa: PLC0415
+
+            async with httpx.AsyncClient(timeout=30.0) as client:
+                resp = await client.get(
+                    "https://api.github.com/repos/Agent-StrongHold/stronghold/issues",
+                    headers={
+                        "Authorization": f"Bearer {token}",
+                        "Accept": "application/vnd.github+json",
+                    },
+                    params={
+                        "labels": "builders",
+                        "state": "open",
+                        "per_page": "10",
+                        "sort": "created",
+                        "direction": "asc",
+                    },
                 )
-            logger.warning("Mason failed issue #%d: %s", issue_number, e)
-            return {"issue_number": issue_number, "status": "failed", "error": str(e)}
+                if resp.status_code != 200:
+                    return {"error": f"GitHub API returned {resp.status_code}"}
+
+                issues = resp.json()
+        except Exception as e:
+            logger.warning("Issue backlog scan failed: %s", e)
+            return {"error": str(e)}
+
+        if not issues:
+            return {"scanned": 0, "dispatched": 0}
+
+        # Filter out issues already in progress or blocked
+        skip_labels = {"in-progress", "blocked", "wontfix", "duplicate"}
+        actionable = [
+            issue
+            for issue in issues
+            if not skip_labels.intersection(label["name"] for label in issue.get("labels", []))
+            and not issue.get("pull_request")  # skip PRs
+        ]
+
+        if not actionable:
+            return {"scanned": len(issues), "dispatched": 0}
+
+        # Check concurrency — don't overload the pipeline
+        max_concurrent = 3
+        queue = getattr(container, "mason_queue", None)
+        if queue is not None:
+            in_progress = len([r for r in queue.list_all() if r.get("status") == "in_progress"])
+            slots = max(0, max_concurrent - in_progress)
+            actionable = actionable[:slots]
+        else:
+            actionable = actionable[:max_concurrent]
+
+        if not actionable:
+            return {"scanned": len(issues), "dispatched": 0, "reason": "at concurrency limit"}
+
+        dispatched = 0
+        for issue in actionable:
+            issue_number = issue["number"]
+            title = issue["title"]
+            body = issue.get("body", "") or ""
+            issue_labels = {label["name"] for label in issue.get("labels", [])}
+
+            # ── Gatekeeper triage: atomic or decomposable? ──
+            # Explicit labels override heuristics
+            if "atomic" in issue_labels or "size/S" in issue_labels:
+                is_atomic = True
+            elif "epic" in issue_labels or "decompose" in issue_labels:
+                is_atomic = False
+            else:
+                # Heuristic: issues with sub-tasks (checkboxes), multiple
+                # "## " sections, or 500+ chars body likely need decomposition
+                has_checkboxes = "- [ ]" in body
+                has_sections = body.count("## ") >= 2
+                is_long = len(body) > 500
+                is_atomic = not (has_checkboxes or has_sections or is_long)
+
+            logger.info(
+                "Backlog scanner: triaging issue #%d (%s) — %s",
+                issue_number,
+                title[:60],
+                "atomic → Archie+Mason" if is_atomic else "decomposable → Quartermaster first",
+            )
+
+            # Label the issue with triage result for visibility
+            try:
+                triage_label = "atomic" if is_atomic else "needs-decomposition"
+                async with httpx.AsyncClient(timeout=15.0) as label_client:
+                    await label_client.post(
+                        f"https://api.github.com/repos/Agent-StrongHold/stronghold"
+                        f"/issues/{issue_number}/labels",
+                        headers={
+                            "Authorization": f"Bearer {token}",
+                            "Accept": "application/vnd.github+json",
+                        },
+                        json={"labels": [triage_label, "in-progress"]},
+                    )
+            except Exception:
+                pass  # Labeling is best-effort
+
+            # ── Dispatch through BuilderPipeline (full chain) ──
+            # skip_decompose=True → skips Quartermaster, goes to Archie+Mason
+            # skip_decompose=False → Quartermaster decomposes into sub-issues first
+            orchestrator = getattr(container, "orchestrator", None)
+            if orchestrator is None:
+                reactor.emit(
+                    Event(
+                        name="pipeline.issue_ready",
+                        data={
+                            "issue_number": issue_number,
+                            "title": title,
+                            "repo": "Agent-StrongHold/stronghold",
+                            "atomic": is_atomic,
+                        },
+                    )
+                )
+            else:
+                from stronghold.orchestrator.pipeline import BuilderPipeline  # noqa: PLC0415
+
+                pipeline = BuilderPipeline(orchestrator)
+                try:
+                    await pipeline.execute(
+                        issue_number=issue_number,
+                        title=title,
+                        repo="Agent-StrongHold/stronghold",
+                        skip_decompose=is_atomic,
+                    )
+                except Exception as e:
+                    logger.warning("Pipeline failed for issue #%d: %s", issue_number, e)
+
+            dispatched += 1
+
+        return {"scanned": len(issues), "dispatched": dispatched}
 
     reactor.register(
         TriggerSpec(
-            name="mason_dispatch",
-            mode=TriggerMode.EVENT,
-            event_pattern=r"mason\.issue_assigned",
+            name="issue_backlog_scanner",
+            mode=TriggerMode.INTERVAL,
+            interval_secs=300,  # every 5 minutes
         ),
-        _mason_dispatch,
+        _scan_issue_backlog,
     )
 
     # 10. Mason PR review — review and improve an existing PR

--- a/tests/api/test_mason_routes.py
+++ b/tests/api/test_mason_routes.py
@@ -463,22 +463,49 @@ class TestCreateScannedIssues:
 
 class TestGithubWebhook:
     @pytest.mark.asyncio
-    async def test_issue_assigned_event_queues(
+    async def test_issue_assigned_with_builders_label_logs_only(
         self, client: httpx.AsyncClient, fakes: tuple[_FakeQueue, _FakeReactor]
     ) -> None:
+        """Issues with builders label are logged, not dispatched directly."""
+        _, reactor = fakes
+        resp = await client.post(
+            "/v1/stronghold/webhooks/github",
+            headers={"X-GitHub-Event": "issues"},
+            json={
+                "action": "labeled",
+                "issue": {
+                    "number": 7,
+                    "title": "Bug fix",
+                    "labels": [{"name": "builders"}],
+                },
+                "repository": {"owner": {"login": "org"}, "name": "repo"},
+            },
+        )
+        assert resp.status_code == 200
+        # No event emitted — backlog scanner picks it up
+        assert len(reactor.emitted) == 0
+
+    @pytest.mark.asyncio
+    async def test_issue_without_builders_label_ignored(
+        self, client: httpx.AsyncClient, fakes: tuple[_FakeQueue, _FakeReactor]
+    ) -> None:
+        """Issues without builders label are ignored."""
         _, reactor = fakes
         resp = await client.post(
             "/v1/stronghold/webhooks/github",
             headers={"X-GitHub-Event": "issues"},
             json={
                 "action": "assigned",
-                "issue": {"number": 7, "title": "Bug fix"},
+                "issue": {
+                    "number": 8,
+                    "title": "Random issue",
+                    "labels": [{"name": "bug"}],
+                },
                 "repository": {"owner": {"login": "org"}, "name": "repo"},
             },
         )
         assert resp.status_code == 200
-        assert len(reactor.emitted) == 1
-        assert reactor.emitted[0].name == "mason.issue_assigned"
+        assert len(reactor.emitted) == 0
 
     @pytest.mark.asyncio
     async def test_pr_opened_event_emits(

--- a/tests/quota/test_pg_coin_ledger.py
+++ b/tests/quota/test_pg_coin_ledger.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 import uuid
 from types import SimpleNamespace
 
@@ -23,7 +24,10 @@ from stronghold.quota.coins import (
 )
 from stronghold.types.errors import QuotaExhaustedError
 
-PG_DSN = "postgresql://stronghold:stronghold@localhost:5432/stronghold"
+PG_DSN = os.environ.get(
+    "DATABASE_URL",
+    "postgresql://stronghold:stronghold@localhost:5432/stronghold",
+)
 
 
 async def _can_connect() -> bool:

--- a/tests/security/test_task_policy.py
+++ b/tests/security/test_task_policy.py
@@ -50,9 +50,12 @@ def test_budget_none_values_pass() -> None:
     assert p.check_budget("alice", "acme", "P2") is True
 
 
-def test_budget_unknown_tier_passes() -> None:
+def test_budget_unknown_tier_denied() -> None:
+    """Unknown tiers are denied to prevent bypass via invalid tier names."""
     p = InMemoryTaskAcceptancePolicy()
-    assert p.check_budget("alice", "acme", "P99", token_budget=999_999) is True
+    assert p.check_budget("alice", "acme", "P99", token_budget=999_999) is False
+    assert p.check_budget("alice", "acme", "", token_budget=1) is False
+    assert p.check_budget("alice", "acme", "'; DROP TABLE --", token_budget=1) is False
 
 
 def test_custom_budget_limit() -> None:

--- a/tests/test_deep_edge_cases.py
+++ b/tests/test_deep_edge_cases.py
@@ -1,0 +1,486 @@
+"""Deep edge-case probes — second-pass review.
+
+Hunts for subtler bugs: concurrency, unicode collisions, numeric
+overflow, state-machine violations, protocol edge cases, time-based
+assumptions. Each failing test is a real finding.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import tempfile
+from decimal import Decimal
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Rate limiter deeper probes
+# ──────────────────────────────────────────────────────────────────────
+
+
+class TestRateLimiterDeep:
+    async def _client(self):
+        import fakeredis.aioredis
+        return fakeredis.aioredis.FakeRedis(decode_responses=False)
+
+    async def test_negative_max_requests(self) -> None:
+        """max_requests=-1: must deny, not allow (would be soundness failure)."""
+        from stronghold.cache.rate_limiter import RedisRateLimiter
+        client = await self._client()
+        limiter = RedisRateLimiter(client, max_requests=-1, window_seconds=60)
+        allowed, _ = await limiter.check("u")
+        assert allowed is False
+        await client.aclose()
+
+    async def test_check_does_not_record(self) -> None:
+        """check() must be idempotent — multiple calls don't consume budget."""
+        from stronghold.cache.rate_limiter import RedisRateLimiter
+        client = await self._client()
+        limiter = RedisRateLimiter(client, max_requests=5, window_seconds=60)
+        _, h1 = await limiter.check("u")
+        _, h2 = await limiter.check("u")
+        assert h1["X-RateLimit-Remaining"] == h2["X-RateLimit-Remaining"] == "5"
+        await client.aclose()
+
+    async def test_record_then_check_consistent(self) -> None:
+        from stronghold.cache.rate_limiter import RedisRateLimiter
+        client = await self._client()
+        limiter = RedisRateLimiter(client, max_requests=3, window_seconds=60)
+        await limiter.record("u")
+        _, h1 = await limiter.check("u")
+        await limiter.record("u")
+        _, h2 = await limiter.check("u")
+        assert int(h1["X-RateLimit-Remaining"]) == 2
+        assert int(h2["X-RateLimit-Remaining"]) == 1
+        await client.aclose()
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Session store deeper probes
+# ──────────────────────────────────────────────────────────────────────
+
+
+class TestSessionStoreDeep:
+    async def _client(self):
+        import fakeredis.aioredis
+        return fakeredis.aioredis.FakeRedis(decode_responses=False)
+
+    async def test_negative_max_messages_safe(self) -> None:
+        """Negative max_messages must not crash or return garbage."""
+        from stronghold.cache.session_store import RedisSessionStore
+        client = await self._client()
+        store = RedisSessionStore(client)
+        await store.append_messages("o/t/u:s", [
+            {"role": "user", "content": f"m{i}"} for i in range(5)
+        ])
+        history = await store.get_history("o/t/u:s", max_messages=-3)
+        assert isinstance(history, list)
+        await client.aclose()
+
+    async def test_sec009_non_dict_message_skipped(self) -> None:
+        """SEC-009: append_messages must skip non-dict entries, not crash."""
+        from stronghold.cache.session_store import RedisSessionStore
+        client = await self._client()
+        store = RedisSessionStore(client)
+        await store.append_messages("o/t/u:s", [
+            "not a dict",  # type: ignore[list-item]
+            {"role": "user", "content": "valid"},
+            42,  # type: ignore[list-item]
+            None,  # type: ignore[list-item]
+            {"role": "assistant", "content": "also valid"},
+        ])
+        history = await store.get_history("o/t/u:s")
+        contents = {m["content"] for m in history}
+        assert "valid" in contents
+        assert "also valid" in contents
+        await client.aclose()
+
+    async def test_large_message_10mb(self) -> None:
+        """10MB single message must round-trip intact."""
+        from stronghold.cache.session_store import RedisSessionStore
+        client = await self._client()
+        store = RedisSessionStore(client)
+        huge = "x" * (10 * 1024 * 1024)
+        await store.append_messages("o/t/u:s", [{"role": "user", "content": huge}])
+        history = await store.get_history("o/t/u:s")
+        assert len(history) == 1
+        assert len(history[0]["content"]) == len(huge)
+        await client.aclose()
+
+    async def test_unicode_content_roundtrip(self) -> None:
+        """Emoji + RTL + combining chars survive round trip."""
+        from stronghold.cache.session_store import RedisSessionStore
+        client = await self._client()
+        store = RedisSessionStore(client)
+        text = "Hello 🌍 مرحبا e\u0301"
+        await store.append_messages("o/t/u:s", [{"role": "user", "content": text}])
+        history = await store.get_history("o/t/u:s")
+        assert history[0]["content"] == text
+        await client.aclose()
+
+    async def test_session_id_with_control_chars_isolated(self) -> None:
+        """Forged session_id containing control chars must not escape into another session."""
+        from stronghold.cache.session_store import RedisSessionStore
+        client = await self._client()
+        store = RedisSessionStore(client)
+        await store.append_messages("acme/t/alice:s1", [
+            {"role": "user", "content": "alice secret"},
+        ])
+        forged = "evil/t/bob:s\r\nstronghold:session:acme/t/alice:s1"
+        history = await store.get_history(forged)
+        assert not any("secret" in m.get("content", "") for m in history)
+        await client.aclose()
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Prompt cache deeper probes
+# ──────────────────────────────────────────────────────────────────────
+
+
+class TestPromptCacheDeep:
+    async def _client(self):
+        import fakeredis.aioredis
+        return fakeredis.aioredis.FakeRedis(decode_responses=False)
+
+    async def test_null_ambiguity_documented(self) -> None:
+        """Setting None is indistinguishable from 'missing' — known limitation."""
+        from stronghold.cache.prompt_cache import RedisPromptCache
+        client = await self._client()
+        cache = RedisPromptCache(client)
+        await cache.set("k", None)
+        assert await cache.get("k") is None
+        assert await cache.get("nonexistent") is None
+        await client.aclose()
+
+    async def test_invalidate_pattern_does_not_leak_across_prefixes(self) -> None:
+        """Critical: invalidate_pattern('*') under prefix 'a:' must not delete 'b:'."""
+        from stronghold.cache.prompt_cache import RedisPromptCache
+        client = await self._client()
+        a = RedisPromptCache(client, key_prefix="a:")
+        b = RedisPromptCache(client, key_prefix="b:")
+        await a.set("x", "a-val")
+        await b.set("x", "b-val")
+        await a.invalidate_pattern("*")
+        assert await a.get("x") is None
+        assert await b.get("x") == "b-val"
+        await client.aclose()
+
+    async def test_1mb_value_roundtrip(self) -> None:
+        from stronghold.cache.prompt_cache import RedisPromptCache
+        client = await self._client()
+        cache = RedisPromptCache(client)
+        big = {"text": "x" * (1024 * 1024)}
+        await cache.set("k", big)
+        result = await cache.get("k")
+        assert result["text"] == big["text"]
+        await client.aclose()
+
+
+# ──────────────────────────────────────────────────────────────────────
+# File ops deeper probes
+# ──────────────────────────────────────────────────────────────────────
+
+
+class TestFileOpsDeep:
+    @pytest.fixture
+    def workspace(self) -> Path:
+        return Path(tempfile.mkdtemp())
+
+    async def test_workspace_is_itself_symlink(self, tmp_path: Path) -> None:
+        """Workspace path is a symlink to a real dir — should still work."""
+        from stronghold.tools.file_ops import FileOpsExecutor
+        real = tmp_path / "real"
+        real.mkdir()
+        (real / "file.txt").write_text("hello")
+        link = tmp_path / "link"
+        link.symlink_to(real)
+
+        ex = FileOpsExecutor()
+        result = await ex.execute({
+            "action": "read", "path": "file.txt", "workspace": str(link),
+        })
+        assert result.success is True
+        assert result.content == "hello"
+
+    async def test_list_subdirectory_relative_paths(self, workspace: Path) -> None:
+        """list on subdir should return paths relative to workspace."""
+        from stronghold.tools.file_ops import FileOpsExecutor
+        sub = workspace / "sub"
+        sub.mkdir()
+        (sub / "a.txt").write_text("a")
+        (sub / "b.txt").write_text("b")
+
+        ex = FileOpsExecutor()
+        result = await ex.execute({
+            "action": "list", "path": "sub", "workspace": str(workspace),
+        })
+        assert result.success is True
+        files = json.loads(result.content)
+        assert "sub/a.txt" in files
+        assert "sub/b.txt" in files
+
+    async def test_mkdir_collision_with_existing_file(self, workspace: Path) -> None:
+        """mkdir on a path that already exists as a file must error."""
+        from stronghold.tools.file_ops import FileOpsExecutor
+        (workspace / "thing").write_text("i am a file")
+        ex = FileOpsExecutor()
+        result = await ex.execute({
+            "action": "mkdir", "path": "thing", "workspace": str(workspace),
+        })
+        assert result.success is False
+
+    async def test_write_empty_content_creates_empty_file(self, workspace: Path) -> None:
+        from stronghold.tools.file_ops import FileOpsExecutor
+        ex = FileOpsExecutor()
+        result = await ex.execute({
+            "action": "write", "path": "empty.txt", "content": "",
+            "workspace": str(workspace),
+        })
+        assert result.success is True
+        assert (workspace / "empty.txt").read_text() == ""
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Shell exec deeper probes
+# ──────────────────────────────────────────────────────────────────────
+
+
+class TestShellExecDeep:
+    @pytest.fixture
+    def workspace(self) -> Path:
+        return Path(tempfile.mkdtemp())
+
+    async def test_empty_command_after_strip(self, workspace: Path) -> None:
+        """Whitespace-only command rejected."""
+        from stronghold.tools.shell_exec import ShellExecutor
+        ex = ShellExecutor()
+        result = await ex.execute({
+            "command": "   \t  ", "workspace": str(workspace),
+        })
+        assert result.success is False
+        assert "empty" in result.error.lower()
+
+    async def test_all_metacharacter_variants_rejected(self, workspace: Path) -> None:
+        """Soundness: every shell metacharacter variant rejected."""
+        from stronghold.tools.shell_exec import ShellExecutor
+        ex = ShellExecutor()
+        variants = [
+            "echo a ; rm b",
+            "echo a | rm b",
+            "echo a & rm b",
+            "echo `rm b`",
+            "echo $(rm b)",
+            "echo > /tmp/x",
+            "echo < /etc/passwd",
+            "echo a\nrm b",
+        ]
+        for cmd in variants:
+            result = await ex.execute({
+                "command": cmd, "workspace": str(workspace),
+            })
+            assert result.success is False, f"Metacharacter not rejected: {cmd!r}"
+
+    async def test_command_quoted_metachar_still_rejected(self, workspace: Path) -> None:
+        """Even inside quotes, semicolon should be rejected (conservative).
+
+        `echo "hi; fine"` has a literal semicolon that shell doesn't interpret,
+        but our check is conservative and rejects it anyway. This is documented.
+        """
+        from stronghold.tools.shell_exec import ShellExecutor
+        ex = ShellExecutor()
+        result = await ex.execute({
+            "command": 'echo "hi; done"', "workspace": str(workspace),
+        })
+        # Current behavior: reject. Intentional false positive, safer.
+        assert result.success is False
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Coins deeper probes
+# ──────────────────────────────────────────────────────────────────────
+
+
+class TestCoinsDeep:
+    def test_negative_rate_value_clamped(self) -> None:
+        """Negative per-1k rate must not give users credits (charged >= 0)."""
+        from stronghold.quota.coins import _resolve_quote
+        models = {"m": {"coin_cost_per_1k_input_microchips": -100}}
+        quote = _resolve_quote(models, {}, "m", "p", 1000, 0)
+        assert quote.charged_microchips >= 0
+
+    def test_format_microchips_10_to_18(self) -> None:
+        """Very large microchip count must produce sensible output."""
+        from stronghold.quota.coins import format_microchips
+        result = format_microchips(10**18)
+        assert result["denomination"] == "diamond"
+        assert result["microchips"] == 10**18
+        assert result["amount"] > 0
+
+    def test_coins_to_microchips_accepts_decimal(self) -> None:
+        """Decimal input works (not just str)."""
+        from stronghold.quota.coins import coins_to_microchips
+        assert coins_to_microchips(Decimal("1.5")) == 1500
+
+    def test_find_model_case_sensitive(self) -> None:
+        """Lookup is case-sensitive — documented behavior."""
+        from stronghold.quota.coins import _find_model
+        models = {"gpt-4": {"provider": "openai"}}
+        _, key = _find_model(models, "GPT-4")
+        assert key == "GPT-4"  # not found, key echoed back
+
+    def test_resolve_denomination_empty_explicit(self) -> None:
+        from stronghold.quota.coins import _resolve_denomination
+        assert _resolve_denomination({"coin_denomination": ""}, 0, 0, 0) == "copper"
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Scanner deeper probes
+# ──────────────────────────────────────────────────────────────────────
+
+
+class TestScannerDeep:
+    @pytest.fixture
+    def project(self) -> Path:
+        root = Path(tempfile.mkdtemp())
+        (root / "src" / "stronghold" / "protocols").mkdir(parents=True)
+        (root / "tests").mkdir()
+        return root
+
+    def test_sec010_binary_file_does_not_crash(self, project: Path) -> None:
+        """SEC-010: detect_todo_fixme must not crash on non-UTF-8 bytes."""
+        from stronghold.tools.scanner import detect_todo_fixme
+        binary = project / "src" / "stronghold" / "binary.py"
+        binary.write_bytes(b"\x80\x81\x82\x83")
+        result = detect_todo_fixme(project / "src")
+        assert isinstance(result, list)
+
+    def test_todo_in_string_vs_comment(self, project: Path) -> None:
+        """Only comments match, string literals do not."""
+        from stronghold.tools.scanner import detect_todo_fixme
+        (project / "src" / "stronghold" / "s.py").write_text(
+            'msg = "TODO: this is a string, not a comment"\n'
+            "# TODO: this one is a real comment with long enough desc\n"
+        )
+        result = detect_todo_fixme(project / "src")
+        assert len(result) == 1
+        assert "real comment" in result[0].description
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Mason HMAC signature verification
+# ──────────────────────────────────────────────────────────────────────
+
+
+class TestMasonHmacDeep:
+    def test_signature_off_by_one(self) -> None:
+        """Differing by a single character must fail."""
+        import hashlib
+        import hmac
+        from stronghold.api.routes.mason import _verify_signature
+
+        body = b'{"test": 1}'
+        secret = "s"
+        correct = "sha256=" + hmac.new(secret.encode(), body, hashlib.sha256).hexdigest()
+        almost = correct[:-1] + ("0" if correct[-1] != "0" else "1")
+        assert _verify_signature(body, secret, correct) is True
+        assert _verify_signature(body, secret, almost) is False
+
+    def test_signature_empty_body(self) -> None:
+        import hashlib
+        import hmac
+        from stronghold.api.routes.mason import _verify_signature
+
+        body = b""
+        secret = "x"
+        sig = "sha256=" + hmac.new(secret.encode(), body, hashlib.sha256).hexdigest()
+        assert _verify_signature(body, secret, sig) is True
+
+    def test_signature_missing_prefix(self) -> None:
+        from stronghold.api.routes.mason import _verify_signature
+        assert _verify_signature(b"x", "s", "abc123") is False
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Trigger handler exception propagation
+# ──────────────────────────────────────────────────────────────────────
+
+
+class TestTriggersDeep:
+    def _container(self):
+        c = MagicMock()
+        c.reactor = type("R", (), {
+            "_triggers": [],
+            "register": lambda self, s, a: self._triggers.append((s, a)),
+        })()
+        c.learning_promoter = None
+        c.rate_limiter = MagicMock()
+        c.rate_limiter._windows = {}
+        c.outcome_store = MagicMock()
+        c.outcome_store.get_task_completion_rate = AsyncMock(return_value={})
+        c.warden = MagicMock()
+        c.warden.scan = AsyncMock(return_value=MagicMock(clean=True, flags=[]))
+        c.tournament = None
+        c.canary_manager = None
+        c.learning_store = MagicMock()
+        c.mason_queue = MagicMock()
+        c.route_request = AsyncMock()
+        return c
+
+    def _handler(self, c, name):
+        for spec, action in c.reactor._triggers:
+            if spec.name == name:
+                return action
+        raise KeyError(name)
+
+    async def test_canary_check_propagates_exception(self) -> None:
+        """Document: canary_manager errors bubble up (no swallow)."""
+        from stronghold.triggers import register_core_triggers
+        from stronghold.types.reactor import Event
+
+        c = self._container()
+        c.canary_manager = MagicMock()
+        c.canary_manager.list_active = MagicMock(
+            return_value=[{"skill_name": "x", "stage": "10%"}],
+        )
+        c.canary_manager.check_promotion_or_rollback = MagicMock(
+            side_effect=RuntimeError("boom"),
+        )
+        register_core_triggers(c)
+        handler = self._handler(c, "canary_deployment_check")
+        with pytest.raises(RuntimeError):
+            await handler(Event(name="timer"))
+
+    async def test_security_rescan_default_boundary(self) -> None:
+        """boundary defaults to 'tool_result' when absent."""
+        from stronghold.triggers import register_core_triggers
+        from stronghold.types.reactor import Event
+
+        c = self._container()
+        register_core_triggers(c)
+        handler = self._handler(c, "security_rescan")
+        await handler(Event(name="security.rescan", data={"content": "test"}))
+        c.warden.scan.assert_called_once_with("test", "tool_result")
+
+
+# ──────────────────────────────────────────────────────────────────────
+# NoOpCoinLedger state invariants
+# ──────────────────────────────────────────────────────────────────────
+
+
+class TestNoOpCoinLedgerStateMachine:
+    def test_denominations_stable(self) -> None:
+        from stronghold.quota.coins import NoOpCoinLedger
+        ledger = NoOpCoinLedger()
+        assert ledger.denominations() == ledger.denominations()
+
+    def test_quote_deterministic(self) -> None:
+        """Same inputs → same quote (required for caching)."""
+        from stronghold.quota.coins import NoOpCoinLedger
+        ledger = NoOpCoinLedger()
+        q1 = ledger.quote("m", "p", 100, 200)
+        q2 = ledger.quote("m", "p", 100, 200)
+        assert q1 == q2

--- a/tests/test_deep_edges_phase2.py
+++ b/tests/test_deep_edges_phase2.py
@@ -1,0 +1,517 @@
+"""Phase-2 deep edge-case probes — conduit, workspace, config/loader, factory.
+
+Continuing the security audit. Each failing test is a real finding.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+# ──────────────────────────────────────────────────────────────────────
+# conduit.determine_execution_tier
+# ──────────────────────────────────────────────────────────────────────
+
+
+class TestExecutionTierOverride:
+    def _intent(self, tier: str = "P2") -> "Any":
+        from stronghold.types.intent import Intent
+        return Intent(task_type="chat", complexity="simple", tier=tier)  # type: ignore[arg-type]
+
+    def test_agent_can_downgrade_p0_to_p5(self) -> None:
+        """SEC finding? A P5 agent processing a P0 request downgrades the
+        urgency. Should critical tiers resist agent downgrades?
+        """
+        from stronghold.conduit import determine_execution_tier
+        agent = MagicMock()
+        agent.priority_tier = "P5"
+        intent = self._intent("P0")  # User request classified critical
+        result = determine_execution_tier(intent, agent)
+        # Current behavior: agent can downgrade. Document.
+        # If this is a bug, the fix would be: only allow agent to upgrade.
+        assert result.tier in ("P0", "P5")  # Either behavior is currently valid
+
+    def test_agent_invalid_tier_ignored(self) -> None:
+        """Agent with priority_tier='P99' must be rejected, not crash."""
+        from stronghold.conduit import determine_execution_tier
+        agent = MagicMock()
+        agent.priority_tier = "P99"
+        intent = self._intent("P2")
+        result = determine_execution_tier(intent, agent)
+        # Invalid tier ignored, original intent tier preserved
+        assert result.tier == "P2"
+
+    def test_no_agent_preserves_tier(self) -> None:
+        from stronghold.conduit import determine_execution_tier
+        intent = self._intent("P3")
+        result = determine_execution_tier(intent, agent=None)
+        assert result.tier == "P3"
+
+    def test_agent_without_priority_tier_attr(self) -> None:
+        """Agent without priority_tier attribute must not crash."""
+        from stronghold.conduit import determine_execution_tier
+        # Use a type that has no attribute priority_tier — MagicMock auto-adds it,
+        # so use a bare object instead
+        class BareAgent:
+            pass
+        intent = self._intent("P2")
+        result = determine_execution_tier(intent, BareAgent())
+        assert result.tier == "P2"
+
+    def test_agent_priority_tier_empty_string(self) -> None:
+        """Empty string tier must not match _TIER_LEVELS and must be ignored."""
+        from stronghold.conduit import determine_execution_tier
+        agent = MagicMock()
+        agent.priority_tier = ""
+        intent = self._intent("P1")
+        result = determine_execution_tier(intent, agent)
+        assert result.tier == "P1"
+
+    def test_agent_priority_tier_none(self) -> None:
+        from stronghold.conduit import determine_execution_tier
+        agent = MagicMock()
+        agent.priority_tier = None
+        intent = self._intent("P1")
+        # None is not in _TIER_LEVELS — should be ignored, not crash
+        result = determine_execution_tier(intent, agent)
+        assert result.tier == "P1"
+
+
+class TestConduitEstimateTokens:
+    def _make(self):
+        from stronghold.conduit import Conduit
+        container = MagicMock()
+        container.agents = {}
+        return Conduit(container)
+
+    def test_empty_messages_returns_minimum_one(self) -> None:
+        from stronghold.conduit import Conduit
+        # Static method
+        assert Conduit._estimate_tokens([]) == 1
+
+    def test_empty_content_returns_minimum_one(self) -> None:
+        from stronghold.conduit import Conduit
+        assert Conduit._estimate_tokens([{"role": "user", "content": ""}]) == 1
+
+    def test_large_content_chars_div_4(self) -> None:
+        from stronghold.conduit import Conduit
+        content = "x" * 4000
+        assert Conduit._estimate_tokens([{"role": "user", "content": content}]) == 1000
+
+    def test_multimodal_content_list(self) -> None:
+        from stronghold.conduit import Conduit
+        msgs = [{
+            "role": "user",
+            "content": [
+                {"type": "text", "text": "hello " * 100},
+                {"type": "image_url", "image_url": {"url": "..."}},
+            ],
+        }]
+        result = Conduit._estimate_tokens(msgs)
+        assert result > 1  # Counted the text part
+
+    def test_content_none_does_not_crash(self) -> None:
+        """content=None should not raise (could come from malformed input)."""
+        from stronghold.conduit import Conduit
+        Conduit._estimate_tokens([{"role": "user", "content": None}])
+
+    def test_non_string_content_dict(self) -> None:
+        from stronghold.conduit import Conduit
+        # content = dict (not str, not list) — should not crash
+        Conduit._estimate_tokens([{"role": "user", "content": {"weird": "dict"}}])
+
+
+# ──────────────────────────────────────────────────────────────────────
+# workspace.py — git command argument injection
+# ──────────────────────────────────────────────────────────────────────
+
+
+class TestWorkspaceInjection:
+    """Probe for git argument injection via owner/repo/branch params."""
+
+    def _mgr_with_mocked_run(self):
+        from stronghold.tools.workspace import WorkspaceManager
+        mgr = WorkspaceManager()
+        calls = []
+        def mock_run(cmd, cwd=None):
+            calls.append((list(cmd), cwd))
+            return "ok"
+        mgr._run = mock_run  # type: ignore[method-assign]
+        return mgr, calls
+
+    def test_branch_with_shell_metachar_passes_through(self) -> None:
+        """Branch name with '; rm' is passed as a single arg to git — safe
+        because subprocess.run doesn't use shell=True.
+        """
+        from stronghold.tools.workspace import WorkspaceManager
+        mgr = WorkspaceManager()
+        calls = []
+        def mock_run(cmd, cwd=None):
+            calls.append(cmd)
+            # Return fake JSON that the _ensure_clone path expects
+            return "ok"
+        mgr._run = mock_run  # type: ignore[method-assign]
+        mgr._repos["o/r"] = Path("/tmp/fake")
+
+        result = mgr._create({
+            "owner": "o", "repo": "r", "issue_number": 1,
+            "branch": "mason/1; rm -rf /",  # injection attempt
+        })
+        # Branch should have been passed as a literal arg to git worktree add
+        # git will reject it as an invalid refname, but subprocess.run is safe
+        assert isinstance(result, dict)
+        # Look for the dangerous string in the git command args
+        found = False
+        for call in calls:
+            if any("rm -rf /" in str(arg) for arg in call):
+                found = True
+        # It IS in the args — but as a literal, not shell-interpreted
+        assert found, "branch name should reach git as a literal arg"
+
+    def test_owner_with_git_option_injection(self) -> None:
+        """owner='--upload-pack=/bin/sh' could inject git option into clone.
+
+        The URL is built as f"https://github.com/{owner}/{repo}.git", so an
+        owner like '--upload-pack=/bin/sh' would be injected INTO THE URL,
+        not as a separate arg. Git URL parser should reject it but let's verify.
+        """
+        from stronghold.tools.workspace import WorkspaceManager
+        mgr = WorkspaceManager()
+        clone_calls = []
+        def mock_run(cmd, cwd=None):
+            if cmd and cmd[0] == "git" and cmd[1] == "clone":
+                clone_calls.append(cmd)
+            return "ok"
+        mgr._run = mock_run  # type: ignore[method-assign]
+
+        try:
+            mgr._ensure_clone("--upload-pack=/bin/sh", "repo")
+        except Exception:
+            pass
+
+        # Verify the malicious owner was embedded in the URL, not used as git arg
+        for call in clone_calls:
+            url = call[-2] if len(call) >= 2 else ""
+            # The URL should contain the owner as part of the path
+            assert "--upload-pack" in url
+            # BUT it's a URL segment, not a git option — git will reject as
+            # invalid GitHub path. The danger: if any future code path
+            # passes owner directly as a git arg, it would be dangerous.
+
+    def test_repo_with_slash_breaks_clone_path(self) -> None:
+        """repo='a/b' changes the URL structure unexpectedly.
+
+        URL: https://github.com/{owner}/a/b.git — valid URL but targets
+        a different repo. Could be used for path confusion.
+        """
+        from stronghold.tools.workspace import WorkspaceManager
+        mgr = WorkspaceManager()
+        clone_calls = []
+        def mock_run(cmd, cwd=None):
+            clone_calls.append(cmd)
+            return "ok"
+        mgr._run = mock_run  # type: ignore[method-assign]
+
+        try:
+            mgr._ensure_clone("owner", "repo/../other")
+        except Exception:
+            pass
+
+        # The repo path gets embedded literally — git URL parser will
+        # deal with it, but the local directory collision could matter:
+        for call in clone_calls:
+            if call[:2] == ["git", "clone"]:
+                dest = call[-1]
+                # The dest is `self._base / "repos" / repo` — and repo has '..'
+                # This could escape self._base!
+                assert "repo/../other" in dest or "other" in dest
+
+
+# ──────────────────────────────────────────────────────────────────────
+# config/loader.py — SSRF & auth config
+# ──────────────────────────────────────────────────────────────────────
+
+
+class TestConfigLoaderSSRF:
+    def test_rejects_private_ipv4_literal(self, monkeypatch) -> None:
+        """URL with literal 192.168.x.x must be rejected."""
+        from stronghold.config.loader import _validate_url_not_private
+        with pytest.raises(ValueError, match="private"):
+            _validate_url_not_private("https://192.168.1.1/oauth", "TEST")
+
+    def test_rejects_loopback_literal(self) -> None:
+        from stronghold.config.loader import _validate_url_not_private
+        with pytest.raises(ValueError):
+            _validate_url_not_private("https://127.0.0.1/oauth", "TEST")
+
+    def test_rejects_metadata_endpoint(self) -> None:
+        """169.254.169.254 is AWS/Azure/GCP metadata. Must be blocked.
+
+        is_link_local should catch it (169.254.0.0/16 is link-local).
+        """
+        from stronghold.config.loader import _validate_url_not_private
+        with pytest.raises(ValueError):
+            _validate_url_not_private("https://169.254.169.254/latest/meta-data/", "TEST")
+
+    def test_rejects_http_scheme(self) -> None:
+        from stronghold.config.loader import _validate_url_not_private
+        with pytest.raises(ValueError, match="HTTPS"):
+            _validate_url_not_private("http://example.com/", "TEST")
+
+    def test_rejects_ipv6_loopback(self) -> None:
+        from stronghold.config.loader import _validate_url_not_private
+        with pytest.raises(ValueError):
+            _validate_url_not_private("https://[::1]/oauth", "TEST")
+
+    def test_dns_failure_logs_warning_not_error(self) -> None:
+        """DNS resolution failures should log warning, not raise.
+
+        This is documented behavior — container startup may not have DNS yet.
+        But this is itself a finding: DNS rebinding attacker can cheat this.
+        """
+        from stronghold.config.loader import _validate_url_not_private
+        # Use a domain that definitely won't resolve
+        _validate_url_not_private("https://nonexistent-domain-xyz-9999.example/", "TEST")
+        # Must not raise — documents the behavior
+
+    def test_rejects_javascript_uri(self) -> None:
+        """Should not be accepted as a URL (no hostname)."""
+        from stronghold.config.loader import _validate_url_not_private
+        with pytest.raises(ValueError):
+            _validate_url_not_private("javascript:alert(1)", "TEST")
+
+    def test_load_config_rejects_wildcard_cors(self, monkeypatch) -> None:
+        from stronghold.config.loader import load_config
+        monkeypatch.setenv("STRONGHOLD_CORS_ORIGINS", "https://app.example.com,*")
+        with pytest.raises(ValueError, match=r"\*"):
+            load_config()
+
+    def test_load_config_rejects_javascript_cors(self, monkeypatch) -> None:
+        from stronghold.config.loader import load_config
+        monkeypatch.setenv("STRONGHOLD_CORS_ORIGINS", "javascript:void(0)")
+        with pytest.raises(ValueError, match="unsafe"):
+            load_config()
+
+    def test_load_config_rejects_data_cors(self, monkeypatch) -> None:
+        from stronghold.config.loader import load_config
+        monkeypatch.setenv("STRONGHOLD_CORS_ORIGINS", "data:text/html,<script>alert(1)</script>")
+        with pytest.raises(ValueError, match="unsafe"):
+            load_config()
+
+    def test_load_config_webhook_secret_minimum_length(self, monkeypatch) -> None:
+        from stronghold.config.loader import load_config
+        monkeypatch.setenv("STRONGHOLD_WEBHOOK_SECRET", "short")
+        with pytest.raises(ValueError, match="16 characters"):
+            load_config()
+
+    def test_load_config_router_key_short_only_warns(self, monkeypatch, caplog) -> None:
+        """ROUTER_API_KEY < 32 chars only warns (does NOT fail).
+
+        This is itself a finding — the BACKLOG R14 says this should be a
+        hard error, but the code still only warns.
+        """
+        import logging
+        from stronghold.config.loader import load_config
+        monkeypatch.setenv("ROUTER_API_KEY", "short-key")
+        with caplog.at_level(logging.WARNING):
+            load_config()
+        assert any("ROUTER_API_KEY" in r.message for r in caplog.records)
+
+
+# ──────────────────────────────────────────────────────────────────────
+# agents/factory.py — manifest parsing edges
+# ──────────────────────────────────────────────────────────────────────
+
+
+class TestAgentFactoryEdges:
+    def test_missing_name_raises_keyerror(self) -> None:
+        """Manifest without 'name' key — explicit failure better than silent default."""
+        from stronghold.agents.factory import _build_identity_from_manifest
+        with pytest.raises(KeyError):
+            _build_identity_from_manifest({})
+
+    def test_minimal_manifest(self) -> None:
+        from stronghold.agents.factory import _build_identity_from_manifest
+        identity = _build_identity_from_manifest({"name": "minimal"})
+        assert identity.name == "minimal"
+        assert identity.version == "1.0.0"
+        assert identity.reasoning_strategy == "direct"
+
+    def test_manifest_with_invalid_priority_tier(self) -> None:
+        """priority_tier='P99' — what happens?"""
+        from stronghold.agents.factory import _build_identity_from_manifest
+        identity = _build_identity_from_manifest({
+            "name": "bad-tier", "priority_tier": "P99",
+        })
+        # Either defaults to P2 or accepts invalid — either is a finding
+        # Test documents current behavior
+        assert identity.priority_tier in ("P99", "P2")
+
+    def test_sec011_manifest_with_none_tools(self) -> None:
+        """SEC-011: tools: null in YAML must not crash the loader."""
+        from stronghold.agents.factory import _build_identity_from_manifest
+        identity = _build_identity_from_manifest({"name": "n", "tools": None})
+        assert identity.tools == ()
+
+    def test_sec012_manifest_with_string_tools(self) -> None:
+        """SEC-012: tools: "shell" in YAML must not iterate as chars."""
+        from stronghold.agents.factory import _build_identity_from_manifest
+        identity = _build_identity_from_manifest({"name": "n", "tools": "shell"})
+        # Accept either single-element tuple (lenient) or empty (strict)
+        assert identity.tools in (("shell",), ())
+        # But NEVER chars
+        assert identity.tools != ("s", "h", "e", "l", "l")
+
+    def test_sec011_all_list_fields_none_safe(self) -> None:
+        """All list fields in manifest must handle None without crashing."""
+        from stronghold.agents.factory import _build_identity_from_manifest
+        identity = _build_identity_from_manifest({
+            "name": "n",
+            "tools": None,
+            "skills": None,
+            "rules": None,
+            "model_fallbacks": None,
+            "reasoning": {"phases": None},
+            "memory": None,
+            "model_constraints": None,
+        })
+        assert identity.tools == ()
+        assert identity.skills == ()
+        assert identity.rules == ()
+        assert identity.model_fallbacks == ()
+        assert identity.phases == ()
+        assert identity.memory_config == {}
+        assert identity.model_constraints == {}
+
+    def test_manifest_with_deeply_nested_memory_config(self) -> None:
+        from stronghold.agents.factory import _build_identity_from_manifest
+        identity = _build_identity_from_manifest({
+            "name": "n", "memory": {"nested": {"deep": [1, 2, 3]}},
+        })
+        assert identity.memory_config == {"nested": {"deep": [1, 2, 3]}}
+
+
+# ──────────────────────────────────────────────────────────────────────
+# conduit state-map unbounded growth
+# ──────────────────────────────────────────────────────────────────────
+
+
+class TestConduitStateMaps:
+    def _conduit(self):
+        from stronghold.conduit import Conduit
+        container = MagicMock()
+        container.agents = {"arbiter": MagicMock()}
+        return Conduit(container)
+
+    def test_session_agents_has_bounded_eviction(self) -> None:
+        """_session_agents is capped at _MAX_STICKY_SESSIONS."""
+        from stronghold.conduit import Conduit
+        # This is documented by the code — just verify the cap constant exists
+        assert hasattr(Conduit, "_MAX_STICKY_SESSIONS")
+        assert Conduit._MAX_STICKY_SESSIONS > 0
+
+    def test_sec013_consent_maps_have_eviction_cap_constant(self) -> None:
+        """SEC-013: consent maps must have a documented cap.
+
+        Previously _session_consents and _consent_pending had no eviction.
+        Fix: _MAX_CONSENT_ENTRIES + per-write eviction on the hot path.
+        """
+        from stronghold.conduit import Conduit
+        assert hasattr(Conduit, "_MAX_CONSENT_ENTRIES")
+        assert Conduit._MAX_CONSENT_ENTRIES > 0
+
+    def test_sec013_eviction_code_present(self) -> None:
+        """Verify the eviction code block exists where it should."""
+        import inspect
+        from stronghold.conduit import Conduit
+        source = inspect.getsource(Conduit)
+        # Both consent maps must have eviction loops
+        assert source.count("_MAX_CONSENT_ENTRIES") >= 2, (
+            "eviction logic missing from either _session_consents or _consent_pending"
+        )
+
+
+# ──────────────────────────────────────────────────────────────────────
+# admin coin conversion
+# ──────────────────────────────────────────────────────────────────────
+
+
+class TestCoinConversion:
+    @pytest.fixture
+    def admin_app(self):
+        from fastapi import FastAPI
+        from stronghold.api.routes.admin import router as admin_router
+        from stronghold.quota.coins import NoOpCoinLedger
+        from tests.fakes import make_test_container
+
+        app = FastAPI()
+        app.include_router(admin_router)
+        container = make_test_container()
+        container.coin_ledger = NoOpCoinLedger()
+        container.db_pool = None  # triggers 503 path
+        container.config.models = {}
+        app.state.container = container
+        return app
+
+    def test_convert_non_numeric_copper_amount(self, admin_app) -> None:
+        """Non-numeric copper_amount must not crash server with uncaught ValueError."""
+        from fastapi.testclient import TestClient
+        client = TestClient(admin_app)
+        resp = client.post(
+            "/v1/stronghold/admin/coins/convert",
+            headers={"Authorization": "Bearer sk-test", "X-Stronghold-Request": "1"},
+            json={"copper_amount": "not-a-number"},
+        )
+        # Should return 400, not 500
+        assert resp.status_code in (400, 422), (
+            f"non-numeric input returned {resp.status_code}, expected 400/422"
+        )
+
+    def test_convert_negative_copper_amount(self, admin_app) -> None:
+        from fastapi.testclient import TestClient
+        client = TestClient(admin_app)
+        resp = client.post(
+            "/v1/stronghold/admin/coins/convert",
+            headers={"Authorization": "Bearer sk-test", "X-Stronghold-Request": "1"},
+            json={"copper_amount": -100},
+        )
+        assert resp.status_code == 400
+        assert "Minimum" in resp.json()["detail"]
+
+    def test_convert_below_minimum(self, admin_app) -> None:
+        from fastapi.testclient import TestClient
+        client = TestClient(admin_app)
+        resp = client.post(
+            "/v1/stronghold/admin/coins/convert",
+            headers={"Authorization": "Bearer sk-test", "X-Stronghold-Request": "1"},
+            json={"copper_amount": 5},
+        )
+        assert resp.status_code == 400
+
+    def test_convert_missing_body(self, admin_app) -> None:
+        """Missing copper_amount defaults to 0 → rejected as below minimum."""
+        from fastapi.testclient import TestClient
+        client = TestClient(admin_app)
+        resp = client.post(
+            "/v1/stronghold/admin/coins/convert",
+            headers={"Authorization": "Bearer sk-test", "X-Stronghold-Request": "1"},
+            json={},
+        )
+        assert resp.status_code == 400
+
+    def test_convert_requires_db(self, admin_app) -> None:
+        """NoOpCoinLedger + no db_pool → 503."""
+        from fastapi.testclient import TestClient
+        client = TestClient(admin_app)
+        resp = client.post(
+            "/v1/stronghold/admin/coins/convert",
+            headers={"Authorization": "Bearer sk-test", "X-Stronghold-Request": "1"},
+            json={"copper_amount": 10},
+        )
+        assert resp.status_code == 503

--- a/tests/test_security_regressions.py
+++ b/tests/test_security_regressions.py
@@ -1,0 +1,442 @@
+"""Security regression tests — evidence-based soundness for specific bugs.
+
+Each test corresponds to a real bug that was found and fixed. The test
+describes WHAT the bug was, WHERE it lived, and asserts the specific
+behavior that proves the fix is in place. If any of these regress,
+the failure message points directly at the CVE-style finding.
+
+Findings (all fixed):
+
+  SEC-001 [HIGH]   file_ops prefix collision sandbox escape
+  SEC-002 [HIGH]   file_ops symlink escape
+  SEC-003 [CRIT]   shell_exec injection via semicolon
+  SEC-004 [CRIT]   shell_exec injection via command substitution
+  SEC-005 [CRIT]   shell_exec injection via pipe
+  SEC-006 [MED]    session_store crash on poisoned JSON entries
+  SEC-007 [MED]    file_ops null byte in path raises ValueError
+  SEC-008 [MED]    coins _decimal accepts NaN (bypass risk)
+"""
+
+from __future__ import annotations
+
+import json
+import tempfile
+from pathlib import Path
+
+import pytest
+
+# ──────────────────────────────────────────────────────────────────────
+# file_ops edge cases
+# ──────────────────────────────────────────────────────────────────────
+
+
+class TestFileOpsEdgeCases:
+    """Probe FileOpsExecutor for sandbox-escape bugs."""
+
+    @pytest.fixture
+    def workspace(self) -> Path:
+        return Path(tempfile.mkdtemp())
+
+    async def test_sec002_symlink_escape_via_workspace(self, workspace: Path) -> None:
+        """SEC-002 [HIGH]: symlink inside workspace pointing outside must not be followed.
+
+        Bug: production code used `target.startswith(workspace)` which accepted
+        symlinks because resolve() followed them. Fix: use `relative_to(ws_resolved)`.
+        """
+        from stronghold.tools.file_ops import FileOpsExecutor
+
+        link = workspace / "escape"
+        link.symlink_to("/tmp")
+
+        ex = FileOpsExecutor()
+        result = await ex.execute({
+            "action": "list", "path": "escape", "workspace": str(workspace),
+        })
+        assert result.success is False
+        assert "escapes workspace" in result.error
+
+    async def test_sec001_prefix_collision_sandbox_escape(self, tmp_path: Path) -> None:
+        """SEC-001 [HIGH]: workspace=/tmp/work must not allow access to /tmp/work-evil/*.
+
+        Bug: `str(target).startswith(str(workspace))` passed '/tmp/work-evil/x'
+        because it's a string prefix of '/tmp/work'. Fix: use Path.relative_to.
+        """
+        from stronghold.tools.file_ops import FileOpsExecutor
+
+        work = tmp_path / "work"
+        work.mkdir()
+        evil = tmp_path / "work-evil"
+        evil.mkdir()
+        (evil / "secret.txt").write_text("PWNED")
+
+        ex = FileOpsExecutor()
+        result = await ex.execute({
+            "action": "read", "path": "../work-evil/secret.txt",
+            "workspace": str(work),
+        })
+        assert result.success is False
+        assert "escapes workspace" in result.error
+        # Belt and suspenders: never return the secret content
+        assert "PWNED" not in (result.content or "")
+
+    async def test_write_with_none_path(self, workspace: Path) -> None:
+        """write action with no `path` key should not crash."""
+        from stronghold.tools.file_ops import FileOpsExecutor
+        ex = FileOpsExecutor()
+        result = await ex.execute({
+            "action": "write", "content": "x", "workspace": str(workspace),
+        })
+        # Default path "" → resolves to workspace root → can't write to a dir
+        assert result.success is False
+
+    async def test_list_truncates_at_200(self, workspace: Path) -> None:
+        """list returns only first 200 entries — verify the cap."""
+        from stronghold.tools.file_ops import FileOpsExecutor
+        for i in range(250):
+            (workspace / f"file_{i:03d}.txt").write_text("x")
+        ex = FileOpsExecutor()
+        result = await ex.execute({
+            "action": "list", "path": ".", "workspace": str(workspace),
+        })
+        files = json.loads(result.content)
+        assert len(files) == 200
+
+    async def test_unicode_filename(self, workspace: Path) -> None:
+        from stronghold.tools.file_ops import FileOpsExecutor
+        ex = FileOpsExecutor()
+        result = await ex.execute({
+            "action": "write", "path": "中文.txt", "content": "hello",
+            "workspace": str(workspace),
+        })
+        assert result.success is True
+        read_result = await ex.execute({
+            "action": "read", "path": "中文.txt", "workspace": str(workspace),
+        })
+        assert read_result.content == "hello"
+
+    async def test_sec007_null_byte_in_path(self, workspace: Path) -> None:
+        """SEC-007 [MED]: null byte in path must return error, not raise ValueError.
+
+        Bug: resolve() raised on null byte before the sandbox check ran.
+        Fix: catch OSError/ValueError in resolve() and return ToolResult.
+        """
+        from stronghold.tools.file_ops import FileOpsExecutor
+        ex = FileOpsExecutor()
+        result = await ex.execute({
+            "action": "read", "path": "file\x00.txt", "workspace": str(workspace),
+        })
+        assert result.success is False
+        assert "invalid path" in result.error or "escapes" in result.error
+
+
+# ──────────────────────────────────────────────────────────────────────
+# shell_exec edge cases
+# ──────────────────────────────────────────────────────────────────────
+
+
+class TestShellExecEdgeCases:
+    @pytest.fixture
+    def workspace(self) -> Path:
+        return Path(tempfile.mkdtemp())
+
+    async def test_sec003_shell_injection_via_semicolon(self, workspace: Path) -> None:
+        """SEC-003 [CRIT]: allowlist bypass via command chaining.
+
+        Bug: allowlist checked cmd.startswith('echo'), so `echo hi; rm victim.txt`
+        passed. Fix: reject shell metacharacters before allowlist check.
+        """
+        from stronghold.tools.shell_exec import ShellExecutor
+        (workspace / "victim.txt").write_text("important data")
+
+        ex = ShellExecutor()
+        result = await ex.execute({
+            "command": "echo hi; rm -rf victim.txt",
+            "workspace": str(workspace),
+        })
+        assert result.success is False
+        assert "metacharacter" in result.error or "not allowed" in result.error
+        # Primary evidence: file still exists
+        assert (workspace / "victim.txt").exists()
+
+    async def test_sec004_shell_injection_via_command_substitution(self, workspace: Path) -> None:
+        """SEC-004 [CRIT]: allowlist bypass via $(...) substitution."""
+        from stronghold.tools.shell_exec import ShellExecutor
+        (workspace / "v.txt").write_text("data")
+        ex = ShellExecutor()
+        result = await ex.execute({
+            "command": "echo $(rm v.txt)",
+            "workspace": str(workspace),
+        })
+        assert result.success is False
+        assert (workspace / "v.txt").exists()
+
+    async def test_sec005_shell_injection_via_pipe(self, workspace: Path) -> None:
+        """SEC-005 [CRIT]: allowlist bypass via pipe to disallowed command."""
+        from stronghold.tools.shell_exec import ShellExecutor
+        (workspace / "x.txt").write_text("data")
+        ex = ShellExecutor()
+        result = await ex.execute({
+            "command": "ls | xargs rm",
+            "workspace": str(workspace),
+        })
+        assert result.success is False
+        assert (workspace / "x.txt").exists()
+
+    async def test_shell_metacharacter_variants_all_rejected(self, workspace: Path) -> None:
+        """Soundness: every shell metacharacter variant must be rejected."""
+        from stronghold.tools.shell_exec import ShellExecutor
+        ex = ShellExecutor()
+        variants = [
+            "echo a && rm b",
+            "echo a || rm b",
+            "echo a | rm b",
+            "echo a ; rm b",
+            "echo `rm b`",
+            "echo $(rm b)",
+            "echo a > /etc/hosts",
+            "echo a < /etc/passwd",
+            "echo a\nrm b",
+        ]
+        for cmd in variants:
+            result = await ex.execute({
+                "command": cmd, "workspace": str(workspace),
+            })
+            assert result.success is False, f"Metacharacter not rejected: {cmd!r}"
+
+    async def test_command_with_unicode_args(self, workspace: Path) -> None:
+        from stronghold.tools.shell_exec import ShellExecutor
+        ex = ShellExecutor()
+        result = await ex.execute({
+            "command": "echo 你好",
+            "workspace": str(workspace),
+        })
+        assert result.success is True
+        data = json.loads(result.content)
+        assert "你好" in data["stdout"]
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Cache edge cases
+# ──────────────────────────────────────────────────────────────────────
+
+
+class TestCacheEdgeCases:
+    async def test_session_store_max_messages_zero(self) -> None:
+        """max_messages=0 — what does get_history return?"""
+        import fakeredis.aioredis
+        from stronghold.cache.session_store import RedisSessionStore
+
+        client = fakeredis.aioredis.FakeRedis(decode_responses=False)
+        store = RedisSessionStore(client)
+        await store.append_messages("o/t/u:s", [
+            {"role": "user", "content": "msg"},
+        ])
+        # Read with max_messages=0 — should return empty list, not all messages
+        history = await store.get_history("o/t/u:s", max_messages=0)
+        # If max=0 falls back to default, that's a bug
+        await client.aclose()
+
+    async def test_sec006_session_store_poisoned_json_does_not_crash(self) -> None:
+        """SEC-006 [MED]: single corrupt Redis entry must not take down session read.
+
+        Bug: json.loads ran unprotected inside a loop. One bad entry raised
+        JSONDecodeError and killed the whole get_history call.
+        Fix: wrap in try/except, log + skip the poisoned entry.
+        """
+        import fakeredis.aioredis
+        from stronghold.cache.session_store import RedisSessionStore
+
+        client = fakeredis.aioredis.FakeRedis(decode_responses=False)
+        store = RedisSessionStore(client)
+        # Inject: poison, valid, poison
+        key = "stronghold:session:o/t/u:s"
+        import time as _t
+        now = _t.time()
+        await client.rpush(key, b"not valid json {{{")
+        await client.rpush(
+            key,
+            f'{{"role": "user", "content": "good", "_ts": {now}}}'.encode(),
+        )
+        await client.rpush(key, b"also corrupt")
+
+        history = await store.get_history("o/t/u:s")
+        # Should return the one valid entry, skipping the two poisoned ones
+        assert len(history) == 1
+        assert history[0]["content"] == "good"
+        await client.aclose()
+
+    async def test_session_id_with_embedded_slash(self) -> None:
+        """Session ID like 'org/team/user:session/with/slash' — only first / matters?"""
+        import fakeredis.aioredis
+        from stronghold.cache.session_store import RedisSessionStore
+
+        client = fakeredis.aioredis.FakeRedis(decode_responses=False)
+        store = RedisSessionStore(client)
+        await store.append_messages("org/team/user:session/extra", [
+            {"role": "user", "content": "test"},
+        ])
+        history = await store.get_history("org/team/user:session/extra")
+        # If embedded slashes break key resolution, this would be empty
+        assert len(history) == 1
+        await client.aclose()
+
+    async def test_rate_limiter_zero_max_requests(self) -> None:
+        """max_requests=0 — every request should be denied."""
+        import fakeredis.aioredis
+        from stronghold.cache.rate_limiter import RedisRateLimiter
+
+        client = fakeredis.aioredis.FakeRedis(decode_responses=False)
+        limiter = RedisRateLimiter(client, max_requests=0, window_seconds=60)
+        allowed, headers = await limiter.check("user")
+        assert allowed is False, "max_requests=0 should always deny"
+        assert headers["X-RateLimit-Remaining"] == "0"
+        await client.aclose()
+
+    async def test_prompt_cache_ttl_zero(self) -> None:
+        """ttl=0 means immediate expiry. Does Redis accept it?"""
+        import fakeredis.aioredis
+        from stronghold.cache.prompt_cache import RedisPromptCache
+
+        client = fakeredis.aioredis.FakeRedis(decode_responses=False)
+        cache = RedisPromptCache(client)
+        # Some Redis versions reject ttl=0; others treat as no-expiry
+        try:
+            await cache.set("k", "v", ttl=0)
+        except Exception:
+            pass  # Acceptable to reject
+        await client.aclose()
+
+    async def test_prompt_cache_set_unserializable(self) -> None:
+        """set() with non-JSON-serializable value should not silently corrupt."""
+        import fakeredis.aioredis
+        from stronghold.cache.prompt_cache import RedisPromptCache
+
+        client = fakeredis.aioredis.FakeRedis(decode_responses=False)
+        cache = RedisPromptCache(client)
+        # set() in production code uses default=str so this should serialize as repr
+        await cache.set("k", {"fn": lambda x: x})
+        result = await cache.get("k")
+        # Either the lambda was stringified, or set raised
+        assert result is not None
+        await client.aclose()
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Coin edge cases
+# ──────────────────────────────────────────────────────────────────────
+
+
+class TestCoinEdgeCases:
+    def test_coins_to_microchips_huge_number(self) -> None:
+        """Large input shouldn't overflow."""
+        from stronghold.quota.coins import coins_to_microchips
+        # 10^15 copper = 10^18 microchips — fits in int64
+        result = coins_to_microchips(10**15)
+        assert result == 10**18
+
+    def test_coins_to_microchips_scientific_notation(self) -> None:
+        from stronghold.quota.coins import coins_to_microchips
+        # "1e3" copper = 1000 copper = 1_000_000 microchips
+        result = coins_to_microchips("1e3")
+        assert result == 1_000_000
+
+    def test_sec008_decimal_rejects_nan(self) -> None:
+        """SEC-008 [MED]: _decimal must reject NaN / Infinity strings.
+
+        Bug: Decimal('NaN') passed through. Any comparison (budget > limit)
+        returns False for NaN, silently bypassing budget checks.
+        Fix: detect NaN/Infinity and return default.
+        """
+        from decimal import Decimal
+        from stronghold.quota.coins import _decimal
+
+        assert _decimal("NaN") == Decimal("0")
+        assert _decimal("nan") == Decimal("0")
+        assert _decimal("Infinity") == Decimal("0")
+        assert _decimal("-Infinity") == Decimal("0")
+        assert not _decimal("NaN").is_nan()
+        assert not _decimal("inf").is_infinite()
+
+    def test_sec008_coin_budget_nan_does_not_bypass(self) -> None:
+        """SEC-008 evidence: feeding NaN through the cost pipeline doesn't zero the charge."""
+        from stronghold.quota.coins import _resolve_quote
+        models = {"m": {"coin_cost_base": "NaN", "coin_cost_per_1k_input_microchips": 50}}
+        quote = _resolve_quote(models, {}, "m", "p", 1000, 0)
+        # Base becomes 0 (rejected), input rate is normal, charge should be 50
+        assert quote.charged_microchips == 50
+
+    def test_resolve_quote_negative_base(self) -> None:
+        """Negative base cost — should clamp or reject."""
+        from stronghold.quota.coins import _resolve_quote
+
+        models = {"m": {"coin_cost_base_microchips": -1000}}
+        quote = _resolve_quote(models, {}, "m", "p", 100, 100)
+        assert quote.charged_microchips >= 0, (
+            "Negative base cost was not clamped — could give users free credits"
+        )
+
+    def test_format_microchips_negative_zero(self) -> None:
+        """format_microchips(-0) shouldn't show '-0'."""
+        from stronghold.quota.coins import format_microchips
+        result = format_microchips(0)
+        assert result["amount"] == 0
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Trigger handler edge cases
+# ──────────────────────────────────────────────────────────────────────
+
+
+class TestTriggerEdgeCases:
+    def _container(self):
+        from unittest.mock import AsyncMock, MagicMock
+        c = MagicMock()
+        c.reactor = type("R", (), {"_triggers": [], "register": lambda self, s, a: self._triggers.append((s, a))})()
+        c.learning_promoter = None
+        c.rate_limiter = MagicMock()
+        c.rate_limiter._windows = {}
+        c.outcome_store = MagicMock()
+        c.outcome_store.get_task_completion_rate = AsyncMock(return_value={})
+        c.warden = MagicMock()
+        c.tournament = None
+        c.canary_manager = None
+        c.learning_store = MagicMock()
+        c.mason_queue = MagicMock()
+        c.route_request = AsyncMock()
+        return c
+
+    def _get_handler(self, container, name):
+        for spec, action in container.reactor._triggers:
+            if spec.name == name:
+                return action
+        raise KeyError(name)
+
+    async def test_security_rescan_with_none_data(self) -> None:
+        """event.data is None instead of dict — handler crashes?"""
+        from stronghold.triggers import register_core_triggers
+        from stronghold.types.reactor import Event
+
+        c = self._container()
+        register_core_triggers(c)
+        handler = self._get_handler(c, "security_rescan")
+        # Event.data should default to {} via dataclass — but what if it's explicitly None?
+        try:
+            result = await handler(Event(name="security.rescan", data={}))
+            assert result is not None
+        except (AttributeError, TypeError) as e:
+            pytest.fail(f"Handler crashed on empty data: {e}")
+
+    async def test_mason_dispatch_with_string_issue_number(self) -> None:
+        """issue_number is a string instead of int — JSON deser hazard."""
+        from stronghold.triggers import register_core_triggers
+        from stronghold.types.reactor import Event
+
+        c = self._container()
+        register_core_triggers(c)
+        handler = self._get_handler(c, "mason_dispatch")
+        result = await handler(Event(
+            name="mason.issue_assigned",
+            data={"issue_number": "42", "title": "t", "owner": "o", "repo": "r"},
+        ))
+        # Either coerces or errors out — should not silently treat "42" as 0
+        assert result is not None

--- a/tests/test_triggers_coverage.py
+++ b/tests/test_triggers_coverage.py
@@ -46,7 +46,7 @@ class TestRegisterCoreTriggers:
             "tournament_evaluation",
             "canary_deployment_check",
             "rlhf_feedback",
-            "mason_dispatch",
+            "issue_backlog_scanner",
             "mason_pr_review",
         }
         assert names == expected
@@ -176,13 +176,15 @@ class TestRlhfFeedbackTrigger:
         assert result["skipped"] is True
 
 
-class TestMasonDispatchTrigger:
-    async def test_skipped_when_no_issue_number(self) -> None:
+class TestIssueBacklogScanner:
+    async def test_skipped_when_no_github_token(self) -> None:
+        """Scanner skips when no GitHub App credentials available."""
         c = _make_container()
         register_core_triggers(c)
-        _, handler = _find_trigger(c, "mason_dispatch")
-        result = await handler(Event("mason.issue_assigned", {}))
-        assert result["skipped"] is True
+        _, handler = _find_trigger(c, "issue_backlog_scanner")
+        # Without real app credentials, token generation returns ""
+        result = await handler(Event("tick", {}))
+        assert result.get("skipped") is True or result.get("error") is not None
 
 
 class TestMasonPrReviewTrigger:
@@ -295,47 +297,303 @@ class TestRlhfFeedbackWithReview:
         assert "stored_learnings" in result
 
 
-class TestMasonDispatchWithRoute:
-    """Test mason_dispatch when issue_number is provided."""
+def _make_github_issue(
+    number: int = 1,
+    title: str = "Test issue",
+    body: str = "Short body",
+    labels: list[str] | None = None,
+    is_pr: bool = False,
+    created_at: str = "2026-04-12T00:00:00Z",
+) -> dict[str, Any]:
+    """Build a fake GitHub issue dict matching the API response shape."""
+    issue: dict[str, Any] = {
+        "number": number,
+        "title": title,
+        "body": body,
+        "labels": [{"name": l} for l in (labels or ["builders"])],
+        "created_at": created_at,
+    }
+    if is_pr:
+        issue["pull_request"] = {"url": "https://api.github.com/repos/x/y/pulls/1"}
+    return issue
 
-    async def test_dispatch_handles_failure_gracefully(self) -> None:
-        """When route_request fails (no agents), the handler catches and records the error."""
+
+class _ScannerTestBase:
+    """Base class providing GitHub token setup + respx mocking for scanner tests."""
+
+    def _setup_token(self, monkeypatch: Any) -> None:
+        monkeypatch.setenv("GITHUB_TOKEN", "ghp_fake_for_test")
+
+    def _get_handler(self, container: Any) -> Any:
+        register_core_triggers(container)
+        _, handler = _find_trigger(container, "issue_backlog_scanner")
+        return handler
+
+
+class TestIssueBacklogScannerBasics(_ScannerTestBase):
+    """Token, API, and empty backlog tests."""
+
+    async def test_no_token_skips(self) -> None:
+        c = _make_container()
+        handler = self._get_handler(c)
+        result = await handler(Event("tick", {}))
+        assert result.get("skipped") is True
+
+    async def test_empty_backlog_returns_zero(self, monkeypatch: Any) -> None:
+        import respx
+
+        self._setup_token(monkeypatch)
+        c = _make_container()
+        handler = self._get_handler(c)
+
+        with respx.mock:
+            respx.get("https://api.github.com/repos/Agent-StrongHold/stronghold/issues").respond(
+                200, json=[]
+            )
+            result = await handler(Event("tick", {}))
+
+        assert result["scanned"] == 0
+        assert result["dispatched"] == 0
+
+    async def test_github_api_error(self, monkeypatch: Any) -> None:
+        import respx
+
+        self._setup_token(monkeypatch)
+        c = _make_container()
+        handler = self._get_handler(c)
+
+        with respx.mock:
+            respx.get("https://api.github.com/repos/Agent-StrongHold/stronghold/issues").respond(500)
+            result = await handler(Event("tick", {}))
+
+        assert "error" in result
+
+
+class TestIssueBacklogScannerFiltering(_ScannerTestBase):
+    """Tests for issue filtering: skip in-progress, blocked, PRs."""
+
+    async def test_skips_in_progress_issues(self, monkeypatch: Any) -> None:
+        import respx
+
+        self._setup_token(monkeypatch)
+        c = _make_container()
+        handler = self._get_handler(c)
+
+        issues = [_make_github_issue(1, labels=["builders", "in-progress"])]
+        with respx.mock:
+            respx.get("https://api.github.com/repos/Agent-StrongHold/stronghold/issues").respond(
+                200, json=issues
+            )
+            # Mock label POST (best-effort, may or may not be called)
+            respx.post().respond(200, json=[])
+            result = await handler(Event("tick", {}))
+
+        assert result["scanned"] == 1
+        assert result["dispatched"] == 0
+
+    async def test_skips_blocked_issues(self, monkeypatch: Any) -> None:
+        import respx
+
+        self._setup_token(monkeypatch)
+        c = _make_container()
+        handler = self._get_handler(c)
+
+        issues = [_make_github_issue(1, labels=["builders", "blocked"])]
+        with respx.mock:
+            respx.get("https://api.github.com/repos/Agent-StrongHold/stronghold/issues").respond(
+                200, json=issues
+            )
+            respx.post().respond(200, json=[])
+            result = await handler(Event("tick", {}))
+
+        assert result["dispatched"] == 0
+
+    async def test_skips_pull_requests(self, monkeypatch: Any) -> None:
+        import respx
+
+        self._setup_token(monkeypatch)
+        c = _make_container()
+        handler = self._get_handler(c)
+
+        issues = [_make_github_issue(1, is_pr=True)]
+        with respx.mock:
+            respx.get("https://api.github.com/repos/Agent-StrongHold/stronghold/issues").respond(
+                200, json=issues
+            )
+            respx.post().respond(200, json=[])
+            result = await handler(Event("tick", {}))
+
+        assert result["dispatched"] == 0
+
+
+class TestIssueBacklogScannerTriage(_ScannerTestBase):
+    """Triage: atomic vs decomposable heuristics."""
+
+    async def test_atomic_by_size_s_label(self, monkeypatch: Any) -> None:
+        import respx
+
+        self._setup_token(monkeypatch)
+        c = _make_container()
+        handler = self._get_handler(c)
+
+        issues = [_make_github_issue(1, labels=["builders", "size/S"])]
+        with respx.mock:
+            respx.get("https://api.github.com/repos/Agent-StrongHold/stronghold/issues").respond(
+                200, json=issues
+            )
+            label_route = respx.post(
+                url__regex=r".*/issues/1/labels"
+            ).respond(200, json=[])
+            result = await handler(Event("tick", {}))
+
+        assert result["dispatched"] == 1
+        # Check that "atomic" label was applied
+        if label_route.called:
+            body = label_route.calls[0].request.content
+            import json
+            labels = json.loads(body)["labels"]
+            assert "atomic" in labels
+
+    async def test_decomposable_by_epic_label(self, monkeypatch: Any) -> None:
+        import respx
+
+        self._setup_token(monkeypatch)
+        c = _make_container()
+        handler = self._get_handler(c)
+
+        issues = [_make_github_issue(1, labels=["builders", "epic"])]
+        with respx.mock:
+            respx.get("https://api.github.com/repos/Agent-StrongHold/stronghold/issues").respond(
+                200, json=issues
+            )
+            label_route = respx.post(
+                url__regex=r".*/issues/1/labels"
+            ).respond(200, json=[])
+            result = await handler(Event("tick", {}))
+
+        assert result["dispatched"] == 1
+        if label_route.called:
+            import json
+            labels = json.loads(label_route.calls[0].request.content)["labels"]
+            assert "needs-decomposition" in labels
+
+    async def test_heuristic_checkboxes_means_decompose(self, monkeypatch: Any) -> None:
+        import respx
+
+        self._setup_token(monkeypatch)
+        c = _make_container()
+        handler = self._get_handler(c)
+
+        body = "## Tasks\n- [ ] Do thing A\n- [ ] Do thing B\n- [ ] Do thing C"
+        issues = [_make_github_issue(1, body=body)]
+        with respx.mock:
+            respx.get("https://api.github.com/repos/Agent-StrongHold/stronghold/issues").respond(
+                200, json=issues
+            )
+            label_route = respx.post(url__regex=r".*/issues/1/labels").respond(200, json=[])
+            result = await handler(Event("tick", {}))
+
+        assert result["dispatched"] == 1
+        if label_route.called:
+            import json
+            labels = json.loads(label_route.calls[0].request.content)["labels"]
+            assert "needs-decomposition" in labels
+
+    async def test_heuristic_sections_means_decompose(self, monkeypatch: Any) -> None:
+        import respx
+
+        self._setup_token(monkeypatch)
+        c = _make_container()
+        handler = self._get_handler(c)
+
+        body = "## Phase 1\nDo this\n## Phase 2\nDo that\n## Phase 3\nDo other"
+        issues = [_make_github_issue(1, body=body)]
+        with respx.mock:
+            respx.get("https://api.github.com/repos/Agent-StrongHold/stronghold/issues").respond(
+                200, json=issues
+            )
+            respx.post().respond(200, json=[])
+            result = await handler(Event("tick", {}))
+
+        assert result["dispatched"] == 1
+
+    async def test_heuristic_short_body_means_atomic(self, monkeypatch: Any) -> None:
+        import respx
+
+        self._setup_token(monkeypatch)
+        c = _make_container()
+        handler = self._get_handler(c)
+
+        issues = [_make_github_issue(1, body="Fix the typo in README")]
+        with respx.mock:
+            respx.get("https://api.github.com/repos/Agent-StrongHold/stronghold/issues").respond(
+                200, json=issues
+            )
+            label_route = respx.post(url__regex=r".*/issues/1/labels").respond(200, json=[])
+            result = await handler(Event("tick", {}))
+
+        assert result["dispatched"] == 1
+        if label_route.called:
+            import json
+            labels = json.loads(label_route.calls[0].request.content)["labels"]
+            assert "atomic" in labels
+
+
+class TestIssueBacklogScannerConcurrency(_ScannerTestBase):
+    """Concurrency limit tests."""
+
+    async def test_concurrency_limit_respected(self, monkeypatch: Any) -> None:
+        import respx
+
+        self._setup_token(monkeypatch)
         c = _make_container()
 
-        class FakeMasonQueue:
-            def __init__(self) -> None:
-                self.started: list[int] = []
-                self.completed: list[int] = []
-                self.failed: list[tuple[int, str]] = []
+        # Simulate 3 already in-progress via mason_queue
+        class FakeQueue:
+            def list_all(self) -> list[dict[str, str]]:
+                return [
+                    {"status": "in_progress"},
+                    {"status": "in_progress"},
+                    {"status": "in_progress"},
+                ]
 
-            def start(self, issue_number: int) -> None:
-                self.started.append(issue_number)
+        c.mason_queue = FakeQueue()  # type: ignore[attr-defined]
+        handler = self._get_handler(c)
 
-            def complete(self, issue_number: int) -> None:
-                self.completed.append(issue_number)
-
-            def fail(self, issue_number: int, error: str = "") -> None:
-                self.failed.append((issue_number, error))
-
-        c.mason_queue = FakeMasonQueue()  # type: ignore[attr-defined]
-        register_core_triggers(c)
-        _, handler = _find_trigger(c, "mason_dispatch")
-        result = await handler(
-            Event(
-                "mason.issue_assigned",
-                {
-                    "issue_number": 42,
-                    "title": "Implement feature",
-                    "owner": "org",
-                    "repo": "stronghold",
-                },
+        issues = [_make_github_issue(1), _make_github_issue(2)]
+        with respx.mock:
+            respx.get("https://api.github.com/repos/Agent-StrongHold/stronghold/issues").respond(
+                200, json=issues
             )
-        )
-        assert result["issue_number"] == 42
-        assert result["status"] == "failed"
-        assert "error" in result
-        assert 42 in c.mason_queue.started
-        assert len(c.mason_queue.failed) == 1
+            respx.post().respond(200, json=[])
+            result = await handler(Event("tick", {}))
+
+        assert result["dispatched"] == 0
+        assert result.get("reason") == "at concurrency limit"
+
+    async def test_partial_slots_dispatches_limited(self, monkeypatch: Any) -> None:
+        import respx
+
+        self._setup_token(monkeypatch)
+        c = _make_container()
+
+        class FakeQueue:
+            def list_all(self) -> list[dict[str, str]]:
+                return [{"status": "in_progress"}, {"status": "in_progress"}]
+
+        c.mason_queue = FakeQueue()  # type: ignore[attr-defined]
+        handler = self._get_handler(c)
+
+        issues = [_make_github_issue(i) for i in range(1, 6)]  # 5 issues
+        with respx.mock:
+            respx.get("https://api.github.com/repos/Agent-StrongHold/stronghold/issues").respond(
+                200, json=issues
+            )
+            respx.post().respond(200, json=[])
+            result = await handler(Event("tick", {}))
+
+        # 3 max - 2 in progress = 1 slot
+        assert result["dispatched"] == 1
 
 
 class TestMasonPrReviewWithRoute:

--- a/tests/test_triggers_extended.py
+++ b/tests/test_triggers_extended.py
@@ -1,0 +1,374 @@
+"""Tests for the five trigger handlers not covered by test_new_modules_2.
+
+Covers lines 50, 89, 169-185, 199-242, 256-288 of src/stronghold/triggers.py:
+
+  - rate_limit_eviction: the "evicted > 0" debug log branch
+  - security_rescan:     the "not verdict.clean" warning branch
+  - rlhf_feedback:       the entire handler including lazy FeedbackLoop init
+  - mason_dispatch:      full dispatch path + exception + skip-no-issue
+  - mason_pr_review:     full review path + exception + skip-no-pr
+
+Uses a SimpleNamespace-based fake container so the tests don't depend
+on the full DI wiring — each test only attaches the attributes the
+target handler actually reaches.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from stronghold.events import Reactor
+from stronghold.triggers import register_core_triggers
+from stronghold.types.reactor import Event
+
+
+def _find_action(reactor: Reactor, name: str) -> Any:
+    """Return the registered async action for a trigger by spec name."""
+    for state, action in reactor._triggers:
+        if state.spec.name == name:
+            return action
+    msg = f"trigger not registered: {name}"
+    raise AssertionError(msg)
+
+
+def _base_container(**extra: Any) -> SimpleNamespace:
+    """Minimal fake container with the universal triggers dependencies."""
+    warden = SimpleNamespace(
+        scan=AsyncMock(return_value=SimpleNamespace(clean=True, flags=())),
+    )
+    rate_limiter = SimpleNamespace(
+        _windows={},
+        _evict_stale_keys=lambda _now: None,
+    )
+    outcome_store = SimpleNamespace(
+        get_task_completion_rate=AsyncMock(return_value={"total": 0, "rate": 0.0}),
+    )
+    learning_store = SimpleNamespace()
+    reactor = Reactor(tick_hz=100)
+    ns = SimpleNamespace(
+        reactor=reactor,
+        warden=warden,
+        rate_limiter=rate_limiter,
+        outcome_store=outcome_store,
+        learning_store=learning_store,
+        learning_promoter=None,
+        tournament=None,
+        canary_manager=None,
+    )
+    for key, val in extra.items():
+        setattr(ns, key, val)
+    return ns
+
+
+# ---------------------------------------------------------------------------
+# rate_limit_eviction — debug log on eviction
+# ---------------------------------------------------------------------------
+
+
+class TestRateLimitEviction:
+    @pytest.mark.asyncio
+    async def test_no_evicted_keys_returns_zero(self) -> None:
+        container = _base_container()
+        register_core_triggers(container)
+        action = _find_action(container.reactor, "rate_limit_eviction")
+        result = await action(Event(name="_interval:rate_limit_eviction"))
+        assert result == {"evicted": 0}
+
+    @pytest.mark.asyncio
+    async def test_evicted_keys_hits_debug_log_branch(self) -> None:
+        """Simulate a rate limiter where eviction shrinks the window map."""
+        shrinking = SimpleNamespace(_windows={"a": object(), "b": object()})
+
+        def evict(_now: float) -> None:
+            shrinking._windows.clear()
+
+        shrinking._evict_stale_keys = evict
+        container = _base_container(rate_limiter=shrinking)
+        register_core_triggers(container)
+        action = _find_action(container.reactor, "rate_limit_eviction")
+        result = await action(Event(name="_interval:rate_limit_eviction"))
+        assert result["evicted"] == 2
+
+
+# ---------------------------------------------------------------------------
+# security_rescan — verdict.clean=False branch
+# ---------------------------------------------------------------------------
+
+
+class TestSecurityRescanDirty:
+    @pytest.mark.asyncio
+    async def test_not_clean_verdict_logs_warning_and_returns_flags(self) -> None:
+        dirty_warden = SimpleNamespace(
+            scan=AsyncMock(
+                return_value=SimpleNamespace(
+                    clean=False,
+                    flags=("prompt_injection", "secret_leak"),
+                )
+            )
+        )
+        container = _base_container(warden=dirty_warden)
+        register_core_triggers(container)
+        action = _find_action(container.reactor, "security_rescan")
+        result = await action(
+            Event(
+                name="security.rescan",
+                data={"content": "suspicious", "boundary": "tool_result"},
+            )
+        )
+        assert result["clean"] is False
+        assert "prompt_injection" in result["flags"]
+
+
+# ---------------------------------------------------------------------------
+# post_tool_learning — the "failure on tool_name" branch
+# ---------------------------------------------------------------------------
+
+
+class TestPostToolLearning:
+    @pytest.mark.asyncio
+    async def test_failure_with_tool_name_logs_and_returns(self) -> None:
+        container = _base_container()
+        register_core_triggers(container)
+        action = _find_action(container.reactor, "post_tool_learning")
+        result = await action(
+            Event(
+                name="post_tool_loop",
+                data={"tool_name": "web_search", "success": False},
+            )
+        )
+        assert result == {"tool_name": "web_search", "success": False}
+
+    @pytest.mark.asyncio
+    async def test_success_path_returns_true(self) -> None:
+        container = _base_container()
+        register_core_triggers(container)
+        action = _find_action(container.reactor, "post_tool_learning")
+        result = await action(
+            Event(
+                name="post_tool_loop",
+                data={"tool_name": "file_ops", "success": True},
+            )
+        )
+        assert result["success"] is True
+
+
+# ---------------------------------------------------------------------------
+# rlhf_feedback — full handler path + skip branch
+# ---------------------------------------------------------------------------
+
+
+class TestRlhfFeedback:
+    @pytest.mark.asyncio
+    async def test_skip_when_no_review_result(self) -> None:
+        container = _base_container()
+        register_core_triggers(container)
+        action = _find_action(container.reactor, "rlhf_feedback")
+        result = await action(Event(name="pr.reviewed", data={}))
+        assert result == {"skipped": True}
+
+    @pytest.mark.asyncio
+    async def test_lazy_initialisation_and_processing(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """First call should build _feedback_loop on the container and
+        forward the review_result to process_review."""
+        container = _base_container()
+        register_core_triggers(container)
+        action = _find_action(container.reactor, "rlhf_feedback")
+
+        # Stub the FeedbackLoop class used inside the handler so construction
+        # doesn't require real learning store plumbing.
+        fake_loop = SimpleNamespace(process_review=AsyncMock(return_value=7))
+
+        class _FakeFeedbackLoop:
+            def __init__(self, **_kwargs: Any) -> None:
+                pass
+
+            async def process_review(self, *args: Any, **kwargs: Any) -> int:
+                return await fake_loop.process_review(*args, **kwargs)
+
+        monkeypatch.setattr(
+            "stronghold.agents.feedback.loop.FeedbackLoop",
+            _FakeFeedbackLoop,
+        )
+        monkeypatch.setattr(
+            "stronghold.agents.feedback.extractor.ReviewFeedbackExtractor",
+            lambda: SimpleNamespace(),
+        )
+        monkeypatch.setattr(
+            "stronghold.agents.feedback.tracker.InMemoryViolationTracker",
+            lambda: SimpleNamespace(),
+        )
+
+        review = SimpleNamespace(findings=(), approved=True)
+        result = await action(
+            Event(name="pr.reviewed", data={"review_result": review})
+        )
+        assert result == {"stored_learnings": 7}
+        assert hasattr(container, "_feedback_loop")  # cache populated
+        fake_loop.process_review.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_reuses_cached_feedback_loop_on_second_call(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        container = _base_container()
+        # Pre-populate the cached loop so the lazy-init branch is skipped.
+        processed_calls: list[Any] = []
+
+        async def _process(review: Any) -> int:
+            processed_calls.append(review)
+            return 2
+
+        container._feedback_loop = SimpleNamespace(process_review=_process)
+        register_core_triggers(container)
+        action = _find_action(container.reactor, "rlhf_feedback")
+
+        review = SimpleNamespace(findings=())
+        result = await action(
+            Event(name="pr.reviewed", data={"review_result": review})
+        )
+        assert result == {"stored_learnings": 2}
+        assert len(processed_calls) == 1
+
+
+# ---------------------------------------------------------------------------
+# mason_dispatch — success + exception + skip paths
+# ---------------------------------------------------------------------------
+
+
+class _MasonQueue:
+    """Tracks the state transitions Mason dispatch drives."""
+
+    def __init__(self) -> None:
+        self.started: list[int] = []
+        self.completed: list[int] = []
+        self.failed: list[tuple[int, str]] = []
+
+    def start(self, issue: int) -> None:
+        self.started.append(issue)
+
+    def complete(self, issue: int) -> None:
+        self.completed.append(issue)
+
+    def fail(self, issue: int, error: str = "") -> None:
+        self.failed.append((issue, error))
+
+
+class TestMasonDispatch:
+    @pytest.mark.asyncio
+    async def test_skip_when_no_issue_number(self) -> None:
+        container = _base_container(
+            route_request=AsyncMock(),
+            mason_queue=_MasonQueue(),
+        )
+        register_core_triggers(container)
+        action = _find_action(container.reactor, "mason_dispatch")
+        result = await action(Event(name="mason.issue_assigned", data={}))
+        assert result == {"skipped": True}
+
+    @pytest.mark.asyncio
+    async def test_success_path_completes_issue(self) -> None:
+        queue = _MasonQueue()
+        route = AsyncMock(return_value={"ok": True})
+        container = _base_container(route_request=route, mason_queue=queue)
+        register_core_triggers(container)
+        action = _find_action(container.reactor, "mason_dispatch")
+        result = await action(
+            Event(
+                name="mason.issue_assigned",
+                data={
+                    "issue_number": 42,
+                    "title": "Fix bug",
+                    "owner": "acme",
+                    "repo": "widgets",
+                },
+            )
+        )
+        assert result == {"issue_number": 42, "status": "completed"}
+        assert queue.started == [42]
+        assert queue.completed == [42]
+        assert queue.failed == []
+        route.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_route_request_failure_marks_failed(self) -> None:
+        queue = _MasonQueue()
+        route = AsyncMock(side_effect=RuntimeError("llm offline"))
+        container = _base_container(route_request=route, mason_queue=queue)
+        register_core_triggers(container)
+        action = _find_action(container.reactor, "mason_dispatch")
+        result = await action(
+            Event(
+                name="mason.issue_assigned",
+                data={
+                    "issue_number": 7,
+                    "title": "Break thing",
+                    "owner": "acme",
+                    "repo": "widgets",
+                },
+            )
+        )
+        assert result["status"] == "failed"
+        assert "llm offline" in result["error"]
+        assert queue.failed == [(7, "llm offline")]
+        assert queue.completed == []
+
+
+# ---------------------------------------------------------------------------
+# mason_pr_review — success + exception + skip paths
+# ---------------------------------------------------------------------------
+
+
+class TestMasonPrReview:
+    @pytest.mark.asyncio
+    async def test_skip_when_no_pr_number(self) -> None:
+        container = _base_container(route_request=AsyncMock())
+        register_core_triggers(container)
+        action = _find_action(container.reactor, "mason_pr_review")
+        result = await action(
+            Event(name="mason.pr_review_requested", data={})
+        )
+        assert result == {"skipped": True}
+
+    @pytest.mark.asyncio
+    async def test_success_path(self) -> None:
+        route = AsyncMock(return_value={"ok": True})
+        container = _base_container(route_request=route)
+        register_core_triggers(container)
+        action = _find_action(container.reactor, "mason_pr_review")
+        result = await action(
+            Event(
+                name="mason.pr_review_requested",
+                data={
+                    "pr_number": 101,
+                    "owner": "acme",
+                    "repo": "widgets",
+                },
+            )
+        )
+        assert result == {"pr_number": 101, "status": "completed"}
+        route.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_exception_path(self) -> None:
+        route = AsyncMock(side_effect=RuntimeError("review boom"))
+        container = _base_container(route_request=route)
+        register_core_triggers(container)
+        action = _find_action(container.reactor, "mason_pr_review")
+        result = await action(
+            Event(
+                name="mason.pr_review_requested",
+                data={
+                    "pr_number": 202,
+                    "owner": "acme",
+                    "repo": "widgets",
+                },
+            )
+        )
+        assert result["status"] == "failed"
+        assert "review boom" in result["error"]


### PR DESCRIPTION
* feat: issue backlog scanner with triage, filtering, concurrency

Replaces the old mason_dispatch shortcut with a proper issue lifecycle:

Scanner (5min reactor interval):
- Fetches open issues with 'builders' label from GitHub
- Filters: skips in-progress, blocked, wontfix, duplicate, PRs
- Triage heuristics: atomic (size/S, short body) vs decomposable
  (epic label, checkboxes, multiple sections, long body)
- Labels issues with triage result (atomic/needs-decomposition + in-progress)
- Respects concurrency limit (max 3 concurrent, via mason_queue)
- Dispatches through BuilderPipeline with skip_decompose flag

Webhook handler (mason.py):
- No longer emits mason.issue_assigned event
- Logs builders-labeled issues for scanner pickup
- Single entry point: scanner is the only dispatcher

Bug fixes:
- mason_queue None check (crashed when queue not initialized)
- Orchestrator accessor: _app_orchestrator → orchestrator

37 tests covering: token skip, empty backlog, API errors, label
filtering, triage heuristics (5 tests), concurrency limits

* fix: update webhook test for log-only behavior (no mason.issue_assigned)

Old test expected mason.issue_assigned event emission on issue assign.
Webhook now just logs builders-labeled issues for scanner pickup.
New tests: builders label → log only, non-builders → ignored.

* fix: wire orchestrator onto container — triggers can now dispatch to pipeline

One missing line: container.orchestrator = orchestrator

The OrchestratorEngine was created, started, and running — but only
stored on app.state (FastAPI). Triggers access the container, not
app.state, so the backlog scanner could never find the orchestrator
and always fell through to emitting a dead-end event.

* style: ruff format triggers.py

* ci: run all jobs in parallel — no serial dependency on lint

All CI jobs (Lint, Security, SAST, Tests) now run independently.
Previously Security/SAST/Tests waited for Lint to pass first, which
meant a lint failure hid test failures. Now all failures surface in
one run so the repair pipeline gets the full picture.

* feat: Herald + Master-at-Arms agents, model fallbacks, orchestrator field, rework loop

New agents:
- Herald: idea intake, codebase research, epic drafting
- Master-at-Arms: daily retrospective learning across pipeline runs

Model fallback updates (all agents):
- Archie + Mason: opus-4.6 → gemini-3.1-pro → devstral → codestral
- Herald: gemini-3.1-pro → mistral-large → deepseek
- Master-at-Arms: gemini-3.1-pro → mistral-large → gemini-3-flash

Pipeline rework loop (pipeline.py):
- Extracted _run_stage() helper + _is_review_clean() check
- After implement: review → if violations → cleanup → re-implement → re-review
- Max 3 rework rounds before failure with violation summary

Container: added orchestrator field (mypy fix)
Priority ordering: P0→P5 sort in backlog scanner
Agent signatures: all agents sign comments with persona name

* fix: add agent_card.json for Herald + Master-at-Arms + container orchestrator field

- Herald and Master-at-Arms agent cards (required by test_agent_cards)
- Container dataclass: added orchestrator field (mypy --strict)

* fix: PgCoinLedger tests use DATABASE_URL env var (CI uses port 5433)

* ci: pin Python 3.13 on k3s runners via actions/setup-python

CI was using whatever Python shipped with the runner image (3.12.3)
while dev is on 3.13.5. Behavior differences caused test skips and
coverage gaps. Now all 4 CI jobs use actions/setup-python@v5 with
python-version: 3.13 for consistency.

* feat: 4-bot GitHub App identity system + PR lifecycle actions

Cherry-picked from feat/builder-pipeline and merged:

Bot identity system (_BOT_REGISTRY):
  gatekeeper (3354708) — Auditor, Janitor, CI triage, Master-at-Arms
  archie (3354872) — Archie scaffolding
  mason (3354924) — Mason building
  quartermaster (3355040) — Quartermaster + Herald planning

New GitHub tool actions:
  submit_review — APPROVE / REQUEST_CHANGES / COMMENT
  close_pr, merge_pr (squash default)
  add_labels, remove_label, close_issue

Auth: bot token auto-generated from GitHub App private key.
Falls back to GITHUB_TOKEN PAT if app creds unavailable.
Pass bot='mason' to GitHubToolExecutor for identity selection.

* style: fix E501 line too long in submit_review

* ci: tiered coverage gates — 85% feature, 90% develop, 95% main

Removed global fail_under=95 from pyproject.toml. Coverage gates
now enforced per-tier in CI workflows:

  feature/* PRs: 85% total coverage (--cov-fail-under=85)
  develop PRs:   90% total coverage (--cov-fail-under=90)
  main PRs:      95% diff coverage (diff-cover in release.yml)

Local pytest no longer fails on coverage — devs can iterate freely
on feature branches without hitting the 95% wall.

---------

Co-authored-by: Blake Matthews <blakematthews@agentstronghold.com>