### PR TITLE
chore(infra): misc cleanups — SEC-014 admin int coerce, parallel CI, gatekeeper workflow, local registry

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,7 +64,6 @@ jobs:
   security:
     name: Security Tests
     runs-on: [self-hosted, stronghold]
-    needs: lint
     steps:
       - uses: actions/checkout@v4
       - name: Set up venv
@@ -89,7 +88,6 @@ jobs:
   sast:
     name: SAST & Supply Chain
     runs-on: [self-hosted, stronghold]
-    needs: lint
     steps:
       - uses: actions/checkout@v4
       - name: Set up venv
@@ -160,7 +158,6 @@ jobs:
   test:
     name: Tests
     runs-on: [self-hosted, stronghold]
-    needs: lint
 
     env:
       ROUTER_API_KEY: sk-ci-test-key-minimum-32-characters

--- a/.github/workflows/gatekeeper-review.yml
+++ b/.github/workflows/gatekeeper-review.yml
@@ -1,0 +1,106 @@
+name: Gatekeeper Review
+
+# When CI passes on a PR, Gatekeeper automatically approves.
+# When CI fails, ci-autofix.yml handles the failure path.
+#
+# This workflow MUST live on the default branch (main) for the
+# workflow_run trigger to fire.
+
+on:
+  workflow_run:
+    workflows: ["CI"]
+    types: [completed]
+
+concurrency:
+  group: gatekeeper-${{ github.event.workflow_run.head_branch }}
+  cancel-in-progress: true
+
+jobs:
+  review:
+    name: Gatekeeper auto-review
+    runs-on: k3s-runners
+    if: >-
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.head_branch != 'main' &&
+      github.event.workflow_run.head_branch != 'integration' &&
+      github.event.workflow_run.head_branch != 'develop'
+    steps:
+      - name: Find PR for this branch
+        id: pr
+        env:
+          GH_TOKEN: ${{ github.token }}
+          HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
+        run: |
+          PR_NUMBER=$(gh pr list --repo "${{ github.repository }}" \
+            --head "$HEAD_BRANCH" --state open \
+            --json number --jq '.[0].number' 2>/dev/null || echo "")
+          echo "number=$PR_NUMBER" >> "$GITHUB_OUTPUT"
+          if [ -z "$PR_NUMBER" ] || [ "$PR_NUMBER" = "null" ]; then
+            echo "No open PR for branch $HEAD_BRANCH — skipping"
+          else
+            echo "Found PR #$PR_NUMBER for branch $HEAD_BRANCH"
+          fi
+
+      - name: Generate Gatekeeper token
+        if: steps.pr.outputs.number != '' && steps.pr.outputs.number != 'null'
+        id: token
+        env:
+          APP_ID: ${{ secrets.GATEKEEPER_APP_ID }}
+          PRIVATE_KEY: ${{ secrets.GATEKEEPER_PRIVATE_KEY }}
+          INSTALLATION_ID: ${{ secrets.GATEKEEPER_INSTALLATION_ID }}
+        run: |
+          # Generate JWT
+          NOW=$(date +%s)
+          IAT=$((NOW - 60))
+          EXP=$((NOW + 600))
+
+          # Base64url encode header and payload
+          HEADER=$(echo -n '{"alg":"RS256","typ":"JWT"}' | openssl base64 -e -A | tr '+/' '-_' | tr -d '=')
+          PAYLOAD=$(echo -n "{\"iat\":$IAT,\"exp\":$EXP,\"iss\":\"$APP_ID\"}" | openssl base64 -e -A | tr '+/' '-_' | tr -d '=')
+
+          # Sign with RSA private key
+          SIGNATURE=$(echo -n "${HEADER}.${PAYLOAD}" | \
+            openssl dgst -sha256 -sign <(echo "$PRIVATE_KEY") -binary | \
+            openssl base64 -e -A | tr '+/' '-_' | tr -d '=')
+
+          JWT="${HEADER}.${PAYLOAD}.${SIGNATURE}"
+
+          # Exchange JWT for installation token
+          TOKEN=$(curl -s -X POST \
+            -H "Authorization: Bearer $JWT" \
+            -H "Accept: application/vnd.github+json" \
+            "https://api.github.com/app/installations/$INSTALLATION_ID/access_tokens" \
+            | jq -r '.token')
+
+          if [ "$TOKEN" = "null" ] || [ -z "$TOKEN" ]; then
+            echo "::error::Failed to generate Gatekeeper installation token"
+            exit 1
+          fi
+
+          echo "::add-mask::$TOKEN"
+          echo "token=$TOKEN" >> "$GITHUB_OUTPUT"
+
+      - name: Submit approval review
+        if: steps.pr.outputs.number != '' && steps.pr.outputs.number != 'null'
+        env:
+          TOKEN: ${{ steps.token.outputs.token }}
+          PR_NUMBER: ${{ steps.pr.outputs.number }}
+          RUN_ID: ${{ github.event.workflow_run.id }}
+        run: |
+          RESPONSE=$(curl -s -w "\n%{http_code}" -X POST \
+            -H "Authorization: Bearer $TOKEN" \
+            -H "Accept: application/vnd.github+json" \
+            "https://api.github.com/repos/${{ github.repository }}/pulls/$PR_NUMBER/reviews" \
+            -d "{\"event\":\"APPROVE\",\"body\":\"CI passed ([run #$RUN_ID](https://github.com/${{ github.repository }}/actions/runs/$RUN_ID)). Approved by Gatekeeper.\"}")
+
+          HTTP_CODE=$(echo "$RESPONSE" | tail -1)
+          BODY=$(echo "$RESPONSE" | head -n -1)
+
+          if [ "$HTTP_CODE" = "200" ] || [ "$HTTP_CODE" = "201" ] || [ "$HTTP_CODE" = "422" ]; then
+            USER=$(echo "$BODY" | jq -r '.user.login // "unknown"')
+            echo "Review submitted by $USER (HTTP $HTTP_CODE)"
+          else
+            echo "::warning::Review submission returned HTTP $HTTP_CODE"
+            echo "$BODY" | jq . 2>/dev/null || echo "$BODY"
+          fi

