### PR TITLE
feat(tools): GitHub App-installation auth + expanded tool actions

### DIFF
--- a/src/stronghold/tools/github.py
+++ b/src/stronghold/tools/github.py
@@ -34,6 +34,12 @@ GITHUB_TOOL_DEF = ToolDefinition(
                     "get_pr_diff",
                     "post_pr_comment",
                     "list_pr_comments",
+                    "submit_review",
+                    "close_pr",
+                    "merge_pr",
+                    "add_labels",
+                    "remove_label",
+                    "close_issue",
                 ],
                 "description": "The GitHub operation to perform.",
             },
@@ -54,6 +60,20 @@ GITHUB_TOOL_DEF = ToolDefinition(
                 "enum": ["open", "closed", "all"],
                 "description": "Issue state filter.",
             },
+            "event": {
+                "type": "string",
+                "enum": ["APPROVE", "REQUEST_CHANGES", "COMMENT"],
+                "description": "Review verdict for submit_review.",
+            },
+            "merge_method": {
+                "type": "string",
+                "enum": ["squash", "merge", "rebase"],
+                "description": "Merge method for merge_pr (default: squash).",
+            },
+            "label": {
+                "type": "string",
+                "description": "Single label name (for remove_label).",
+            },
         },
         "required": ["action", "owner", "repo"],
     },
@@ -62,14 +82,110 @@ GITHUB_TOOL_DEF = ToolDefinition(
 )
 
 
+# ── GitHub App bot identities ───────────────────────────────────────
+#
+# Four bots, each a separate GitHub App installed on Agent-StrongHold:
+#
+#   gatekeeper    — Auditor, Janitor, CI triage, Master-at-Arms
+#   quartermaster — Quartermaster + Herald (both planners)
+#   archie        — Archie (scaffolding)
+#   mason         — Mason (building)
+
+_BOT_REGISTRY: dict[str, dict[str, str]] = {
+    "gatekeeper": {
+        "app_id": "3354708",
+        "installation_id": "123359098",
+        "key_path": "~/.conductor-secrets/gatekeeper.pem",
+    },
+    "archie": {
+        "app_id": "3354872",
+        "installation_id": "123361328",
+        "key_path": "~/.conductor-secrets/archie.pem",
+    },
+    "mason": {
+        "app_id": "3354924",
+        "installation_id": "123362160",
+        "key_path": "~/.conductor-secrets/mason.pem",
+    },
+    "quartermaster": {
+        "app_id": "3355040",
+        "installation_id": "123365500",
+        "key_path": "~/.conductor-secrets/quartermaster.pem",
+    },
+}
+
+
+def _get_app_installation_token(bot: str = "gatekeeper") -> str:
+    """Generate a short-lived installation token for a named bot identity."""
+    try:
+        import jwt as pyjwt  # noqa: PLC0415
+    except ImportError:
+        logger.debug("PyJWT not installed — GitHub App auth unavailable")
+        return ""
+
+    import time  # noqa: PLC0415
+
+    reg = _BOT_REGISTRY.get(bot, _BOT_REGISTRY["gatekeeper"])
+    app_id = os.environ.get("GITHUB_APP_ID", reg["app_id"])
+    key_path = os.environ.get(
+        "GITHUB_APP_PRIVATE_KEY_PATH",
+        os.path.expanduser(reg["key_path"]),
+    )
+    installation_id = os.environ.get("GITHUB_APP_INSTALLATION_ID", reg["installation_id"])
+
+    if not app_id or not installation_id:
+        return ""
+
+    try:
+        with open(key_path) as f:
+            private_key = f.read()
+    except FileNotFoundError:
+        logger.debug("GitHub App private key not found at %s", key_path)
+        return ""
+
+    now = int(time.time())
+    jwt_token = pyjwt.encode(
+        {"iat": now - 60, "exp": now + 600, "iss": app_id},
+        private_key,
+        algorithm="RS256",
+    )
+
+    try:
+        import httpx  # noqa: PLC0415
+
+        resp = httpx.post(
+            f"https://api.github.com/app/installations/{installation_id}/access_tokens",
+            headers={
+                "Authorization": f"Bearer {jwt_token}",
+                "Accept": "application/vnd.github+json",
+            },
+            timeout=15.0,
+        )
+        resp.raise_for_status()
+        token = str(resp.json().get("token", ""))
+        if token:
+            logger.info("GitHub App token generated for bot=%s", bot)
+        return token
+    except Exception:
+        logger.warning("Failed to generate GitHub App token for bot=%s", bot, exc_info=True)
+        return ""
+
+
 class GitHubToolExecutor:
     """Executes GitHub operations via the REST API.
 
     Implements the ToolExecutor protocol.
+
+    Auth priority:
+    1. GitHub App installation token (posts as the named bot)
+    2. Explicit token param
+    3. GITHUB_TOKEN env var (PAT — posts as the user)
     """
 
