### PR TITLE
fix(agents): add missing agent_card.json for herald + master-at-arms

### DIFF
--- a/agents/herald/agent_card.json
+++ b/agents/herald/agent_card.json
@@ -1,0 +1,22 @@
+{
+  "id": "herald",
+  "name": "herald",
+  "description": "Receives raw ideas and feature requests, clarifies them, researches the codebase for existing work, and drafts structured epics for the Quartermaster to decompose into actionable issues.",
+  "version": "1.0.0",
+  "protocolVersion": "2024-11-05",
+  "capabilities": {
+    "reasoning_strategy": "react",
+    "tools": ["github", "file_ops", "shell"],
+    "skills": [],
+    "max_tool_rounds": 10
+  },
+  "trust_tier": "t1",
+  "priority_tier": "P4",
+  "model": "auto",
+  "model_fallbacks": [
+    "google-gemini-3.1-pro",
+    "mistral-large",
+    "deepseek-deepseek"
+  ],
+  "active": true
+}

--- a/agents/master-at-arms/agent_card.json
+++ b/agents/master-at-arms/agent_card.json
@@ -1,0 +1,22 @@
+{
+  "id": "master-at-arms",
+  "name": "master-at-arms",
+  "description": "Daily retrospective learning agent that reviews all pipeline runs, extracts success/failure patterns, and stores learnings that improve all agents over time.",
+  "version": "1.0.0",
+  "protocolVersion": "2024-11-05",
+  "capabilities": {
+    "reasoning_strategy": "react",
+    "tools": ["github", "file_ops"],
+    "skills": [],
+    "max_tool_rounds": 5
+  },
+  "trust_tier": "t1",
+  "priority_tier": "P4",
+  "model": "auto",
+  "model_fallbacks": [
+    "google-gemini-3.1-pro",
+    "mistral-large",
+    "google-gemini-3-flash"
+  ],
+  "active": true
+}


### PR DESCRIPTION
## Summary
Herald + Master-at-Arms were added in 1251a50 with `agent.yaml` + `SOUL.md` but no `agent_card.json`. This has caused `tests/agents/test_agent_cards.py::test_all_agents_have_cards` to fail on every integration push since 2026-04-13.

Cards derived directly from each agent's `agent.yaml` (strategy, tools, trust_tier, priority_tier, model, fallbacks). Schema follows the existing arbiter card.

## Test plan
- [x] All 9 tests in `tests/agents/test_agent_cards.py` pass locally
- [ ] CI green on integration after merge — unblocks #1109 (deploy GitOps PR)