--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,4 @@ Thumbs.db
 deploy/k8s/litellm_config.yaml
 litellm_config.yaml
 .hypothesis/
+.claude/worktrees/

--- a/deploy/helm/stronghold/values-prod-homelab.yaml
+++ b/deploy/helm/stronghold/values-prod-homelab.yaml
@@ -43,9 +43,21 @@ mcp:
   github:
     devMode: true
 
+# Local registry on PVE host (no ghcr.io needed for private repo).
+# Images stored on MergerFS at /mnt/storage/registry.
+image:
+  repository: 10.10.42.100:5000/stronghold
+  tag: latest
+  pullPolicy: Always
+
 # Homelab resource tuning (single-node, 32GB RAM, 10 vCPU).
 strongholdApi:
   replicas: 1
+  image:
+    registry: ""
+    repository: 10.10.42.100:5000/stronghold
+    tag: latest
+    pullPolicy: Always
   resources:
     requests:
       cpu: 500m

--- a/scripts/cleanroom-lint.sh
+++ b/scripts/cleanroom-lint.sh
@@ -51,6 +51,7 @@ if [[ "$mode" == "all" ]]; then
   matches=$(git ls-files -z \
     | xargs -0 grep -inEH "$PATTERN" 2>/dev/null \
     | grep -v '^\.claude/worktrees/' \
+    | grep -v '^scripts/cleanroom-lint\.sh:' \
     || true)
 else
   echo "cleanroom-lint: mode = diff vs ${base}"
@@ -60,12 +61,19 @@ else
     matches=$(git ls-files -z \
       | xargs -0 grep -inEH "$PATTERN" 2>/dev/null \
       | grep -v '^\.claude/worktrees/' \
+      | grep -v '^scripts/cleanroom-lint\.sh:' \
       || true)
   else
     # Get the list of files changed (added or modified) vs base.
     changed_files=$(git diff --name-only --diff-filter=AM "${base}...HEAD" || true)
     if [[ -z "$changed_files" ]]; then
       green "cleanroom-lint: no changed files vs ${base}, nothing to scan"