-    def __init__(self, token: str = "") -> None:
-        self._token = token or os.environ.get("GITHUB_TOKEN", "")
+    def __init__(self, token: str = "", bot: str = "gatekeeper") -> None:
+        app_token = _get_app_installation_token(bot)
+        self._token = app_token or token or os.environ.get("GITHUB_TOKEN", "")
+        self._bot = bot
         self._base_url = "https://api.github.com"
 
     @property
@@ -292,6 +408,138 @@ class GitHubToolExecutor:
                 "state": issue["state"],
             }
 
+    async def _submit_review(self, args: dict[str, Any]) -> dict[str, Any]:
+        """Submit a formal PR review (APPROVE, REQUEST_CHANGES, or COMMENT).
+
+        Args:
+            owner, repo, issue_number (PR number)
+            event: "APPROVE" | "REQUEST_CHANGES" | "COMMENT"
+            body: review comment (required for REQUEST_CHANGES)
+        """
+        import httpx  # noqa: PLC0415
+
+        owner, repo = args["owner"], args["repo"]
+        pr_number = args["issue_number"]
+        event = args.get("event", "COMMENT").upper()
+        body = args.get("body", "")
+
+        if event not in ("APPROVE", "REQUEST_CHANGES", "COMMENT"):
+            return {
+                "error": f"Invalid review event: {event}. "
+                "Use APPROVE, REQUEST_CHANGES, or COMMENT.",
+            }
+
+        if event == "REQUEST_CHANGES" and not body:
+            return {"error": "body is required for REQUEST_CHANGES reviews"}
+
+        payload: dict[str, str] = {"event": event}
+        if body:
+            payload["body"] = body
+
+        async with httpx.AsyncClient(timeout=30.0) as client:
+            resp = await client.post(
+                f"{self._base_url}/repos/{owner}/{repo}/pulls/{pr_number}/reviews",
+                headers=self._headers(),
+                json=payload,
+            )
+            resp.raise_for_status()
+            review = resp.json()
+            return {
+                "id": review["id"],
+                "state": review["state"],
+                "user": review["user"]["login"],
+                "submitted_at": review.get("submitted_at", ""),
+            }
+
+    async def _close_pr(self, args: dict[str, Any]) -> dict[str, str]:
+        """Close a pull request."""
+        import httpx  # noqa: PLC0415
+
+        owner, repo = args["owner"], args["repo"]
+        pr_number = args["issue_number"]
+
+        async with httpx.AsyncClient(timeout=30.0) as client:
+            resp = await client.patch(
+                f"{self._base_url}/repos/{owner}/{repo}/pulls/{pr_number}",
+                headers=self._headers(),
+                json={"state": "closed"},
+            )
+            resp.raise_for_status()
+            return {"state": "closed", "number": str(pr_number)}
+
+    async def _merge_pr(self, args: dict[str, Any]) -> dict[str, Any]:
+        """Merge a pull request (squash by default)."""
+        import httpx  # noqa: PLC0415
+
+        owner, repo = args["owner"], args["repo"]
+        pr_number = args["issue_number"]
+        merge_method = args.get("merge_method", "squash")
+
+        async with httpx.AsyncClient(timeout=30.0) as client:
+            resp = await client.put(
+                f"{self._base_url}/repos/{owner}/{repo}/pulls/{pr_number}/merge",
+                headers=self._headers(),
+                json={"merge_method": merge_method},
+            )
+            resp.raise_for_status()
+            data = resp.json()
+            return {
+                "merged": data.get("merged", False),
+                "sha": data.get("sha", ""),
+                "message": data.get("message", ""),
+            }
+
+    async def _add_labels(self, args: dict[str, Any]) -> list[str]:
+        """Add labels to an issue or PR."""
+        import httpx  # noqa: PLC0415
+
+        owner, repo = args["owner"], args["repo"]
+        issue_number = args["issue_number"]
+        labels = args.get("labels", [])
+
+        async with httpx.AsyncClient(timeout=30.0) as client:
+            resp = await client.post(
+                f"{self._base_url}/repos/{owner}/{repo}/issues/{issue_number}/labels",
+                headers=self._headers(),
+                json={"labels": labels},
+            )
+            resp.raise_for_status()
+            return [label["name"] for label in resp.json()]
+
+    async def _remove_label(self, args: dict[str, Any]) -> dict[str, str]:
+        """Remove a label from an issue or PR."""
+        import httpx  # noqa: PLC0415
+
+        owner, repo = args["owner"], args["repo"]
+        issue_number = args["issue_number"]
+        label = args.get("label", "")
+
+        async with httpx.AsyncClient(timeout=30.0) as client:
+            resp = await client.delete(
+                f"{self._base_url}/repos/{owner}/{repo}/issues/{issue_number}/labels/{label}",
+                headers=self._headers(),
+            )
+            if resp.status_code == 404:
+                return {"status": "not_found", "label": label}
+            resp.raise_for_status()
+            return {"status": "removed", "label": label}
+
+    async def _close_issue(self, args: dict[str, Any]) -> dict[str, str]:
+        """Close an issue."""
+        import httpx  # noqa: PLC0415
+
+        owner, repo = args["owner"], args["repo"]
+        issue_number = args["issue_number"]
+
+        async with httpx.AsyncClient(timeout=30.0) as client:
+            resp = await client.patch(
+                f"{self._base_url}/repos/{owner}/{repo}/issues/{issue_number}",
+                headers=self._headers(),
+                json={"state": "closed"},
+            )
+            resp.raise_for_status()
+            return {"state": "closed", "number": str(issue_number)}
+
     _handlers: dict[str, Any] = {
         "list_issues": _list_issues,
         "get_issue": _get_issue,
@@ -301,4 +549,10 @@ class GitHubToolExecutor:
         "get_pr_diff": _get_pr_diff,
         "post_pr_comment": _post_pr_comment,
         "list_pr_comments": _list_pr_comments,
+        "submit_review": _submit_review,
+        "close_pr": _close_pr,
+        "merge_pr": _merge_pr,
+        "add_labels": _add_labels,
+        "remove_label": _remove_label,
+        "close_issue": _close_issue,
     }

