### PR TITLE
docs(cfm): Conductor Feature Migration design pass (CFM-1..CFM-5)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -845,3 +845,235 @@ stronghold/
 ## 14. Threat Model Baseline
 
 See `/root/conductor_security.md` for the full 50-concern threat model of the current Conductor stack. Every concern has a corresponding mitigation in this architecture. The Stronghold security model (Warden + Sentinel + Gate + trust tiers + config-driven RBAC + per-agent memory scoping + K8s secrets) is designed to close every identified gap.
+
+---
+
+## 15. Conductor Feature Migration (CFM-1..CFM-5)
+
+**Added:** 2026-04-18. **Targets:** v1.4 through v1.7 (see `ROADMAP.md`). **Backlog:** `BACKLOG.md` § "Conductor Feature Migration (2026-04-18)".
+
+Five subsystems that port capabilities from the still-running conductor-router with a Stronghold-native shape. They compose: CFM-1 is the foundation (review queue), CFM-2 defines the signal that drives the queue's priorities and gates dispatch (trust floor), CFM-3 provides the declarative-spec artifact whose mutations go through CFM-1, CFM-4 is another artifact kind that flows through CFM-1, and CFM-5 makes all of this observable. Build in order.
+
+### 15.1 CFM-1: Review Queue Engine
+
+**Core insight:** Every forged skill, promoted variant, tier crossing, APM edit, and session-trust descent is the same shape — a decision waiting on a reviewer. One queue with typed items beats N parallel queues because reviewers move through a single inbox, priority policy lives in one place, and the trust signal that drives priority is the same signal everywhere.
+
+The review engine lives **beside** the `OrchestratorEngine`, not inside it. Reviews are human-in-the-loop-often; their latency model (hours/days), failure modes (reviewer unavailability, not exceptions), and scaling needs (independent of request volume) differ fundamentally from execution `WorkItem`s. Mixing them makes priority semantics confusing and starvation math awful.
+
+```
+┌──────────────────────────────────────────────────────────────────┐
+│                           Reactor (1000Hz)                        │
+│  forge.skill_created · variant.hit_threshold · apm.change_submitted │
+│  session.stf_descent_pending · learning.ready_for_promote          │
+└──────────────────────────────────────────────────────────────────┘
+             │ emits                              │ gates
+             ▼                                    ▼
+┌───────────────────────────┐      ┌───────────────────────────┐
+│   Review Queue Engine     │      │   Orchestrator Engine      │
+│   (src/stronghold/review) │◀────▶│   (priority WorkItems)     │
+│                           │ share│                           │
+│   ReviewItem + priority   │types/│   WorkItem + priority     │
+│   reducer + classes       │prio  │   reducer                 │
+└─────────┬─────────────────┘      └───────────────────────────┘
+          │ consumes                           ▲
+          ▼                                    │
+┌───────────────┬───────────────┐              │
+│ Auditor agent │ Human inbox   │              │
+│ (ai_allowed,  │ (human_only + │──────────────┘
+│ ai_only)      │ override any) │   approvals execute
+└───────────────┴───────────────┘
+```
+
+**Types.** `ReviewItem { id, kind, subject_ref, origin_stf, origin_user_tier, stakes_tier, submitted_at, reviewer_class, state }`. Kinds: `forge_skill`, `forge_node_kind`, `recipe_variant_promote`, `apm_change`, `user_tier_promote`, `stf_ratchet_decision`, `learning_promote`, `agent_import`.
+
+**Priority calculator.** `f(stakes_impact, −origin_stf, plan_tier_sla, age_bonus, blast_radius, backlog_pressure)` — the queue self-sorts toward "aged + dangerous + high-stakes." Low-trust origins float to the top; high-plan users get SLA priority; domain backlog pressure prevents any single kind from starving.
+
+**Reviewer classes.**
+| Class | Who can close | Examples |
+|---|---|---|
+| `human_only` | Admin with appropriate tier | First T0→T0+ promotion; APM change declaring new tool access; skill forged in Skull session |
+| `ai_allowed` | Auditor agent OR human | Recipe variant promotion after N wins; learning promotion after N reinforcements |
+| `ai_only` | Auditor only, no human needed | Metrics-driven promotions with hard thresholds — every AI decision still audited and overridable |
+
+The Auditor is the AI reviewer in the existing Herald→QM→Archie→Mason→**Auditor**→Gatekeeper→Master-at-Arms pipeline plan.
+
+**In-session HITL.** STF-ratchet decisions reuse the engine primitives but render inline in the chat UI (synchronous — blocks the turn), because the user is actively present and the session is blocking. Three decision surfaces: (a) pending input would lower STF, (b) action blocked by current STF, (c) passive trust indicator always visible.
+
+**Cross-subsystem boundary.** Review and orchestration share only `types/priority.py` (`PrioritySignal`) and `types/review.py` (`ReviewRequest`). No imports across subsystems.
+
+### 15.2 CFM-2: Session Trust Floor (STF) + Trust Ledger
+
+**Core insight:** Trust is not a fixed property of a user, agent, or tool — it's a *session-scoped minimum* that every contributor can only lower. Once a session is compromised, no amount of subsequent clean activity restores it within that session. This closes the most common prompt-injection path: user pastes innocuous content → tool fetches untrusted doc → doc contains injection → subsequent high-privilege action executes. A monotonically non-increasing STF makes the descent visible and gates the privilege.
+
+**Reducer.**
+```
+STF(t) = min(
+    STF(t-1),                      # never rises
+    agent.tier,
+    recipe.tier,
+    flow_node.kind.tier,
+    tool.tier,
+    input_source.tier,             # user paste / tool output / retrieved doc / web
+    user.trust_score_tier,         # from ledger
+    warden.safety_confidence_tier, # from verdict confidence
+    ... future contributors
+)
+```
+
+Every contributor emits `TrustSignal { source, tier, confidence, rationale, trace_ref }` on entry. Unknown sources default to `☠️ Skull`. The session reducer takes `min()`. That's the full arithmetic.
+
+**Monotonicity is a hard invariant.**
+- Redaction is cosmetic — removing the poisoned message does not restore STF
+- Compaction does not heal — summaries inherit the source's floor (otherwise compaction becomes a laundering vector, a well-known prompt-injection exploit)
+- Forks and sub-flows inherit the parent STF
+- Only a new session (new trace root) resets — and even then `user.trust_score` persists cross-session
+
+**Read-down, not write-down.** A lowered STF blocks *new* privileged actions, not *reading* already-in-context data. Stricter read-blocking surprises users and adds little real safety (the data's already in the context window; the cognitive model can't un-see it).
+
+**Ledger arithmetic.** User trust points accrue via:
+```
+Δ trust_points = plan_multiplier × copper_value(action) × session_T_score
+```
+| Plan | Multiplier |
+|---|---:|
+| Free | 0 |
+| Paid | 1 |
+| Team plan | 2 |
+| Team admin | 5 |
+| Org admin | 10 |
+| Super admin | 100 |
+
+| STF at action time | `session_T_score` | Admin override |
+|---|---:|---|
+| T1 | +2 | — |
+| T2 | +1 | — |
+| T3 | 0 | — |
+| ☠️ Skull | −10 | clamps to 0 for team_admin and above |
+
+Copper is the canonical economic unit — `tokens_used × token_value` — with exchange rates from other currencies via `trust/exchange.py`. Free users have multiplier 0 by design (can't earn, can't sabotage, can't farm). Admins clamp to 0 at Skull to preserve legitimate security testing.
+
+**Tier thresholds.** Exponential, origin-centered slightly positive into T2:
+- T2 narrow band (fast honeymoon exit for new paid users)
+- T1 and T3 wide (single actions don't cascade; sustained behavior moves tiers)
+- T0 and Skull unbounded (gated by badge tiers and soft-barriers respectively)
+
+Thresholds hot-reloadable via `trust/thresholds.yaml`.
+
+**Dispatch gating.** When `STF < recipe.required_tier`, dispatch emits an `stf_insufficient` event (not an exception) and the review engine renders a HITL decision. The user can accept-and-ratchet (explicit consent, logged), reject the blocking input (preserves floor), or quarantine the session.
+
+**Package shape.**
+```
+src/stronghold/trust/
+├── reducer.py         # STF min-reduction over contributors
+├── signals.py         # TrustSignal type + source contracts
+├── ledger.py          # trust_points accrual, ties into copper ledger
+├── thresholds.py      # points → tier contribution; YAML-backed
+├── policy.py          # plan_multiplier, admin predicate, skull clamp
+└── exchange.py        # copper ↔ other currencies
+```
+
+### 15.3 CFM-3: Recipe + Variant Evolution
+
+**Core insight:** Stronghold's tournament-evolution feature (`COMPARISON.md §2`) needs a mechanism that decides *which agent variant wins a route*. The mechanism is Thompson sampling over a Beta posterior per `(recipe_id, variant_id, intent)`. But the artifact being sampled over should be a **pure declarative spec** — executor-agnostic, YAML-serializable, lintable before instantiation. This forces spec/engine separation and makes a single envelope work for both simple strategy agents and graph/workflow agents.
+
+**Single envelope, one pattern.**
+
+```python
+class RecipeSpec:                    # pure data, no Python callables
+    id: str
+    agent_ref: str
+    model_class: str                 # symbolic — router resolves at dispatch
+    tools: list[ToolRef]             # names only, no handlers
+    memory: MemoryPolicy
+    apm_ref: str | None
+    required_tier: TrustTier
+    flow: FlowSpec                   # always a graph
+
+class FlowSpec:
+    entry: NodeRef
+    state: StateSchema
+    nodes: list[NodeSpec]
+    edges: list[EdgeSpec]
+
+class NodeSpec:
+    id: str
+    kind: str                        # "reason" | "tool" | "branch" | "recipe" | "collect" | third-party
+    params: dict                     # schema-validated per-kind
+    # no executor, no import paths
+```
+
+A simple strategy agent is a degenerate graph: one `reason` node, no edges. A graph/workflow agent uses multiple nodes and conditional edges. Same envelope, same validator, same variants, same promotion logic. Nesting falls out naturally — a `recipe` node references another RecipeSpec by id, which is how Archie→Mason-style pipelines compose.
+
+**Spec vs engine.**
+- `src/stronghold/evaluation/` owns specs: `recipes.py` (CRUD), `thompson.py` (sampling), `outcomes.py`, `promotion.py`, `validator.py` (reachability, schema check, no-orphan edges, no-undeclared-state-refs)
+- `src/stronghold/execution/` owns interpretation: `graph_runner.py`, `node_handlers.py`, `state.py`
+- They share only `types/recipe.py`. Multiple executors can interpret the same spec — today's tool-loop, tomorrow's streaming executor, a replay engine for RCA.
+
+**Open node-kind registry with Skull default.** `NodeSpec.kind` is open, not a closed enum. Built-in kinds (`reason`, `tool`, `branch`, `recipe`, `collect`) are reserved and ship at T0. Third-party or Forge-created kinds register at runtime with a required `param_schema` and `declared_side_effects: list[str]`. **Unknown or unregistered kinds default to `☠️ Skull`** — declarative specs referencing them are harmless (a spec is just data), only execution is gated. This reuses the existing trust-tier machinery instead of inventing a parallel governance mechanism.
+
+Tier resolution: `effective_tier = min(recipe.tier, min(node.kind.tier for node in flow.nodes))`. `declared_side_effects` are enforced by Sentinel at run time — a kind declaring `["network"]` that tries to open a filesystem handle gets killed mid-span. Prevents tier-promotion by misdirection.
+
+**Thompson sampling.** For each dispatch, sample from `Beta(successes, failures)` per `(recipe_id, variant_id, intent)`. Higher posterior = more likely to be chosen. Outcomes update the posterior after each `WorkItem` completion. Variants accumulate evidence; Thompson's regret bounds keep exploration sensible.
+
+**Promotion via review queue.** `promote_variant` does not execute inline. A reactor trigger enqueues a `recipe_variant_promote` review when a variant hits policy thresholds (e.g., 20 wins + 5× advantage over incumbent). Review engine (CFM-1) handles the decision — often `ai_allowed` with human override.
+
+**GitAgent round-trip.** `RecipeSpec` serializes cleanly to YAML; `variants` live alongside the parent spec. Export and re-import round-trip — no Python objects, no import paths, no fragile pickle. This is what makes recipes shareable and makes the "GitAgent marketplace" in COMPARISON a real story.
+
+### 15.4 CFM-4: APM (Agent Personality Manifest)
+
+**Core insight:** Today `AgentIdentity` is config scaffolding — there's no human-readable, editable, round-trippable personality artifact. APM gives each agent a structured 7-section personality document that any reasoning strategy can render into a system-prompt fragment. This is what makes GitAgent export-import complete.
+
+**Schema.**
+```python
+class APM:
+    identity: str            # who the agent is
+    core_values: list[str]
+    communication_style: str
+    expertise: list[str]
+    boundaries: list[str]    # what it refuses or escalates
+    tools_and_methods: str
+    memory_anchors: list[str]  # canonical memories the agent always carries
+```
+
+Every agent resolves exactly one APM at load. If the agent declares none, a trust-tier baseline is merged in (T0 agents get the "canonical built-in" APM; T3 agents get the "community-provided default" APM, etc.).
+
+**Warden-gated writes.** `PUT /v1/stronghold/agents/{id}/apm` goes through Warden scan before persistence — an APM is an agent prompt, which is one of the highest-trust surfaces in the system. APM changes enqueue a `apm_change` review (human_only by default; policy may downgrade to ai_allowed after operational maturity).
+
+**Rendering is strategy-agnostic.** `prompts/apm_renderer.py` turns an APM into a system-prompt fragment. Every reasoning strategy (direct, react, plan_execute, delegate, custom) calls the renderer. No strategy-specific wiring means graph-based agents (CFM-3) and strategy-based agents share the same APM plumbing.
+
+**Audit.** Every change writes an audit entry: `actor`, `old_hash`, `new_hash`, `trace_id`. The hash-on-save is how Intel's evolution timeline (CFM-5) renders APM diffs.
+
+### 15.5 CFM-5: Intel Dashboard
+
+**Core insight:** The memory, learning, and mutation subsystems accumulate enormous amounts of signal, but today that signal is opaque — there's no place to see what's been happening. Intel exposes Langfuse traces, RCA post-mortems, an evolution timeline across all mutation sources, and the review queue inbox as a single four-tab dashboard. It turns Stronghold's existing stores from write-only into reviewable.
+
+**Four tabs.**
+
+| Tab | Source | What it shows |
+|---|---|---|
+| **Traces** | Langfuse | Paginated browse, filter by agent/intent/verdict, click into full span tree, inline scoring (1–5 + tags + free-text note) |
+| **RCA** | `rca.py` (auto-generated post-mortems from failed `WorkItem`s) | Root cause, failing tool, suggested learning, retrigger button |
+| **Evolution** | Aggregator across memory, recipes, skills, learnings, node kinds | Chronological `EvolutionEvent` stream with structural diffs (RecipeSpec, FlowSpec, node graph changes — not just prompt text) |
+| **Reviews** | Review Queue Engine (CFM-1) | Same inbox as `/dashboard/reviews.html`, reproduced here for workflow continuity |
+
+**Trace scoring is a trust event.** `POST /v1/stronghold/traces/{id}/score` dual-writes to Langfuse and to the outcomes store. The scorer earns trust points via the ledger (CFM-2) — thoughtful reviewing is positive behavior in the trust economy. Rubber-stamping flagged by pattern detection over the ledger.
+
+**RCA pipeline.** A `WorkItem` failure emits a reactor event → bounded-concurrency `rca.generate_rca` runs → structured post-mortem lands in the RCA store → at low weight, fed to `memory/learnings/extractor.py` as a candidate learning. Promotion requires reinforcement from other signals (recurring failure, operator confirmation, matching fail→succeed pattern). This turns failure into memory without turning every failure into a false positive.
+
+**Structural diff rendering.** Because RecipeSpec and FlowSpec are declarative YAML (CFM-3), the evolution tab can render *structural* diffs — "variant v2 added a `branch` node at position 3 and retargeted edge e4 to the new branch" — not just "the prompt changed." This is dramatically more useful for reviewing what the system is actually learning about itself.
+
+### 15.6 Reactor Enhancements (land with CFM-1)
+
+Two small additions to the existing reactor that complement the review queue:
+
+**Density-aware jitter.** Per-firing-bin trigger count drives jitter budget: `max_jitter_secs = min(ceiling, base + k × log2(density))`. A single trigger at 06:00 fires exactly on time (density=1 → log=0 → base jitter). A thousand triggers at 06:00 spread into a minutes-wide window. Prevents thundering-herd on shared firing times.
+
+**Coalescence / timer-slack.** A trigger can declare a tolerance window: `leeway: "±Nmin"`. The reactor looks for other triggers within overlapping leeway and snaps them to a shared firing time — batch DB writes, reuse warm caches, single Langfuse flush. Opposite direction from density jitter: spread when dense, gather when sparse.
+
+Combined: the reactor becomes a *load-aware scheduler*. Trigger authors declare how much they care (leeway); the reactor decides where inside that window to fire based on what else is happening. Extend `TriggerSpec` to accept `jitter` for `TIME` mode (currently only `INTERVAL`) and add the `leeway` field. Log bucketing decisions in the trigger audit so "why did this fire at 06:07?" is answerable.
+
+### 15.7 Build Order
+
+CFM-1 is the foundation — every promotion and review in CFM-2..CFM-5 consumes it. CFM-2 gates dispatch for the rest. CFM-3 and CFM-4 are independent and can land in parallel after CFM-2. CFM-5 lands last because its evolution timeline wants to include recipe and APM changes.
+
+Recommended sequence: **CFM-1 → CFM-2 → (CFM-3 || CFM-4) → CFM-5**. Reactor enhancements (§15.6) ride alongside CFM-1. Gamification, skull soft-barrier engine, and currency exchange UX (v1.7) follow CFM-2 once the trust economy has data to surface.

--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -1,7 +1,7 @@
 # Stronghold Backlog
 
-**Last Updated:** 2026-03-31
-**Status:** Pre-v1.0 — Phases 1-4 complete + 3 security audits + 1 live red team done
+**Last Updated:** 2026-04-18
+**Status:** Pre-v1.0 — Phases 1-4 complete + 3 security audits + 1 live red team done. CFM-1 through CFM-5 added 2026-04-18 (Conductor Feature Migration → v1.4–v1.7).
 
 ---
 
@@ -332,6 +332,81 @@ bypass all application-level security controls.
 - [ ] **Canvas compositor service** — layer assembly (background + characters + objects + text), position/scale/rotate per layer, PNG/WebP output.
 - [ ] **Wire Fabulist agent** — children's storybook creator, uses canvas tool, add `storybook` task type to classifier.
 
+### Conductor Feature Migration (2026-04-18)
+
+Five features worth porting from the running conductor-router with Stronghold-native shape. Listed in build-dependency order. Design rationale in the 2026-04-18 session log. Full architecture coverage in `ARCHITECTURE.md §15`.
+
+#### CFM-1: Review Queue Engine (foundation for the four below)
+- [ ] **`src/stronghold/review/`** — typed review items + priority calculator + reviewer classes + reactor-driven enqueue. Lives BESIDE the orchestrator (review work is often human-in-the-loop; latency, failure modes, and scaling differ fundamentally from execution `WorkItem`s)
+- [ ] `ReviewItem.kind` vocabulary: `forge_skill`, `forge_node_kind`, `recipe_variant_promote`, `apm_change`, `user_tier_promote`, `stf_ratchet_decision`, `learning_promote`, `agent_import`
+- [ ] Priority calculator = `f(stakes_impact, −origin_stf, plan_tier_sla, age_bonus, blast_radius, backlog_pressure)` — queue self-sorts toward "aged + dangerous + high-stakes"
+- [ ] Reviewer classes: `human_only` | `ai_allowed` | `ai_only` (Auditor agent owns the AI side — maps to the existing Herald→QM→Archie→Mason→Auditor→Gatekeeper→Master-at-Arms pipeline plan)
+- [ ] `/dashboard/reviews.html` inbox with filters by kind × state × `origin_stf`
+- [ ] Reactor enqueue hooks: `forge.skill_created`, `variant.hit_threshold`, `apm.change_submitted`, `session.stf_descent_pending`, `learning.ready_for_promote`
+- [ ] In-session STF-ratchet HITL reuses engine primitives; renders inline in chat UI (synchronous — blocks the turn)
+- [ ] SLA + escalation-on-stale + auto-expire + reassignment on reviewer unavailability
+- [ ] `ReviewOutcome { reviewer, decision, rationale, trace_ref }` is a first-class audit artifact
+- [ ] Shared with orchestrator only via `types/priority.py` (`PrioritySignal`) and `types/review.py` (`ReviewRequest`) — no cross-subsystem imports
+
+#### CFM-2: Session Trust Floor (STF) + Trust Ledger
+- [ ] **`src/stronghold/trust/`** — `reducer.py`, `signals.py`, `ledger.py`, `thresholds.py`, `policy.py`, `exchange.py`
+- [ ] `STF = min(agent.tier, recipe.tier, node.tier, tool.tier, input_source.tier, user.trust_score_tier, warden.safety_confidence_tier, …)` computed dynamically at runtime
+- [ ] Monotonically non-increasing per session — redaction, compaction, and summarization do NOT heal (otherwise compaction becomes a laundering vector)
+- [ ] Forks and sub-flows inherit parent STF; new session required to reset
+- [ ] Contributors emit `TrustSignal { source, tier, confidence, rationale, trace_ref }`; unknown sources default to `☠️ Skull`
+- [ ] User trust ledger: `Δ = plan_multiplier × copper_value × session_T_score`
+- [ ] `plan_multiplier`: free=0, paid=1, team_plan=2, team_admin=5, org_admin=10, super_admin=100
+- [ ] `session_T_score`: T1=+2, T2=+1, T3=0, ☠️Skull=−10 (clamps to 0 for team_admin and above — preserves security-testing legitimacy)
+- [ ] Exponential tier thresholds in `thresholds.yaml` (hot-reloadable), origin centered slightly positive into T2 (narrow T2 band, wide T1/T3, unbounded T0/Skull)
+- [ ] Copper = `tokens_used × token_value`; other currencies convert via `trust/exchange.py`
+- [ ] Warden verdict gains `confidence ∈ [0,1]` — low confidence drags input's effective tier down
+- [ ] Recipe dispatch emits `stf_insufficient` event (not exception) when `STF < recipe.required_tier` → review engine renders HITL decision
+- [ ] HITL surface: (a) pending input would lower STF, (b) action blocked by current STF, (c) passive trust indicator always visible with descent timeline
+- [ ] Read-down semantics only — lowered STF blocks NEW privileged actions, does not block reading poisoned context
+
+#### CFM-3: Recipe + Variant Evolution Engine
+- [ ] **`src/stronghold/types/recipe.py`** — `RecipeSpec`, `FlowSpec`, `NodeSpec`, `EdgeSpec`, `StateSchema` — pure data, YAML-serializable, no Python callables
+- [ ] **`src/stronghold/evaluation/`** — `recipes.py` (CRUD), `thompson.py` (Beta posteriors per `(recipe_id, variant_id, intent)`), `outcomes.py`, `promotion.py`, `validator.py` (reachability, schema check, no-orphan edges, no-undeclared-state-refs)
+- [ ] **`src/stronghold/execution/`** — `graph_runner.py`, `node_handlers.py`, `state.py` — interprets `FlowSpec`. Simple agents are degenerate graphs (one node, no edges); graph/workflow agents share the same envelope
+- [ ] Single envelope for all agent shapes — strategy-based AND graph-based bind through one `RecipeSpec`; `FlowSpec` expresses both
+- [ ] `NodeSpec.kind` is an OPEN registry. Built-in kinds (`reason`, `tool`, `branch`, `recipe`, `collect`) are reserved and ship at T0
+- [ ] Unknown kinds default to `☠️ Skull` tier — declarative specs are harmless, only execution is gated (trust tier system already handles the governance concern)
+- [ ] Per-kind `param_schema` required at registration; `declared_side_effects: list[str]` enforced by Sentinel at runtime (kind claiming `["network"]` cannot open filesystem)
+- [ ] `effective_tier = min(recipe.tier, min(node.kind.tier for node in flow.nodes))`
+- [ ] Variant promotion → review queue (not immediate) with policy-driven auto-approve thresholds
+- [ ] `RecipeSpec` round-trips through GitAgent export/import as YAML
+- [ ] Variants carry spec diffs, not runtime objects; Thompson sampling operates on spec hashes
+- [ ] `migrations/00XX_recipes.sql` — `recipes`, `variants`, `variant_outcomes`, `node_kinds` tables
+
+#### CFM-4: APM (Agent Personality Manifest)
+- [ ] **`src/stronghold/types/apm.py`** — Pydantic model with seven sections: `identity`, `core_values`, `communication_style`, `expertise`, `boundaries`, `tools_and_methods`, `memory_anchors`
+- [ ] **`src/stronghold/agents/apm_store.py`** — persistence, trust-tier default resolution, hash-on-save
+- [ ] **`src/stronghold/prompts/apm_renderer.py`** — APM → system prompt fragment, strategy-agnostic
+- [ ] Every agent has exactly one APM (merged from trust-tier baseline if none declared)
+- [ ] `GET/PUT /v1/stronghold/agents/{id}/apm` — PUT gated by Warden scan (APM edits are a high-trust boundary — an APM is an agent prompt)
+- [ ] APM changes enqueue review (`human_only` by default; downgrade to `ai_allowed` via policy later)
+- [ ] APM included in GitAgent export bundle as `apm.yaml`; re-hydrates on import
+- [ ] Audit entry per change: `actor`, `old_hash`, `new_hash`, `trace_id`
+- [ ] `migrations/00XX_apm.sql` — `apm` table (agent_id PK, yaml, hash, updated_at)
+- [ ] `/dashboard/agents/{id}/apm` — edit UI with diff preview and "request review" flow
+
+#### CFM-5: Intel Dashboard (Traces + RCA + Evolution + Reviews)
+- [ ] **`src/stronghold/intel/`** — `traces.py` (Langfuse client + pagination + score writeback), `rca.py` (structured post-mortem generation), `evolution.py` (timeline aggregator)
+- [ ] **`src/stronghold/api/routes/intel.py`** and **`src/stronghold/dashboard/intel.html`** — four tabs: Traces, RCA, Evolution, Reviews
+- [ ] Traces tab: paginated browser with filters by agent/intent/verdict; click → span tree; inline score control (1–5 + tags + note)
+- [ ] `POST /v1/stronghold/traces/{id}/score` — dual-writes to Langfuse + outcomes store; reviewer trust accrual credits the scorer
+- [ ] RCA tab: auto-generated post-mortems from failed `WorkItem`s (root cause, failing tool, suggested learning)
+- [ ] `WorkItem` failure → reactor event → `rca.generate_rca` (async, bounded concurrency, retrigger endpoint for manual runs)
+- [ ] RCA candidates feed `memory/learnings/extractor.py` at low weight until reinforced
+- [ ] Evolution tab: chronological `EvolutionEvent` stream across memory, recipe, skill, learning, and node-kind mutations — renders STRUCTURAL diffs (not just prompt text) including `RecipeSpec` and `FlowSpec` changes
+- [ ] Reviews tab: mirrors the Review Queue Engine inbox with the same filters
+
+#### CFM Support — Reactor Enhancements (small, lands with CFM-1)
+- [ ] **Density-aware jitter** — per-firing-bin trigger count drives jitter budget via `max_jitter_secs = min(ceiling, base + k × log2(density))` — prevents thundering-herd on shared firing times (many 06:00 triggers spread into a minutes-wide window)
+- [ ] **Coalescence / timer slack** — `leeway: "±Nmin"` field lets reactor snap low-density triggers together for batch wake efficiency (opposite direction: spread when dense, gather when sparse)
+- [ ] Extend `TriggerSpec` to accept `jitter` for `TIME` mode (not just `INTERVAL`); add `leeway` field
+- [ ] Log bucketing decisions in trigger audit so "why did this fire at 06:07?" is answerable
+
 ### Documentation
 - [ ] Update SECURITY.md with L2.5/L3 descriptions
 - [ ] API documentation (OpenAPI spec review)
@@ -368,6 +443,33 @@ bypass all application-level security controls.
 - Tournament-based skill promotion
 - Learning promotion requires approval gate
 - Automated security re-scan via reactor triggers
+
+### v1.3: Multi-Tenant + Adaptive Tools
+- See `ROADMAP.md` — K8s namespace-per-tenant isolation, per-tenant prompt isolation, agent marketplace, adaptive tool composition
+
+### v1.4: Governance Queue + Trust Economy (see CFM-1, CFM-2)
+- Review Queue Engine (CFM-1) — typed review items, priority calculator, Auditor consumer, HITL dashboard
+- Session Trust Floor (CFM-2) — monotonic per-session floor, contributor signals, Warden confidence, HITL descent dialog
+- Trust Ledger — copper-value-denominated user trust points, plan-multiplier accrual, exponential tier thresholds, admin skull clamp
+- Density-aware jitter + coalescence / timer slack in Reactor
+
+### v1.5: Recipe + Variant Evolution + APM (see CFM-3, CFM-4)
+- Recipe engine — pure-spec `RecipeSpec`/`FlowSpec`/`NodeSpec` with open node-kind registry defaulting new kinds to Skull
+- Execution layer — `graph_runner` interprets `FlowSpec`; strategy agents are degenerate graphs
+- Thompson-sampled variant selection + promotion-via-review
+- APM — 7-section Agent Personality Manifest with Warden-gated writes, GitAgent round-trip, review-queued changes
+
+### v1.6: Intel Dashboard + Structured Evolution Timeline (see CFM-5)
+- Intel dashboard with Traces + RCA + Evolution + Reviews tabs
+- RCA pipeline — failed `WorkItem` → reactor event → structured post-mortem → candidate learning
+- Evolution timeline renders structural diffs (RecipeSpec + FlowSpec + node-kind tier changes)
+- Trace scoring dual-writes to Langfuse + outcomes store; scorer earns trust
+
+### v1.7: Trust Economy Surface + Currency Layer
+- Top-tier gamification — profile badges for T0/T0+/T0++, profile-load effects, differential AI greetings keyed off rank
+- Skull soft-barrier engine — plan-aware depth response: paid user progressive rate-limit + auto-block, team plan escalating admin notifications + tool lockdown
+- Currency exchange layer — copper + additional currencies with configurable exchange rates, ledger conversion primitive
+- Reviewer trust accrual — thoughtful approvers earn trust points; stale/rubber-stamp approvals flagged
 
 ### v2.0: Enterprise GA
 - Per-tenant security policy configuration
@@ -435,3 +537,19 @@ bypass all application-level security controls.
 - **Wave 3** (advanced evasion): scan window gap bypass confirmed (input Warden missed, output Sentinel caught), learning poisoning blocked by Warden scan, strike persistence gap (in-memory = lost on restart), forged JWT budget consumption, prompt PUT 500 error
 - **Total: 28 infrastructure/deployment findings** (R1-R28): 11 CRITICAL, 9 HIGH, 8 MEDIUM
 - **Combined with code audit: 70 security findings** across 4 audit rounds
+
+### 2026-04-18: Conductor Feature Migration Design Pass
+- Audited the still-running conductor-router against Stronghold to identify portable features
+- Ignored the conductor roadmap's aspirational feature names (Dream Loop, Mood Ring, Phantom, Context Archaeology, Temporal Patterns) — those labels do not appear in the live code
+- Confirmed Stronghold's reactor is a cleaner refactor of conductor-router's — same four modes + circuit breaker, improvements: split types/runtime/action, jitter on intervals, proper DI. `OrchestratorEngine` is Stronghold's net-new piece over conductor (priority-tiered `WorkItem` dispatch)
+- Identified five portable features → **CFM-1 through CFM-5**: review queue engine, STF + trust ledger, recipe + variant engine, APM, Intel dashboard
+- Key design decisions captured:
+  - Recipe is a **single declarative envelope** with `FlowSpec`; strategy agents and graph/workflow agents share one shape. Spec/engine separation — YAML round-trips, pure-data validation before instantiation
+  - `NodeSpec.kind` is an **open registry defaulting new kinds to Skull** — declarative specs are harmless, execution is gated by the existing trust-tier apparatus
+  - Session Trust Floor is **`min()` of every contributor and monotonically non-increasing within a session** — redaction and compaction do not heal (otherwise compaction becomes a laundering vector)
+  - User trust points accrue via `plan_multiplier × copper_value × session_T_score` — copper wraps `tokens_used × token_value`; admins clamp to 0 at Skull to preserve security-testing legitimacy; free users have multiplier 0 so they neither earn nor sabotage; exponential tier thresholds with narrow T2 band
+  - Review engine lives **beside** the orchestrator because reviews are often HITL and have fundamentally different latency/failure modes from execution `WorkItem`s
+  - Three reviewer classes: `human_only` | `ai_allowed` | `ai_only` — Auditor agent owns the AI side, ties into the existing Herald→…→Master-at-Arms pipeline plan
+- Roadmap-only items added: top-tier gamification (badges, fireworks, differential AI greetings), skull soft-barrier engine (plan-aware depth response), currency exchange layer, reviewer trust accrual
+- Reactor gets two minor extensions alongside CFM-1: density-aware jitter (spread thundering herds) and coalescence/timer-slack (gather sparse triggers for efficiency)
+- Architecture coverage: `ARCHITECTURE.md §15`. Roadmap integration: `ROADMAP.md` v1.4–v1.7

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,7 +1,7 @@
 # Stronghold Roadmap
 
-**Last Updated:** 2026-03-25
-**Status:** Pre-implementation — architecture complete, no code yet
+**Last Updated:** 2026-04-18
+**Status:** Pre-implementation — architecture complete, no code yet. CFM-1 through CFM-5 (Conductor Feature Migration, v1.4–v1.7) added 2026-04-18. Architecture coverage: `ARCHITECTURE.md §15`.
 
 ---
 
@@ -22,6 +22,10 @@ v1.0  Production release                  ← Phase 10 + Security Gate
 v1.1  Closed-loop feedback (phase 1-3)
 v1.2  Tournaments + Forge + advanced memory
 v1.3  Multi-tenant + adaptive tools
+v1.4  Review queue + Session Trust Floor + trust ledger  ← CFM-1, CFM-2
+v1.5  Recipe + variant evolution + APM                   ← CFM-3, CFM-4
+v1.6  Intel dashboard + structured evolution timeline    ← CFM-5
+v1.7  Trust economy surface + currency exchange
 v2.0  Full personalized intelligence
 ```
 
@@ -658,6 +662,95 @@ stronghold/
 - [ ] Usage-weighted tool schema pruning
 - [ ] Tool composition learning (frequent chains → pre-inject)
 - [ ] Custom agent containers (Dockerfile + A2A endpoint)
+
+## v1.4: Review Queue + Session Trust Floor + Trust Ledger
+
+**Theme:** Governance becomes a first-class runtime subsystem. Every promotion, every tier crossing, every potentially-poisoning input is a queued decision with a reviewer.
+
+### Review Queue Engine (CFM-1 — foundation)
+- [ ] `src/stronghold/review/` beside `orchestrator/` — reviews are HITL-often; latency, failure modes, and scaling differ from execution `WorkItem`s
+- [ ] Typed `ReviewItem` kinds: `forge_skill`, `forge_node_kind`, `recipe_variant_promote`, `apm_change`, `user_tier_promote`, `stf_ratchet_decision`, `learning_promote`, `agent_import`
+- [ ] Priority calculator = `f(stakes_impact, −origin_stf, plan_tier_sla, age_bonus, blast_radius, backlog_pressure)`
+- [ ] Reviewer classes: `human_only` / `ai_allowed` / `ai_only`. Auditor agent consumes AI-eligible items; maps to existing Herald→QM→Archie→Mason→Auditor→Gatekeeper→Master-at-Arms pipeline
+- [ ] `/dashboard/reviews.html` inbox; reactor-driven enqueue on forge/promote/change events; SLA + escalation + auto-expire
+- [ ] Shared with orchestrator only via `types/priority.py` and `types/review.py`
+
+### Session Trust Floor (CFM-2)
+- [ ] `src/stronghold/trust/` — `reducer.py`, `signals.py`, `ledger.py`, `thresholds.py`, `policy.py`, `exchange.py`
+- [ ] STF = `min()` over all contributors (agent, recipe, node, tool, input source, user trust score tier, Warden safety confidence tier, …)
+- [ ] Monotonically non-increasing within a session — redaction/compaction/summarization do not heal. New session required to reset
+- [ ] Forks and sub-flows inherit parent STF
+- [ ] `TrustSignal { source, tier, confidence, rationale, trace_ref }` contract; unknown sources default to `☠️ Skull`
+- [ ] Warden verdict gains `confidence ∈ [0,1]` — low confidence floors input's effective contribution
+- [ ] HITL surface: pending-input dialog (accept-and-ratchet or reject), blocked-action dialog, passive trust indicator with descent timeline
+
+### Trust Ledger
+- [ ] User trust accrual: `Δ = plan_multiplier × copper_value × session_T_score` on each completed action
+- [ ] `plan_multiplier`: free=0, paid=1, team_plan=2, team_admin=5, org_admin=10, super_admin=100
+- [ ] `session_T_score`: T1=+2, T2=+1, T3=0, ☠️Skull=−10 (clamps to 0 for team_admin+)
+- [ ] Exponential tier thresholds — narrow T2 band, wide T1/T3, unbounded T0/Skull; origin centered slightly positive into T2 for new paid users
+- [ ] Copper = `tokens_used × token_value`; conversion from other currencies via `trust/exchange.py`
+- [ ] Thresholds hot-reloadable via `trust/thresholds.yaml`
+- [ ] Dispatch refuses execution when `STF < recipe.required_tier` — emits event to review engine, doesn't raise
+
+### Reactor Enhancements (land with CFM-1)
+- [ ] Density-aware jitter for shared firing times — `max_jitter_secs = min(ceiling, base + k × log2(density))`
+- [ ] Coalescence / timer-slack — `leeway: "±Nmin"` lets reactor snap low-density triggers together for batch efficiency
+- [ ] Extend `TriggerSpec` jitter to `TIME` mode (not just `INTERVAL`); add `leeway` field
+- [ ] Log bucketing decisions in trigger audit
+
+## v1.5: Recipe + Variant Evolution + APM
+
+**Theme:** Agent structure becomes a declarative spec. Tournaments have a real selection backbone. Agent personality is a first-class, reviewable, round-trippable artifact.
+
+### Recipe + Variant Engine (CFM-3)
+- [ ] `src/stronghold/types/recipe.py` — `RecipeSpec` with `FlowSpec` body. Pure data, YAML-serializable, no Python callables
+- [ ] Single envelope for all agent shapes — strategy agents are degenerate graphs (one node, no edges); graph/workflow agents share the same envelope
+- [ ] `src/stronghold/evaluation/` — spec CRUD, Thompson sampling over `Beta(successes, failures)` posteriors per `(recipe_id, variant_id, intent)`, outcome recording, promotion logic, validator (reachability + schema + no-orphan edges + no-undeclared-state-refs)
+- [ ] `src/stronghold/execution/` — `graph_runner.py` + `node_handlers.py` + `state.py`. Spec/engine separation means the same spec can be run by multiple executors (today's tool-loop, tomorrow's streaming, a replay engine for RCA)
+- [ ] `NodeSpec.kind` is an OPEN registry. Built-in kinds reserved: `reason`, `tool`, `branch`, `recipe`, `collect` (ship at T0). Unknown kinds default to `☠️ Skull` — execution gated, specs harmless
+- [ ] Per-kind `param_schema` required at registration; `declared_side_effects` enforced by Sentinel (kind claiming `["network"]` can't open filesystem)
+- [ ] `effective_tier = min(recipe.tier, min(node.kind.tier for node in flow.nodes))`
+- [ ] Variants carry spec diffs, not runtime objects; Thompson sampling operates on spec hashes
+- [ ] Variant promotion → review queue (not immediate) with policy-driven auto-approve thresholds
+- [ ] Round-trips through GitAgent export/import as YAML
+- [ ] `migrations/00XX_recipes.sql` — `recipes`, `variants`, `variant_outcomes`, `node_kinds`
+
+### APM — Agent Personality Manifest (CFM-4)
+- [ ] `src/stronghold/types/apm.py` — Pydantic model with seven sections: `identity`, `core_values`, `communication_style`, `expertise`, `boundaries`, `tools_and_methods`, `memory_anchors`
+- [ ] Every agent resolves exactly one APM at load (merged from trust-tier baseline if none declared)
+- [ ] `PUT /v1/stronghold/agents/{id}/apm` — Warden-scanned (APM is an agent prompt; this is a high-trust boundary)
+- [ ] Changes enqueue review — `human_only` by default; policy-driven downgrade to `ai_allowed` later
+- [ ] Rendered into system prompt by every strategy via `prompts/apm_renderer.py` — strategy-agnostic wiring
+- [ ] Included in GitAgent export bundle; re-hydrates on import
+- [ ] Audit entry per change: actor, old_hash, new_hash, trace_id
+- [ ] `/dashboard/agents/{id}/apm` — diff preview and "request review" flow
+
+## v1.6: Intel Dashboard + Structured Evolution Timeline
+
+**Theme:** Memory, traces, and mutations become an inspectable, annotable audit trail.
+
+### Intel Dashboard (CFM-5)
+- [ ] `src/stronghold/intel/` — `traces.py` + `rca.py` + `evolution.py`
+- [ ] Four tabs: **Traces**, **RCA**, **Evolution**, **Reviews**
+- [ ] **Traces** — paginated Langfuse browse, filter by agent/intent/verdict, click into span tree, inline score (1–5 + tags + note)
+- [ ] `POST /v1/stronghold/traces/{id}/score` — dual-writes to Langfuse + outcomes store; reviewer earns trust points
+- [ ] **RCA** — auto-generated post-mortems from failed `WorkItem`s. Reactor-triggered `rca.generate_rca` on `work_failed`; candidates feed learnings extractor at low weight until reinforced
+- [ ] **Evolution** — chronological `EvolutionEvent` stream across memory, recipes, skills, learnings, node-kind mutations. Structural diffs (RecipeSpec + FlowSpec + node graph changes) — not just prompt text
+- [ ] **Reviews** — mirrors Review Queue inbox with the same filters
+
+## v1.7: Trust Economy Surface + Currency Exchange
+
+**Theme:** Trust ledger surfaces in the UX. Soft barriers do the right thing by plan tier. Gamification makes clean behavior visible.
+
+- [ ] **Top-tier gamification** — profile badges at T0/T0+/T0++, profile-load effects (fireworks, aurora), differential AI greetings keyed off rank (T0: `"Welcome back, {name}. Ready when you are."` → T0++: `"Welcome back, Supreme Divine Ruler of the Universe. How can we be of service?"`). Skull: guarded greeting + small warning sigil
+- [ ] **Skull soft-barrier engine** — plan-aware depth response:
+  - Paid: progressive action rate-limits; auto-block past threshold
+  - Team plan: escalating admin notifications (digest → alert → real-time); progressive tool lockdown
+  - Team/org/super admin: skull T-score clamps to 0 (no accrual, no penalty) — security testing remains legitimate
+- [ ] **Currency exchange layer** — copper as canonical unit; other currencies (credits, compute-minutes) plug in via `trust/exchange.py` with configurable rates
+- [ ] **Reviewer trust accrual** — thoughtful approvals earn trust points; rubber-stamp and stale decisions flagged
+- [ ] **Trust timeline widget** — per-session descent visualization with cause annotations
 
 ## v2.0: Personalized Intelligence
 


### PR DESCRIPTION
## Summary

Decomposes five features from the still-running conductor-router into Stronghold-native specs (**CFM-1..CFM-5**), mapped to roadmap versions **v1.4–v1.7**. Pure design documentation — no code changes.

## What's in each file

- **`ARCHITECTURE.md`** — new **§15** with per-subsystem core insight, type sketches, an ASCII diagram for the review/orchestrator seam, and a build-order recommendation
- **`BACKLOG.md`** — checklist decomposition per CFM item, v1.3–v1.7 roadmap bullets, a 2026-04-18 session log entry
- **`ROADMAP.md`** — release timeline extended through v1.7 plus four new phase sections

## Key design decisions

- **Recipe is a single declarative envelope** with `FlowSpec` — strategy agents are degenerate one-node graphs; graph/workflow agents share the same envelope. Spec/engine separation means YAML round-trips and pure-data validation before instantiation.
- **`NodeSpec.kind` is an open registry defaulting to Skull** — unregistered or third-party kinds appear in specs harmlessly; execution is gated by the existing trust-tier apparatus. No new governance mechanism needed.
- **Session Trust Floor is `min()` of every contributor and monotonically non-increasing within a session** — redaction, compaction, and summarization do NOT heal (otherwise compaction becomes a laundering vector).
- **Trust ledger arithmetic**: `Δ = plan_multiplier × copper_value × session_T_score`. Admins clamp to 0 at Skull to preserve security-testing legitimacy. Free users have multiplier 0 by design.
- **Review engine lives beside the orchestrator**, not inside — reviews are HITL-often and have fundamentally different latency/failure modes from execution `WorkItem`s.

## Cross-doc consistency

- CFM-1..CFM-5 appear in all three docs with matching numbering
- Roadmap versions v1.4–v1.7 match between `BACKLOG.md` and `ROADMAP.md`
- Existing v1.3 (Multi-Tenant + Adaptive Tools) retained; new items slot above v2.0
- Session-log summary in `BACKLOG.md` points to `ARCHITECTURE.md §15` and roadmap phases

## Test plan

- [ ] N/A — documentation only, no tests to run
- [ ] Review `ARCHITECTURE.md §15` for consistency against existing §2.9 (Reactor), §2.6 (Routing/Tournaments), §3.5 (Trust Tiers)
- [ ] Confirm `BACKLOG.md` CFM checklists and `ROADMAP.md` phase items align item-for-item
- [ ] Sanity-check the reactor-enhancement additions against `src/stronghold/triggers.py` and `src/stronghold/types/reactor.py` to make sure `jitter` extension to `TIME` mode and `leeway` field fit the existing types