+      exit 0
+    fi
+    # Exclude this script — it contains the pattern list by definition.
+    changed_files=$(echo "$changed_files" | grep -v 'scripts/cleanroom-lint\.sh')
+    if [[ -z "$changed_files" ]]; then
+      green "cleanroom-lint: only cleanroom-lint.sh changed, nothing else to scan"
       exit 0
     fi
     # Only inspect lines added in this branch (the '+' diff lines).

--- a/src/stronghold/agents/strategies/builders_learning.py
+++ b/src/stronghold/agents/strategies/builders_learning.py
@@ -276,24 +276,24 @@ class BuildersLearningStrategy:
             )
             if ruff and "error" in str(ruff).lower():
                 issues.append(f"ruff: {str(ruff)[:200]}")
-        except Exception:
-            pass
+        except Exception as e:
+            issues.append(f"ruff: tool_executor failed: {e}")
         try:
             mypy = await tool_executor(
                 "shell", {"command": "mypy src/stronghold/ --strict 2>&1 | tail -3"}
             )
             if mypy and "error" in str(mypy).lower():
                 issues.append(f"mypy: {str(mypy)[:200]}")
-        except Exception:
-            pass
+        except Exception as e:
+            issues.append(f"mypy: tool_executor failed: {e}")
         try:
             tests = await tool_executor(
                 "shell", {"command": "pytest tests/ -x -q --tb=line 2>&1 | tail -5"}
             )
             if tests and "failed" in str(tests).lower():
                 issues.append(f"pytest: {str(tests)[:200]}")