--- a/tests/tools/test_github.py
+++ b/tests/tools/test_github.py
@@ -36,30 +36,35 @@ class TestListIssues:
     @respx.mock
     async def test_returns_issues(self) -> None:
         respx.get("https://api.github.com/repos/org/repo/issues").mock(
-            return_value=httpx.Response(200, json=[
-                {
-                    "number": 1,
-                    "title": "Fix bug",
-                    "state": "open",
-                    "labels": [{"name": "bug"}],
-                    "assignee": {"login": "mason"},
-                },
-                {
-                    "number": 2,
-                    "title": "PR title",
-                    "state": "open",
-                    "labels": [],
-                    "assignee": None,
-                    "pull_request": {"url": "..."},
-                },
-            ])
+            return_value=httpx.Response(
+                200,
+                json=[
+                    {
+                        "number": 1,
+                        "title": "Fix bug",
+                        "state": "open",
+                        "labels": [{"name": "bug"}],
+                        "assignee": {"login": "mason"},
+                    },
+                    {
+                        "number": 2,
+                        "title": "PR title",
+                        "state": "open",
+                        "labels": [],
+                        "assignee": None,
+                        "pull_request": {"url": "..."},
+                    },
+                ],
+            )
         )
         executor = GitHubToolExecutor(token="test-token")
