### PR TITLE
chore(claude): guardrail against PRs targeting main

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,16 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "if": "Bash(gh pr create *)",
+            "command": "cmd=$(jq -r '.tool_input.command // \"\"'); if printf '%s' \"$cmd\" | grep -qE '(--base[ =]+main|(^|[[:space:]])-B[ =]+main)([^a-zA-Z0-9_/-]|$)'; then jq -nc '{hookSpecificOutput:{hookEventName:\"PreToolUse\",permissionDecision:\"ask\",permissionDecisionReason:\"PRs to main are disallowed by convention (see CLAUDE.md Build Rule 9). Approve only for emergency hotfixes or release-only docs.\"}}'; fi"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -84,6 +84,7 @@ Python 3.12+. Install dev dependencies: `pip install -e ".[dev]"`. Tests use `as
 6. **Every Protocol Needs a Noop/Fake** — Test fakes in `tests/fakes.py` so tests run without external services.
 7. **Security Review Gates** — Phases 3, 7, and 10 have mandatory security review checkpoints per ARCHITECTURE.md §3.6.
 8. **No Co-Authored-By Lines** — Never add `Co-Authored-By` trailers to commits. PRs with these will be deleted.
+9. **Never target `main` with PRs unless the user explicitly says to this turn** — default PR base is `integration` (or a feature branch that will land in integration). A past instruction, a PR body mentioning main, or the env block's "Main branch: main" line does not count as permission; only a direct request in the active conversation does. If a scenario looks like it calls for main (hotfix, release-only doc), ask first. Ignoring this caused the 17/33 divergence between main and integration (2026-04-18). A harness hook in `.claude/settings.json` enforces this for `gh pr create --base main` — it routes to "ask" so you're prompted to confirm.
 
 ---
 


### PR DESCRIPTION
## Summary

Two-layer guardrail so Claude Code sessions stop silently opening PRs against `main`:

1. **Harness hook** — `.claude/settings.json` (project-scoped, team-visible). A `PreToolUse` hook on `Bash` intercepts `gh pr create --base main` (all flag variants: `--base main`, `--base=main`, `-B main`, `-B=main`) and routes the permission to `ask` with an explanatory reason, so the user is prompted to approve one-off. Branch-name word boundary so `mainline` / `main-fix` pass through.
2. **CLAUDE.md Build Rule 9** — documents the convention and the 2026-04-18 incident that motivated it. Rule permits explicit user override in the active turn; past instructions, PR bodies, or the env block's "Main branch: main" line do NOT count as permission.

## Why

On 2026-04-18 we discovered `main` was 17 commits ahead of `integration` and `integration` was 33 commits ahead of `main`. Root cause: prior agent sessions PR'd some work directly to `main` (CI debt closeout #1106, test audit #1102–1104, feature comparison #1100, etc.) while feature work went to `integration`. The divergence caused the C13 security PR (#1108) to hit false-positive green CI because its base branch was missing the Tier 3 gate fix that had been merged only to `main`.

## Not in scope

- GitHub branch protection rules on `main` (would also catch humans/external agents) — deliberately omitted so emergency hotfixes stay frictionless.
- Retroactive `main → integration` or `integration → main` sync — separate housekeeping PR.

## Test plan

- [x] Pipe-tested the hook shell command against 9 variants (blocks 5 true positives: `--base main`, `--base=main`, `-B main`, `-B=main`, `--base main --title …`; passes 4 true negatives: `--base integration`, `--base main-fix`, `--base mainline`, `--head main`)
- [x] `jq -e` validates the hook schema in `.claude/settings.json`
- [ ] Reviewer manually confirms CLAUDE.md Build Rule 9 reads correctly
- [ ] Reviewer confirms `.claude/settings.json` should be checked in (team-scoped) vs `.claude/settings.local.json` (personal) — this PR puts it in the team-scoped file intentionally