-        except Exception:
-            pass
+        except Exception as e:
+            issues.append(f"pytest: tool_executor failed: {e}")
 
         has_critical = len(issues) > 0
         return {

--- a/src/stronghold/api/routes/admin.py
+++ b/src/stronghold/api/routes/admin.py
@@ -1115,7 +1115,11 @@ async def convert_coins(request: Request) -> JSONResponse:
     container = request.app.state.container
     body: dict[str, Any] = await request.json()
 
-    copper_amount = int(body.get("copper_amount", 0))
+    # SEC-014: guard int() against non-numeric input
+    try:
+        copper_amount = int(body.get("copper_amount", 0))
+    except (TypeError, ValueError) as e:
+        raise HTTPException(status_code=400, detail=f"copper_amount must be an integer: {e}") from e
     if copper_amount < 10:
         raise HTTPException(status_code=400, detail="Minimum conversion: 10 copper")
 

--- a/tests/agents/strategies/test_builders_learning.py
+++ b/tests/agents/strategies/test_builders_learning.py
@@ -1,6 +1,9 @@
 """Tests for BuildersLearningStrategy."""
 
+from datetime import UTC
+
 import pytest
+
 from stronghold.agents.strategies.builders_learning import BuildersLearningStrategy
 
 
@@ -248,3 +251,302 @@ def mock_trace():
             pass
 
     return MockTrace()
+
+
+# ── Tests targeting uncovered lines 217-298 ──────────────────────────
+
+
+class TestCheckRepositoryState:
+    """Cover _check_repository_state with and without tool_executor."""
+
+    async def test_no_tool_executor_returns_empty(self):
+        strategy = BuildersLearningStrategy()
+        result = await strategy._check_repository_state()
+        assert result == {"code": [], "tests": [], "failed_prs": []}
+
+    async def test_with_tool_executor_success(self):
+        async def tool_executor(tool_name, args):
+            if "src/stronghold" in args.get("command", ""):
+                return "src/stronghold/main.py\nsrc/stronghold/app.py"
+            if "tests" in args.get("command", ""):
+                return "tests/test_main.py"
+            return ""
+
+        strategy = BuildersLearningStrategy()
+        result = await strategy._check_repository_state(tool_executor=tool_executor)
+        assert len(result["code"]) == 2
+        assert "src/stronghold/main.py" in result["code"]
+        assert len(result["tests"]) == 1
+        assert result["failed_prs"] == []
+
+    async def test_with_tool_executor_returns_none(self):
+        """tool_executor returns None (falsy) for both calls."""
+
+        async def tool_executor(tool_name, args):
+            return None
+
+        strategy = BuildersLearningStrategy()
+        result = await strategy._check_repository_state(tool_executor=tool_executor)
+        assert result["code"] == []
+        assert result["tests"] == []
+
+    async def test_with_tool_executor_exception(self):
+        """tool_executor raises; should catch and return empty."""
+
+        async def tool_executor(tool_name, args):
+            raise RuntimeError("connection failed")
+
+        strategy = BuildersLearningStrategy()
+        result = await strategy._check_repository_state(tool_executor=tool_executor)
+        assert result == {"code": [], "tests": [], "failed_prs": []}
+
+
+class TestAnalyzeFailurePatterns:
+    """Cover _analyze_failure_patterns with and without tool_executor."""
+
+    async def test_no_tool_executor_returns_empty(self):
+        strategy = BuildersLearningStrategy()
+        result = await strategy._analyze_failure_patterns()
+        assert result == {"similar_issues": [], "failures": [], "reasons": [], "lessons": []}
+
+    async def test_with_tool_executor_success(self):
+        async def tool_executor(tool_name, args):
+            return "PR #10 rejected\nPR #11 rejected\nPR #12 rejected"
+
+        strategy = BuildersLearningStrategy()
+        result = await strategy._analyze_failure_patterns(tool_executor=tool_executor)
+        assert len(result["failures"]) == 3
+        assert result["similar_issues"] == []
+        assert result["reasons"] == []
+        assert result["lessons"] == []
+
+    async def test_with_tool_executor_returns_none(self):
+        async def tool_executor(tool_name, args):
+            return None
+
+        strategy = BuildersLearningStrategy()
+        result = await strategy._analyze_failure_patterns(tool_executor=tool_executor)
+        assert result["failures"] == []
+
+    async def test_with_tool_executor_exception(self):
+        async def tool_executor(tool_name, args):
+            raise RuntimeError("API error")
+
+        strategy = BuildersLearningStrategy()
+        result = await strategy._analyze_failure_patterns(tool_executor=tool_executor)
+        assert result == {"similar_issues": [], "failures": [], "reasons": [], "lessons": []}
+
+
+class TestRunPrDiagnostics:
+    """Cover _run_pr_diagnostics with and without tool_executor."""
+
+    async def test_no_tool_executor_returns_all_passed(self):
+        strategy = BuildersLearningStrategy()
+        result = await strategy._run_pr_diagnostics()
+        assert result["all_passed"] is True
+        assert result["issues"] == []
+        assert result["has_critical_issues"] is False
+
+    async def test_all_checks_pass(self):
+        async def tool_executor(tool_name, args):
+            return "All checks passed"
+
+        strategy = BuildersLearningStrategy()
+        result = await strategy._run_pr_diagnostics(tool_executor=tool_executor)
+        assert result["all_passed"] is True
+        assert result["issues"] == []
+        assert result["has_critical_issues"] is False
+
+    async def test_ruff_finds_errors(self):
+        async def tool_executor(tool_name, args):
+            cmd = args.get("command", "")
+            if "ruff" in cmd:
+                return "Found 3 error(s)"
+            return "OK"
+
+        strategy = BuildersLearningStrategy()
+        result = await strategy._run_pr_diagnostics(tool_executor=tool_executor)
+        assert result["has_critical_issues"] is True
+        assert len(result["issues"]) == 1
+        assert "ruff" in result["issues"][0]
+
+    async def test_mypy_finds_errors(self):
+        async def tool_executor(tool_name, args):
+            cmd = args.get("command", "")
+            if "mypy" in cmd:
+                return "Found 2 error(s) in 1 file"
+            return "OK"
+
+        strategy = BuildersLearningStrategy()
+        result = await strategy._run_pr_diagnostics(tool_executor=tool_executor)
+        assert result["has_critical_issues"] is True
+        assert any("mypy" in issue for issue in result["issues"])
+
+    async def test_pytest_finds_failures(self):
+        async def tool_executor(tool_name, args):
+            cmd = args.get("command", "")
+            if "pytest" in cmd:
+                return "1 failed, 9 passed"
+            return "OK"
+
+        strategy = BuildersLearningStrategy()
+        result = await strategy._run_pr_diagnostics(tool_executor=tool_executor)
+        assert result["has_critical_issues"] is True
+        assert any("pytest" in issue for issue in result["issues"])
+
+    async def test_all_checks_fail(self):
+        async def tool_executor(tool_name, args):
+            # Must contain "error" for ruff/mypy and "failed" for pytest
+            return "error: something failed here"
+
+        strategy = BuildersLearningStrategy()
+        result = await strategy._run_pr_diagnostics(tool_executor=tool_executor)
+        assert result["has_critical_issues"] is True
+        assert len(result["issues"]) == 3
+
+    async def test_tool_executor_exceptions_report_as_failures(self):
+        """Broken tool_executor = quality gate failure, not silent pass."""
+        call_count = 0
+
+        async def tool_executor(tool_name, args):
+            nonlocal call_count
+            call_count += 1
+            raise RuntimeError("boom")
+
+        strategy = BuildersLearningStrategy()
+        result = await strategy._run_pr_diagnostics(tool_executor=tool_executor)
+        assert result["all_passed"] is False
+        assert result["has_critical_issues"] is True
+        assert len(result["issues"]) == 3
+        assert all("tool_executor failed" in issue for issue in result["issues"])
+        assert call_count == 3  # all three checks attempted
+
+
+class TestMasonWithCriticalDiagnostics:
+    """Cover Mason path where diagnostics find critical issues (lines 185-199)."""
+
+    async def test_mason_critical_issues_sets_done_false(self, mock_llm, mock_trace):
+        """When PR diagnostics find critical issues, result.done should be False."""
+
+        async def failing_tool_executor(tool_name, args):
+            cmd = args.get("command", "")
+            if "ruff" in cmd:
+                return "error: found issues"
+            return "OK"
+
+        strategy = BuildersLearningStrategy(enable_learning=True)
+        messages = [{"role": "user", "content": "Implement feature"}]
+
+        result = await strategy.reason(
+            messages,
+            "model",
+            mock_llm,
+            trace=mock_trace,
+            worker="mason",
+            run_id="test-critical",
+            frank_diagnostic={"existing_code": False},
+            tool_executor=failing_tool_executor,
+        )
+
+        assert result.done is False
+        assert "Self-diagnosis" in result.response
+        assert "issues" in result.response
+
+
+class TestFrankWithToolExecutor:
+    """Cover Frank path with tool_executor wired (hits lines 217-260)."""
+
+    async def test_frank_with_tool_executor_and_learning(self, mock_llm, mock_trace):
+        call_log = []
+
+        async def tool_executor(tool_name, args):
+            call_log.append((tool_name, args))
+            if tool_name == "shell":
+                return "src/stronghold/foo.py"
+            if tool_name == "github":
+                return "PR #5 rejected"
+            return ""
+
+        strategy = BuildersLearningStrategy(enable_learning=True)
+        messages = [{"role": "user", "content": "Add auth"}]
+
+        result = await strategy.reason(
+            messages,
+            "model",
+            mock_llm,
+            trace=mock_trace,
+            worker="frank",
+            run_id="test-frank-tool",
+            tool_executor=tool_executor,
+        )
+
+        assert result.done is True
+        # Verify tool_executor was called for repo recon and failure analysis
+        tool_names = [name for name, _ in call_log]
+        assert "shell" in tool_names
+        assert "github" in tool_names
+
+
+class TestFallbackToReact:
+    """Cover the fallback path when worker is neither frank nor mason."""
+
+    async def test_unknown_worker_falls_back_to_react(self, mock_llm, mock_trace):
+        strategy = BuildersLearningStrategy()
+        messages = [{"role": "user", "content": "Do something"}]
+
+        result = await strategy.reason(
+            messages,
+            "model",
+            mock_llm,
+            trace=mock_trace,
+            worker="unknown",
+        )
+
+        assert result.done is True
+
+    async def test_no_worker_falls_back_to_react(self, mock_llm, mock_trace):
+        strategy = BuildersLearningStrategy()
+        messages = [{"role": "user", "content": "Do something"}]
+
+        result = await strategy.reason(
+            messages,
+            "model",
+            mock_llm,
+            trace=mock_trace,
+        )
+
+        assert result.done is True
+
+
+class TestUtcNow:
+    """Cover _utc_now helper."""
+
+    def test_utc_now_returns_aware_datetime(self):
+
+        strategy = BuildersLearningStrategy()
+        now = strategy._utc_now()
+        assert now.tzinfo is not None
+        assert now.tzinfo == UTC
+
+
+class TestStoreLearningMethods:
+    """Cover _store_frank_learning and _store_mason_learning directly."""
+
+    async def test_store_frank_learning(self):
+        from stronghold.types.agent import ReasoningResult
+
+        strategy = BuildersLearningStrategy()
+        repo_state = {"code": ["a.py", "b.py"], "tests": ["t.py"], "failures": []}
+        failure_patterns = {"failures": ["pr1", "pr2"]}
+        result = ReasoningResult(response="done", done=True)
+        # Should not raise
+        await strategy._store_frank_learning(repo_state, failure_patterns, result)
+
+    async def test_store_mason_learning(self):
+        from stronghold.types.agent import ReasoningResult
+
+        strategy = BuildersLearningStrategy()
+        diagnostics = {"all_passed": True, "issues": []}
+        result = ReasoningResult(response="done", done=True, tool_history=[{"tool": "shell"}])
+        # Should not raise
+        await strategy._store_mason_learning(diagnostics, result)


### PR DESCRIPTION
## Summary
**Slice E of #1098 breakdown.** Grab-bag of small infra + defensive fixes that don't fit any larger theme. No dependency on other slices.

| Where | Change |
|---|---|
| \`src/stronghold/api/routes/admin.py\` | **SEC-014**: wrap \`int(copper_amount)\` in try/except — returns 400 on non-numeric input instead of uncaught 500 |
| \`src/stronghold/agents/strategies/builders_learning.py\` | Replace silent \`except Exception: pass\` on ruff/mypy/pytest tool_executor calls with explicit issue append |
| \`.github/workflows/ci.yml\` | Run Security Tests / SAST / Tests in parallel — drop \`needs: lint\`. Runner labels unchanged. |
| \`.github/workflows/gatekeeper-review.yml\` *(new)* | Auto-APPROVE review when CI is green |
| \`scripts/cleanroom-lint.sh\` | Self-exclude from scan |
| \`deploy/helm/stronghold/values-prod-homelab.yaml\` | Point strongholdApi at local PVE registry (10.10.42.100:5000) |
| \`.gitignore\` | Ignore \`.claude/worktrees/\` |

## Test plan
- [x] 55 tests pass (builders_learning + admin_routes)
- [x] \`ruff check\` clean
- [x] \`ruff format --check\` clean
- [x] \`mypy --strict\` clean
- [x] Commit GPG-signed

## Skipped from #1098 (regressions vs current integration)
- \`ci-autofix.yml\` / \`cleanroom-lint.yml\` / \`drift-check.yml\` — obsolete k3s-runners label
- \`src/stronghold/agents/artificer/strategy.py\` rewrite — would revert C13 Sentinel+Warden+PII pipeline (merged as #1108)
- \`src/stronghold/worker_main.py\` deletion — still referenced by tests (\`test_new_modules_2.py\`, \`test_logging.py\`). Can ship in a follow-up that updates those tests.
- \`pyproject.toml\` coverage \`fail_under\` removal — referenced retired \`develop\` tier