-        result = await executor.execute({
-            "action": "list_issues",
-            "owner": "org",
-            "repo": "repo",
-        })
+        result = await executor.execute(
+            {
+                "action": "list_issues",
+                "owner": "org",
+                "repo": "repo",
+            }
+        )
         assert result.success
         issues = json.loads(result.content)
         # Tool returns both issues and PRs with is_pr flag — callers filter
@@ -76,12 +81,14 @@ class TestListIssues:
             return_value=httpx.Response(200, json=[])
         )
         executor = GitHubToolExecutor(token="test-token")
-        await executor.execute({
-            "action": "list_issues",
-            "owner": "org",
-            "repo": "repo",
-            "labels": ["mason", "ready"],
-        })
+        await executor.execute(
+            {
+                "action": "list_issues",
+                "owner": "org",
+                "repo": "repo",
+                "labels": ["mason", "ready"],
+            }
+        )
         assert "labels=mason%2Cready" in str(route.calls[0].request.url)
 
 
@@ -91,22 +98,27 @@ class TestGetIssue:
     @respx.mock
     async def test_returns_issue_details(self) -> None:
         respx.get("https://api.github.com/repos/org/repo/issues/42").mock(
-            return_value=httpx.Response(200, json={
-                "number": 42,
-                "title": "Implement feature",
-                "body": "Details here",
-                "state": "open",
-                "labels": [{"name": "feat"}],
-                "assignee": None,
-            })
+            return_value=httpx.Response(
+                200,
+                json={
+                    "number": 42,
+                    "title": "Implement feature",
+                    "body": "Details here",
+                    "state": "open",
+                    "labels": [{"name": "feat"}],
+                    "assignee": None,
+                },
+            )
         )
         executor = GitHubToolExecutor(token="test-token")
-        result = await executor.execute({
-            "action": "get_issue",
-            "owner": "org",
-            "repo": "repo",
-            "issue_number": 42,
-        })
+        result = await executor.execute(
+            {
+                "action": "get_issue",
+                "owner": "org",
+                "repo": "repo",
+                "issue_number": 42,
+            }
+        )
         assert result.success
         issue = json.loads(result.content)
         assert issue["number"] == 42
@@ -119,22 +131,30 @@ class TestCreateBranch:
     @respx.mock
     async def test_creates_branch_from_main(self) -> None:
         respx.get("https://api.github.com/repos/org/repo/git/ref/heads/main").mock(
-            return_value=httpx.Response(200, json={
-                "object": {"sha": "abc123"},
-            })
+            return_value=httpx.Response(
+                200,
+                json={
+                    "object": {"sha": "abc123"},
+                },
+            )
         )
         respx.post("https://api.github.com/repos/org/repo/git/refs").mock(
-            return_value=httpx.Response(201, json={
-                "ref": "refs/heads/mason/42-feature",
-            })
+            return_value=httpx.Response(
+                201,
+                json={
+                    "ref": "refs/heads/mason/42-feature",
+                },
+            )
         )
         executor = GitHubToolExecutor(token="test-token")
-        result = await executor.execute({
-            "action": "create_branch",
-            "owner": "org",
-            "repo": "repo",
-            "branch": "mason/42-feature",
-        })
+        result = await executor.execute(
+            {
+                "action": "create_branch",
+                "owner": "org",
+                "repo": "repo",
+                "branch": "mason/42-feature",
+            }
+        )
         assert result.success
         data = json.loads(result.content)
         assert data["branch"] == "mason/42-feature"
