### PR TITLE
fix(ci): gatekeeper-review uses self-hosted runner label

### DIFF
--- a/.github/workflows/gatekeeper-review.yml
+++ b/.github/workflows/gatekeeper-review.yml
@@ -18,7 +18,7 @@ concurrency:
 jobs:
   review:
     name: Gatekeeper auto-review
-    runs-on: k3s-runners
+    runs-on: [self-hosted, stronghold]
     if: >-
       github.event.workflow_run.conclusion == 'success' &&
       github.event.workflow_run.event == 'pull_request' &&


### PR DESCRIPTION
Small follow-up from #1120. The `gatekeeper-review.yml` I imported in Slice E still referenced the obsolete `k3s-runners` runner label. All other workflows target `[self-hosted, stronghold]` — this brings that one in line so the auto-review job can actually be picked up.