### PR TITLE
feat(deploy): GitOps via Argo CD — split into integration + production envs

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,42 +1,85 @@
 name: Deploy
 
-# Blue-green deploy to agentstronghold.com
-# Triggered on push to main (after release PR merges) or manual dispatch
+# GitOps deploy for Stronghold.
+#
+# Build the image, push to GHCR, and bump the matching values-{env}-image.yaml
+# file. Argo CD watches this repo and reconciles the cluster state on change.
+#
+#   push to integration  →  build + push + bot commits tag bump to integration
+#                            →  Argo CD auto-syncs stronghold-integration
+#
+#   push to main         →  build + push + bot opens PR titled
+#                            "deploy(production): bump image to <tag>"
+#                            →  operator reviews + merges (signed commit)
+#                            →  operator runs `argocd app sync stronghold-production`
+#
+# See deploy/argocd/README.md for the full flow and rollback procedure.
 
 on:
   push:
-    branches: [main]
+    branches: [integration, main]
   workflow_dispatch:
     inputs:
       environment:
-        description: "Deploy environment"
+        description: "Force a deploy to this environment"
         required: true
-        default: "production"
         type: choice
         options:
+          - integration
           - production
 
+permissions:
+  contents: write       # bot pushes the image-tag bump
+  packages: write       # push image to GHCR
+  pull-requests: write  # bot opens deploy PR for production
+
+concurrency:
+  group: deploy-${{ github.ref }}
+  cancel-in-progress: false
+
+env:
+  IMAGE: ghcr.io/agent-stronghold/stronghold
+
 jobs:
+  resolve-env:
+    name: Resolve target environment
+    runs-on: ubuntu-latest
+    outputs:
+      env: ${{ steps.pick.outputs.env }}
+      tag_file: ${{ steps.pick.outputs.tag_file }}
+    steps:
+      - id: pick
+        run: |
+          set -eu
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            ENV="${{ inputs.environment }}"
+          elif [ "${{ github.ref }}" = "refs/heads/integration" ]; then
+            ENV="integration"
+          elif [ "${{ github.ref }}" = "refs/heads/main" ]; then
+            ENV="production"
+          else
+            echo "Unsupported ref for deploy: ${{ github.ref }}" >&2
+            exit 1
+          fi
+          echo "env=${ENV}" >> "$GITHUB_OUTPUT"
+          echo "tag_file=deploy/helm/stronghold/values-${ENV}-image.yaml" >> "$GITHUB_OUTPUT"
+
   build:
     name: Build & Push Image
+    needs: resolve-env
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      packages: write
-
     outputs:
-      image_tag: ${{ steps.meta.outputs.tags }}
-      version: ${{ steps.version.outputs.version }}
-
+      image_tag: ${{ steps.tag.outputs.tag }}
     steps:
       - uses: actions/checkout@v4
 
-      - name: Extract version
-        id: version
+      - name: Compute image tag
+        id: tag
         run: |
-          VERSION=$(python3 -c "import tomllib; print(tomllib.load(open('pyproject.toml','rb'))['project']['version'])")
-          SHA=$(git rev-parse --short HEAD)
-          echo "version=${VERSION}-${SHA}" >> "$GITHUB_OUTPUT"
+          set -eu
+          ENV="${{ needs.resolve-env.outputs.env }}"
+          SHA="$(git rev-parse --short HEAD)"
+          echo "tag=${ENV}-${SHA}" >> "$GITHUB_OUTPUT"
 
       - name: Log in to GHCR
         uses: docker/login-action@v3
@@ -45,72 +88,118 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Build and push
         uses: docker/build-push-action@v6
-        id: meta
         with:
           context: .
           push: true
           tags: |