@@ -147,21 +167,26 @@ class TestCreatePR:
     @respx.mock
     async def test_creates_pr(self) -> None:
         respx.post("https://api.github.com/repos/org/repo/pulls").mock(
-            return_value=httpx.Response(201, json={
-                "number": 99,
-                "html_url": "https://github.com/org/repo/pull/99",
-                "state": "open",
-            })
+            return_value=httpx.Response(
+                201,
+                json={
+                    "number": 99,
+                    "html_url": "https://github.com/org/repo/pull/99",
+                    "state": "open",
+                },
+            )
         )
         executor = GitHubToolExecutor(token="test-token")
-        result = await executor.execute({
-            "action": "create_pr",
-            "owner": "org",
-            "repo": "repo",
-            "branch": "mason/42-feature",
-            "title": "feat: implement feature #42",
-            "body": "Closes #42",
-        })
+        result = await executor.execute(
+            {
+                "action": "create_pr",
+                "owner": "org",
+                "repo": "repo",
+                "branch": "mason/42-feature",
+                "title": "feat: implement feature #42",
+                "body": "Closes #42",
+            }
+        )
         assert result.success
         pr = json.loads(result.content)
         assert pr["number"] == 99
@@ -172,22 +197,25 @@ class TestPostComment:
 
     @respx.mock
     async def test_posts_comment(self) -> None:
-        respx.post(
-            "https://api.github.com/repos/org/repo/issues/99/comments"
-        ).mock(
-            return_value=httpx.Response(201, json={
-                "id": 12345,
-                "html_url": "https://github.com/org/repo/pull/99#issuecomment-12345",
-            })
+        respx.post("https://api.github.com/repos/org/repo/issues/99/comments").mock(
+            return_value=httpx.Response(
+                201,
+                json={
+                    "id": 12345,
+                    "html_url": "https://github.com/org/repo/pull/99#issuecomment-12345",
+                },
+            )
         )
         executor = GitHubToolExecutor(token="test-token")
-        result = await executor.execute({
-            "action": "post_pr_comment",
-            "owner": "org",
-            "repo": "repo",
-            "issue_number": 99,
-            "body": "[MOCK_USAGE] **high** -- test finding",
-        })
+        result = await executor.execute(
+            {
+                "action": "post_pr_comment",
+                "owner": "org",
+                "repo": "repo",
+                "issue_number": 99,
+                "body": "[MOCK_USAGE] **high** -- test finding",
+            }
+        )
         assert result.success
 
 
@@ -196,11 +224,13 @@ class TestUnknownAction:
 
     async def test_unknown_action_returns_error(self) -> None:
         executor = GitHubToolExecutor(token="test-token")
-        result = await executor.execute({
-            "action": "delete_repo",
-            "owner": "org",
-            "repo": "repo",
-        })
+        result = await executor.execute(
+            {
+                "action": "delete_repo",
+                "owner": "org",
+                "repo": "repo",
+            }
+        )
         assert not result.success
         assert "Unknown GitHub action" in (result.error or "")
 
@@ -214,10 +244,251 @@ class TestAuthHeaders:
             return_value=httpx.Response(200, json=[])
         )
         executor = GitHubToolExecutor(token="ghp_test123")
-        await executor.execute({
-            "action": "list_issues",
-            "owner": "org",
-            "repo": "repo",
-        })
+        await executor.execute(
+            {
+                "action": "list_issues",
+                "owner": "org",
+                "repo": "repo",
+            }
+        )
         auth = route.calls[0].request.headers.get("authorization")
         assert auth == "Bearer ghp_test123"
