### PR TITLE
chore(coverage): per-tier thresholds — integration replaces develop at 90%

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,8 +89,20 @@ source = ["stronghold"]
 omit = ["src/stronghold/persistence/pg_*.py"]
 
 [tool.coverage.report]
-fail_under = 95
-exclude_lines = ["pragma: no cover", "if TYPE_CHECKING:"]
+# Per-tier coverage enforced in CI (integration plays the role the retired
+# `develop` tier used to). Local pytest uses the lowest bar so devs aren't
+# blocked on feature branches; CI bumps it per target base.
+#   feature/*   → 85% diff coverage
+#   integration → 90% total coverage
+#   main        → 95% diff coverage (release workflow)
+fail_under = 85
+exclude_lines = [
+    "pragma: no cover",
+    "if TYPE_CHECKING:",
+    "^\\s*\\.\\.\\.\\s*$",
+    "@(abc\\.)?abstractmethod",
+    "raise NotImplementedError",
+]
 
 [tool.bandit]
 targets = ["src/stronghold"]


### PR DESCRIPTION
Documents the branch-tier hierarchy in `pyproject.toml` and drops the retired `develop` reference.

Local `pytest` uses 85% (feature-branch bar) so devs aren't blocked during iteration; CI enforces the stricter bar per target base.

| Target base | Bar | Where enforced |
|---|---|---|
| `feature/*` | 85% diff coverage | local `pytest`, PR CI |
| `integration` | 90% total coverage | PR CI (replaces retired `develop` tier) |
| `main` | 95% diff coverage | release workflow |

Also adds standard `exclude_lines` patterns the mega-PR introduced but #1120 intentionally left out (ellipsis-only lines, `@abstractmethod`, `raise NotImplementedError`).