-            ghcr.io/agent-stronghold/stronghold:latest
-            ghcr.io/agent-stronghold/stronghold:${{ steps.version.outputs.version }}
+            ${{ env.IMAGE }}:${{ steps.tag.outputs.tag }}
+            ${{ env.IMAGE }}:${{ needs.resolve-env.outputs.env }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
 
-  deploy:
-    name: Blue-Green Deploy
+  promote:
+    name: Promote (bump image tag in git)
+    needs: [resolve-env, build]
     runs-on: ubuntu-latest
-    needs: build
-    environment: production
-
     steps:
       - uses: actions/checkout@v4
-
-      - name: Deploy via SSH
-        uses: appleboy/ssh-action@v1
         with:
-          host: ${{ secrets.DEPLOY_HOST }}
-          username: ${{ secrets.DEPLOY_USER }}
-          key: ${{ secrets.DEPLOY_SSH_KEY }}
-          script: |
-            set -e
-            cd /root/github/stronghold
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
 
-            # Pull latest code
-            git pull origin main
-
-            # Pull new image
-            docker pull ghcr.io/agent-stronghold/stronghold:latest
-
-            # Blue-green swap
-            # 1. Start green (new version) alongside blue (current)
-            docker compose -f docker-compose.yml -p stronghold-green up -d --build stronghold
-            sleep 10
-
-            # 2. Health check green
-            for i in $(seq 1 12); do
-              if curl -sf http://localhost:8101/health > /dev/null 2>&1; then
-                echo "Green is healthy"
-                break
-              fi
-              if [ "$i" -eq 12 ]; then
-                echo "Green failed health check — rolling back"
-                docker compose -p stronghold-green down
-                exit 1
-              fi
-              sleep 5
-            done
-
-            # 3. Swap: stop blue, promote green
-            docker compose down stronghold
-            docker compose up -d stronghold
-            docker compose -p stronghold-green down 2>/dev/null || true
-
-            # 4. Verify
-            sleep 5
-            curl -sf http://localhost:8100/health || exit 1
-            echo "Deploy complete: ${{ needs.build.outputs.version }}"
-
-      - name: Create release tag
-        if: success()
+      - name: Bump image.tag in values file
+        env:
+          TAG_FILE: ${{ needs.resolve-env.outputs.tag_file }}
+          NEW_TAG: ${{ needs.build.outputs.image_tag }}
         run: |
-          git tag "v${{ needs.build.outputs.version }}"
-          git push origin "v${{ needs.build.outputs.version }}"
+          set -eu
+          python3 - <<'PY'
+          import os, re, sys
+          path = os.environ["TAG_FILE"]
+          new_tag = os.environ["NEW_TAG"]
+          with open(path) as f:
+              content = f.read()
+          new_content = re.sub(
+              r'(\n\s*tag:\s*).+',
+              lambda m: f'{m.group(1)}"{new_tag}"',
+              content,
+          )
+          if new_content == content:
+              print(f"ERROR: no `tag:` lines updated in {path}", file=sys.stderr)
+              sys.exit(1)
+          with open(path, "w") as f:
+              f.write(new_content)
+          PY
+          git diff --stat "$TAG_FILE" || true
+
+      - name: Identify bot
+        run: |
+          git config user.name  "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Commit + push (integration)
+        if: needs.resolve-env.outputs.env == 'integration'
+        env:
+          TAG_FILE: ${{ needs.resolve-env.outputs.tag_file }}
+          NEW_TAG: ${{ needs.build.outputs.image_tag }}
+        run: |
+          set -eu
+          git add "$TAG_FILE"
+          if git diff --cached --quiet; then
+            echo "No-op: tag already at ${NEW_TAG}."
+            exit 0
+          fi
+          git commit -m "deploy(integration): bump image to ${NEW_TAG} [skip ci]"
+          git push origin HEAD:integration
+
+      - name: Open PR (production)
+        if: needs.resolve-env.outputs.env == 'production'
+        env:
+          TAG_FILE: ${{ needs.resolve-env.outputs.tag_file }}
+          NEW_TAG: ${{ needs.build.outputs.image_tag }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -eu
+          if git diff --quiet -- "$TAG_FILE"; then
+            echo "No-op: tag already at ${NEW_TAG}."
+            exit 0
+          fi
+          BRANCH="deploy/production-${NEW_TAG}"
+          git checkout -b "$BRANCH"
+          git add "$TAG_FILE"
+          git commit -m "deploy(production): bump image to ${NEW_TAG}"
+          git push -u origin "$BRANCH"
+          gh pr create \
+            --base main \
+            --head "$BRANCH" \
+            --title "deploy(production): bump image to ${NEW_TAG}" \
+            --body "Auto-generated by deploy.yml.
+
+          **Approve + merge** to stage the production image bump.
+          After merge, run \`argocd app sync stronghold-production\`
+          (or use the Argo CD UI) to apply.
+
+          Image: \`${{ env.IMAGE }}:${NEW_TAG}\`"
+
+      - name: Summary
+        env:
+          ENV: ${{ needs.resolve-env.outputs.env }}
+          NEW_TAG: ${{ needs.build.outputs.image_tag }}
+        run: |
+          {
+            echo "### Deploy: ${ENV}"
+            echo ""
+            echo "Image: \`${{ env.IMAGE }}:${NEW_TAG}\`"
+            echo ""
+            if [ "${ENV}" = "production" ]; then
+              echo "Production tag bump opened as a PR. Merge + sync via Argo CD:"
+              echo "  https://10.10.42.31:30443/applications/argocd/stronghold-production"
+            else
+              echo "Argo CD will auto-sync stronghold-integration within ~1 min."
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/deploy/argocd/README.md
+++ b/deploy/argocd/README.md
@@ -1,0 +1,131 @@
+# Stronghold GitOps via Argo CD
+
+This directory wires Stronghold's two deploy environments to Argo CD.
+Argo CD watches this repo and reconciles the cluster state to match.
+
+## Layout
+
+```
+deploy/argocd/
+├── README.md                                  (this file)
+└── applications/
+    ├── stronghold-integration.yaml            Argo Application: integration env
+    └── stronghold-production.yaml             Argo Application: production env
+
+deploy/helm/stronghold/
+├── values.yaml                                Chart defaults
+├── values-vanilla-k8s.yaml                    Disables OpenShift-specific resources
+├── values-integration.yaml                    Integration overlay (small footprint)
+├── values-production.yaml                     Production overlay (k3s today, AKS later)
+├── values-integration-image.yaml              Auto-bumped by CI on push to integration
+└── values-production-image.yaml               Auto-bumped by CI on push to main
+```
+
+## Environments
+
+| Application                | Tracks branch | Namespace                | Sync policy |
+|---------------------------|---------------|--------------------------|------------|
+| `stronghold-integration`  | `integration` | `stronghold-integration` | **Auto** (prune + selfHeal) |
+| `stronghold-production`   | `main`        | `stronghold-platform`    | **Manual** (approval gate) |
+
+Both currently target the k3s cluster at `10.10.42.31`. Production migrates
+to Azure AKS once blue-green is proven on k3s — at that point only
+`destination.server` and the values overlay change; the workflow stays the same.
+
+## Deploy flow
+
+```
+push to integration                 push to main
+         │                                │
+         ▼                                ▼
+.github/workflows/deploy.yml runs:
+  1. Build image, push to ghcr.io/agent-stronghold/stronghold:<env>-<sha>
+  2. Bump image.tag in the matching values-{env}-image.yaml
+  3. integration: bot commits directly to integration with [skip ci]
+     production:  bot opens PR against main; operator approves + merges
+
+         ↓                                ↓
+Argo CD detects the commit:
+  integration → auto-syncs immediately (~1 min)
+  production  → waits for manual sync (operator runs `argocd app sync` or clicks UI)
+```
+
+## Bootstrap
+
+Apply both Applications once against the cluster:
+
+```bash
+export KUBECONFIG=/root/okd-install/k3s-kubeconfig
+
+kubectl apply -n argocd -f deploy/argocd/applications/stronghold-integration.yaml
+kubectl apply -n argocd -f deploy/argocd/applications/stronghold-production.yaml
+
+kubectl get applications -n argocd
+```
+
+## Verifying a deploy
+
+Integration (after every merge):
+```bash
+kubectl get application stronghold-integration -n argocd \
+  -o jsonpath='{.status.sync.status}{"\n"}{.status.health.status}{"\n"}'
+# Expect: Synced / Healthy
+
+kubectl get pods -n stronghold-integration
+```
+
+Production (after merging a `deploy(production):` PR):
+```bash
+# Stage 1: confirm Argo sees the new revision
+argocd app get stronghold-production --refresh
+# OutOfSync → expected; manual approval pending.
+
+# Stage 2: approve + sync
+argocd app sync stronghold-production
+argocd app wait stronghold-production --health --timeout 300
+
+kubectl get pods -n stronghold-platform
+```
+
+## Rollback
+
+**Integration** — revert the offending bump commit on `integration`:
+```bash
+git revert <bump-sha>
+git push origin integration
+# Argo auto-syncs back within ~1 min.
+```
+
+**Production** — revert the bump commit on `main`, merge, then sync:
+```bash
+git revert <bump-sha>            # via PR or direct push if hotfix
+git push origin main
+argocd app sync stronghold-production
+```
+
+**Emergency (production)** — if you need to roll back faster than git:
+```bash
+helm history stronghold -n stronghold-platform
+helm rollback stronghold <revision> -n stronghold-platform
+# Then immediately fix git so Argo doesn't re-apply the bad version:
+argocd app set stronghold-production --revision <known-good-sha>
+```
+
+## Migration to Azure AKS (future)
+
+When the AKS cluster is ready and registered with Argo CD
+(`argocd cluster add <ctx>`), edit `applications/stronghold-production.yaml`:
+
+- Change `destination.server` to the AKS cluster URL.
+- Append `values-aks.yaml` to `helm.valueFiles` (after `values-production.yaml`).
+
+That's it. The workflow, bot PR pattern, and rollback procedure are unchanged.
+
+## Why bot opens a PR for production (not a direct push)
+
+The `main` branch enforces signed commits via branch protection. The
+`github-actions[bot]` user can't sign commits. Rather than weaken the
+signing requirement, the workflow opens a PR — operators review and
+merge with their own signed commit, which preserves the audit chain.
+
+Integration does not enforce signed commits, so the bot pushes directly.

--- a/deploy/argocd/applications/stronghold-integration.yaml
+++ b/deploy/argocd/applications/stronghold-integration.yaml
@@ -1,0 +1,37 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: stronghold-integration
+  namespace: argocd
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/Agent-StrongHold/stronghold.git
+    targetRevision: integration
+    path: deploy/helm/stronghold
+    helm:
+      releaseName: stronghold
+      valueFiles:
+        - values.yaml
+        - values-vanilla-k8s.yaml
+        - values-integration.yaml
+        - values-integration-image.yaml
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: stronghold-integration
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+      - ServerSideApply=true
+      - PruneLast=true
+    retry:
+      limit: 5
+      backoff:
+        duration: 30s
+        factor: 2
+        maxDuration: 5m

--- a/deploy/argocd/applications/stronghold-production.yaml
+++ b/deploy/argocd/applications/stronghold-production.yaml
@@ -1,0 +1,38 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: stronghold-production
+  namespace: argocd
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/Agent-StrongHold/stronghold.git
+    targetRevision: main
+    path: deploy/helm/stronghold
+    helm:
+      releaseName: stronghold
+      valueFiles:
+        - values.yaml
+        - values-vanilla-k8s.yaml
+        - values-production.yaml
+        - values-production-image.yaml
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: stronghold-platform
+  syncPolicy:
+    # MANUAL sync — production deploys require human approval. Bumping
+    # the image tag in main only stages the change; Argo will not apply
+    # until an operator runs `argocd app sync stronghold-production`
+    # or clicks Sync in the UI.
+    syncOptions:
+      - CreateNamespace=false   # namespace already exists; do not risk wiping
+      - ServerSideApply=true
+      - PruneLast=true
+    retry:
+      limit: 3
+      backoff:
+        duration: 30s
+        factor: 2
+        maxDuration: 5m

--- a/deploy/helm/stronghold/values-integration-image.yaml
+++ b/deploy/helm/stronghold/values-integration-image.yaml
@@ -1,0 +1,14 @@
+# Auto-managed by .github/workflows/deploy.yml — DO NOT HAND-EDIT.
+#
+# Bumped on every push to the `integration` branch after the image is
+# built and pushed to GHCR. The bot commits this file directly to
+# integration with `[skip ci]` so the change does not retrigger the
+# workflow. Argo CD's stronghold-integration Application detects the
+# commit and auto-syncs.
+#
+# To roll back: `git revert` the offending bump commit on integration.
+image:
+  tag: integration-init
+strongholdApi:
+  image:
+    tag: integration-init

--- a/deploy/helm/stronghold/values-integration.yaml
+++ b/deploy/helm/stronghold/values-integration.yaml
@@ -1,0 +1,52 @@
+# values-integration.yaml
+#
+# Integration-environment overlay for the k3s cluster (10.10.42.31).
+# Composed on top of values.yaml + values-vanilla-k8s.yaml.
+# Image tag is supplied separately by values-integration-image.yaml,
+# which CI (.github/workflows/deploy.yml) bumps on every push to integration.
+#
+# Footprint is intentionally smaller than production (single replica,
+# autoscaling off) so multiple integration revisions can coexist on the
+# same cluster without resource contention.
+
+openshift:
+  enabled: false
+
+namespace:
+  create: false
+  name: stronghold-integration
+
+priorityClasses:
+  create: true
+
+rbac:
+  create: true
+
+extraNamespaces:
+  create: true
+
+networkPolicy:
+  enabled: true
+
+ingressRoutes:
+  enabled: false
+
+# Dev-mode shared-PAT for the github-mcp template is acceptable in the
+# integration env (single-tenant). Production sets devMode: false.
+mcp:
+  github:
+    devMode: true
+
+image:
+  repository: ghcr.io/agent-stronghold/stronghold
+  pullPolicy: Always
+
+strongholdApi:
+  replicas: 1
+  image:
+    registry: ghcr.io
+    repository: agent-stronghold/stronghold
+    pullPolicy: Always
+
+autoscaling:
+  enabled: false

--- a/deploy/helm/stronghold/values-production-image.yaml
+++ b/deploy/helm/stronghold/values-production-image.yaml
@@ -1,0 +1,17 @@
+# Auto-managed by .github/workflows/deploy.yml — DO NOT HAND-EDIT.
+#
+# On every push to `main`, CI builds and pushes a new image, then opens
+# a PR titled `deploy(production): bump image to <tag>` against main.
+# Merging that PR bumps this file; Argo CD's stronghold-production
+# Application then detects the change but DOES NOT auto-sync —
+# production deploys require manual sync (approval gate) via:
+#
+#   argocd app sync stronghold-production
+#   # or the Argo CD UI: https://10.10.42.31:30443/applications/argocd/stronghold-production
+#
+# To roll back: `git revert` the bump commit on main, merge, then sync.
+image:
+  tag: production-init
+strongholdApi:
+  image:
+    tag: production-init

--- a/deploy/helm/stronghold/values-production.yaml
+++ b/deploy/helm/stronghold/values-production.yaml
@@ -1,0 +1,55 @@
+# values-production.yaml
+#
+# Production-environment overlay.
+#
+# CURRENT TARGET: k3s cluster (10.10.42.31), namespace stronghold-platform.
+# FUTURE TARGET: Azure AKS — compose values-aks.yaml on top once the
+#                blue-green pattern is proven on k3s (ADR-K8S-007).
+#
+# Composed on top of values.yaml + values-vanilla-k8s.yaml.
+# Image tag is supplied separately by values-production-image.yaml,
+# which CI (.github/workflows/deploy.yml) bumps via PR on every push to main.
+
+openshift:
+  enabled: false
+
+namespace:
+  create: false
+  name: stronghold-platform
+
+priorityClasses:
+  create: true
+
+rbac:
+  create: true
+
+extraNamespaces:
+  create: true
+
+networkPolicy:
+  enabled: true
+
+ingressRoutes:
+  enabled: false
+
+# Production uses per-tenant credentials, not the shared-PAT dev mode.
+mcp:
+  github:
+    devMode: false
+
+image:
+  repository: ghcr.io/agent-stronghold/stronghold
+  pullPolicy: IfNotPresent
+
+strongholdApi:
+  replicas: 2
+  image:
+    registry: ghcr.io
+    repository: agent-stronghold/stronghold
+    pullPolicy: IfNotPresent
+
+podDisruptionBudgets:
+  enabled: true
+
+autoscaling:
+  enabled: false

--- a/deploy/helm/stronghold/values.yaml
+++ b/deploy/helm/stronghold/values.yaml
@@ -22,6 +22,10 @@ ingress:
           pathType: Prefix
   tls: []
 
+# Vault sidecar (disabled by default; enabled per-environment for prod overlays)
+vault:
+  enabled: false
+
 # PostgreSQL (bundled or external)
 postgresql:
   enabled: true


### PR DESCRIPTION
## Summary
- Replaces the SSH/docker-compose blue-green flow (which never matched the production target) with a GitOps loop: build → push to GHCR → bump image-tag file in git → Argo CD reconciles.
- Adds two Argo CD `Application` resources: `stronghold-integration` (auto-sync, prune, selfHeal) and `stronghold-production` (manual sync, approval gate).
- Adds per-env helm value overlays (`values-integration.yaml`, `values-production.yaml`) plus auto-managed `values-{env}-image.yaml` files that CI bumps on every push.
- Both envs target the k3s cluster (10.10.42.31). Production migrates to Azure AKS later by changing `destination.server` + appending `values-aks.yaml`; the workflow stays identical.
- Fixes a chart-render regression: `vault.enabled` had no default, causing `helm template` to fail on `vault-deployment.yaml`. Added `vault: { enabled: false }` to `values.yaml`.

## Why bot opens a PR for production rather than direct push
`main` enforces signed commits. `github-actions[bot]` can't sign. The bot pushes a branch + opens \`deploy(production): bump image to <tag>\`; an operator merges with their own signed commit, then runs \`argocd app sync stronghold-production\`. Audit chain stays intact.

## Test plan
- [x] `helm template` renders cleanly for both overlays (integration: 3345 lines, production: 3228 lines)
- [x] `kubectl apply --dry-run=client` passes for both Argo Applications
- [x] tag-bump regex correctly updates both `image.tag` and `strongholdApi.image.tag` (verified locally on both files)
- [ ] After merge: bootstrap by applying both Applications against the cluster (one-time, see `deploy/argocd/README.md`)
- [ ] After merge: first push to integration triggers full loop, Argo auto-syncs `stronghold-integration` namespace
- [ ] First push to main opens a `deploy(production)` PR; merge + manual sync verifies production half