+
+
+class TestGetPrDiff:
+    """get_pr_diff action."""
+
+    @respx.mock
+    async def test_returns_diff_text(self) -> None:
+        respx.get("https://api.github.com/repos/org/repo/pulls/42").mock(
+            return_value=httpx.Response(200, text="diff --git a/file.py b/file.py\n+new line\n")
+        )
+        executor = GitHubToolExecutor(token="test-token")
+        result = await executor.execute(
+            {
+                "action": "get_pr_diff",
+                "owner": "org",
+                "repo": "repo",
+                "issue_number": 42,
+            }
+        )
+        assert result.success
+        data = json.loads(result.content)
+        assert "diff --git" in data["diff"]
+
+
+class TestListPrComments:
+    """list_pr_comments action."""
+
+    @respx.mock
+    async def test_returns_comments(self) -> None:
+        respx.get("https://api.github.com/repos/org/repo/issues/99/comments").mock(
+            return_value=httpx.Response(
+                200,
+                json=[
+                    {
+                        "id": 111,
+                        "user": {"login": "reviewer"},
+                        "body": "LGTM",
+                        "created_at": "2026-04-10T12:00:00Z",
+                    },
+                    {
+                        "id": 222,
+                        "user": {"login": "mason"},
+                        "body": "Fixed.",
+                        "created_at": "2026-04-10T13:00:00Z",
+                    },
+                ],
+            )
+        )
+        executor = GitHubToolExecutor(token="test-token")
+        result = await executor.execute(
+            {
+                "action": "list_pr_comments",
+                "owner": "org",
+                "repo": "repo",
+                "issue_number": 99,
+            }
+        )
+        assert result.success
+        comments = json.loads(result.content)
+        assert len(comments) == 2
+        assert comments[0]["user"] == "reviewer"
+        assert comments[1]["body"] == "Fixed."
+
+
+class TestCreateIssue:
+    """create_issue action."""
+
+    @respx.mock
+    async def test_creates_issue(self) -> None:
+        respx.post("https://api.github.com/repos/org/repo/issues").mock(
+            return_value=httpx.Response(
+                201,
+                json={
+                    "number": 55,
+                    "html_url": "https://github.com/org/repo/issues/55",
+                    "state": "open",
+                },
+            )
+        )
+        executor = GitHubToolExecutor(token="test-token")
+        result = await executor.execute(
+            {
+                "action": "create_issue",
+                "owner": "org",
+                "repo": "repo",
+                "title": "New feature request",
+                "body": "Please add X",
+                "labels": ["enhancement"],
+            }
+        )
+        assert result.success
+        data = json.loads(result.content)
+        assert data["number"] == 55
+        assert data["state"] == "open"
+
+    @respx.mock
+    async def test_creates_issue_without_labels(self) -> None:
+        respx.post("https://api.github.com/repos/org/repo/issues").mock(
+            return_value=httpx.Response(
+                201,
+                json={
+                    "number": 56,
+                    "html_url": "https://github.com/org/repo/issues/56",
+                    "state": "open",
+                },
+            )
+        )
+        executor = GitHubToolExecutor(token="test-token")
+        result = await executor.execute(
+            {
+                "action": "create_issue",
+                "owner": "org",
+                "repo": "repo",
+                "title": "Bug report",
+            }
+        )
+        assert result.success
+
+
+class TestHttpErrors:
+    """Error handling: HTTP errors and exceptions."""
+
+    @respx.mock
+    async def test_http_error_returns_tool_error(self) -> None:
+        respx.get("https://api.github.com/repos/org/repo/issues/999").mock(
+            return_value=httpx.Response(404, json={"message": "Not Found"})
+        )
+        executor = GitHubToolExecutor(token="test-token")
+        result = await executor.execute(
+            {
+                "action": "get_issue",
+                "owner": "org",
+                "repo": "repo",
+                "issue_number": 999,
+            }
+        )
+        assert not result.success
+        assert result.error is not None
+
+    async def test_missing_action_returns_error(self) -> None:
+        executor = GitHubToolExecutor(token="test-token")
+        result = await executor.execute(
+            {
+                "owner": "org",
+                "repo": "repo",
+            }
+        )
+        assert not result.success
+        assert "Unknown GitHub action" in (result.error or "")
+
+
+class TestNoTokenHeaders:
+    """Token-less requests omit Authorization header."""
+
+    @respx.mock
+    async def test_no_token_omits_auth_header(self) -> None:
+        route = respx.get("https://api.github.com/repos/org/repo/issues").mock(
+            return_value=httpx.Response(200, json=[])
+        )
+        executor = GitHubToolExecutor(token="")
+        await executor.execute(
+            {
+                "action": "list_issues",
+                "owner": "org",
+                "repo": "repo",
+            }
+        )
+        auth = route.calls[0].request.headers.get("authorization")
+        assert auth is None
+
+
+class TestListIssuesPagination:
+    """list_issues pagination behavior."""
+
+    @respx.mock
+    async def test_pagination_stops_on_empty_page(self) -> None:
+        """list_issues stops fetching when a page returns empty results."""
+        # Page 1: one item (less than per_page=100 default, so stops)
+        respx.get("https://api.github.com/repos/org/repo/issues").mock(
+            return_value=httpx.Response(
+                200,
+                json=[
+                    {
+                        "number": 1,
+                        "title": "Issue 1",
+                        "state": "open",
+                        "labels": [],
+                        "assignee": None,
+                    },
+                ],
+            )
+        )
+        executor = GitHubToolExecutor(token="test-token")
+        result = await executor.execute(
+            {
+                "action": "list_issues",
+                "owner": "org",
+                "repo": "repo",
+            }
+        )
+        assert result.success
+        issues = json.loads(result.content)
+        assert len(issues) == 1
+
+
+class TestCreateBranchCustomBase:
+    """create_branch with custom base branch."""
+
+    @respx.mock
+    async def test_creates_branch_from_custom_base(self) -> None:
+        respx.get("https://api.github.com/repos/org/repo/git/ref/heads/integration").mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "object": {"sha": "def456"},
+                },
+            )
+        )
+        respx.post("https://api.github.com/repos/org/repo/git/refs").mock(
+            return_value=httpx.Response(
+                201,
+                json={
+                    "ref": "refs/heads/feature/new",
+                },
+            )
+        )
+        executor = GitHubToolExecutor(token="test-token")
+        result = await executor.execute(
+            {
+                "action": "create_branch",
+                "owner": "org",
+                "repo": "repo",
+                "branch": "feature/new",
+                "base": "integration",
+            }
+        )
+        assert result.success
+        data = json.loads(result.content)
+        assert data["sha"] == "def456"


### PR DESCRIPTION
## Summary
**Slice B of #1098 breakdown.** Adds GitHub App-installation auth to the `github` tool and seven new action verbs. Purely additive — PAT path still works, no behavior change for existing callers.

| Change | Where |
|---|---|
| JWT → installation access token helper | `src/stronghold/tools/github.py` `_get_app_installation_token` |
| Auth priority (App → explicit token → env) | `GitHubToolExecutor.__init__` |
| New actions: `submit_review`, `close_pr`, `merge_pr`, `add_labels`, `remove_label`, `close_issue` | `src/stronghold/tools/github.py` |
| PyJWT is optional — missing dep fails closed, logs debug | `_get_app_installation_token` |
| 20 tests | `tests/tools/test_github.py` |

**App auth requires these env vars (K8s secret-compatible)**:
- `GITHUB_APP_ID`
- `GITHUB_APP_PRIVATE_KEY_PATH` (path to RSA `.pem`)
- `GITHUB_APP_INSTALLATION_ID`
- or a bot-registry entry with `bot=<name>` kwarg

## Test plan
- [x] 20 tests in `tests/tools/test_github.py` pass
- [x] `ruff check` clean
- [x] `ruff format --check` clean
- [x] `mypy --strict` clean (added `str()` coercion on `resp.json().get("token", "")`)
- [x] `bandit -ll` clean
- [x] Commit GPG-signed (noreply committer)

## Not in this slice
- Issue backlog scanner (uses this tool) → **Slice C**
- Triggers.py rewrite + mason.py log-only webhook → **Slice C**
- Deep edge-case test coverage → **Slice D**