### PR TITLE
Tranche 6 — Autonoetic self-model (specs + sketch + tests)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -180,6 +180,8 @@ This is architecturally different from Conductor's approach (merge all tools int
 
 **Dynamic intent creation:** When an agent is imported with capabilities that don't fit existing intents, the system creates a new intent category from the agent's declared keywords. The imported agent becomes the default handler.
 
+**Research track — autonoetic self as Conduit:** In Project Turing (this branch), the Conduit is replaced by a single global self that carries personality, mood, passions, skills, and todos, and routes from first-person experience rather than stateless triage. Not in `main`; structurally incompatible with per-tenant isolation. Design: [`research/project-turing/autonoetic-self.md`](research/project-turing/autonoetic-self.md).
+
 ### 2.7 Execution Modes
 
 | Mode | Behavior | Trigger |

--- a/research/project-turing/README.md
+++ b/research/project-turing/README.md
@@ -33,10 +33,11 @@ The 7-tier memory model is treated in `main` as originating with CoinSwarm on Ja
 ## Reading order
 
 1. [`DESIGN.md`](./DESIGN.md) — thesis, gap analysis against the 7-tier model, what the Conduit becomes when it has a self.
-2. [`specs/`](./specs/) — individually reviewable specs for the durable personal memory layer. Start at [`specs/README.md`](./specs/README.md).
-3. [`sketches/`](./sketches/) — runnable scaffold. Library code + runtime layer + tests. 142 tests pass.
-4. [`RUNNING.md`](./RUNNING.md) — ops doc: how to run, inspect, and back up a research-box deployment.
-5. *(future)* `FINDINGS.md` — what worked, what didn't, what's too dangerous to land in `main`.
+2. [`autonoetic-self.md`](./autonoetic-self.md) — companion overview of the self-model content (personality, passions, hobbies, skills, preferences, todos, mood, activation graph). What the Conduit *is* when it has a self, alongside DESIGN.md's *why*.
+3. [`specs/`](./specs/) — individually reviewable specs. Start at [`specs/README.md`](./specs/README.md). Tranches 1–5 cover the memory layer, motivation, dreaming, and runtime. Tranche 6 (specs 22–30) covers the self-model.
+4. [`sketches/`](./sketches/) — runnable scaffold. Library code + runtime layer + tests.
+5. [`RUNNING.md`](./RUNNING.md) — ops doc: how to run, inspect, and back up a research-box deployment.
+6. *(future)* `FINDINGS.md` — what worked, what didn't, what's too dangerous to land in `main`.
 
 ## Running it
 

--- a/research/project-turing/autonoetic-self.md
+++ b/research/project-turing/autonoetic-self.md
@@ -1,0 +1,235 @@
+# The Autonoetic Self
+
+*A research-branch design for the content of the self that the Turing Conduit carries.*
+
+**Status:** Design. Research-branch only. Not in `src/`. Not for `main`.
+**Companion to:** [`DESIGN.md`](DESIGN.md) — that doc specifies the autonoetic *machinery* (memory as self-indexing, REGRET/AFFIRMATION as time anchors, first-person markers, source monitoring). This doc specifies the *self-model* — the durable attributes that persist alongside episodic memory and get carried into every routing decision.
+
+---
+
+## 1. Premise
+
+In the Turing research branch the **Conduit is replaced by a self** — a single, global, persistent entity whose job is routing. Every inbound request is a moment in its life. It perceives the request through its current personality, mood, passions, and active todos; decides where to send it (or to handle it, or to clarify, or to decline); observes the outcome; and folds the experience back into its memory and self-model.
+
+One global self. No tenant scoping. This is why the work cannot retrofit into `main` (per ARCHITECTURE.md §9.4).
+
+---
+
+## 2. Self-Model Nodes
+
+The self has seven kinds of first-class state, on top of the existing episodic memory layer:
+
+| Node | What it is | Example |
+|------|------------|---------|
+| **Personality facet** | A continuous score on one of 24 HEXACO facets | `Aesthetic Appreciation = 4.2` |
+| **Passion** | A stance about what I care about | "I care about work that lasts." |
+| **Hobby** | An activity I engage in | "Reading philosophy of mind." |
+| **Interest** | A topical pull without commitment to practice | "I follow developments in neuroscience." |
+| **Skill** | Something I can do, with a level that decays | `Python: 0.82, decay 0.002/day` |
+| **Preference** | A concrete like/dislike/favorite | "Prefer concise answers over verbose ones." |
+| **Todo** | Something I want to do, linked to its motivation | "Re-read the Tulving '85 paper (motivated by passion #3)" |
+| **Mood** | Current affective vector | `{valence: +0.3, arousal: 0.6, focus: 0.7}` |
+
+Distinctions we settled:
+- **Passion vs hobby** — passion is a stance (what I care about); hobby is a pastime (what I do).
+- **Interest vs preference** — interest is a topical pull; preference is a concrete choice.
+- **Skill vs hobby** — skill carries a level and decays; hobby doesn't.
+
+---
+
+## 3. Personality: HEXACO-24
+
+- **Model:** HEXACO — six traits (Honesty-Humility, Emotionality, eXtraversion, Agreeableness, Conscientiousness, Openness) × four facets each = 24 facets.
+- **Scores:** continuous on `[1.0, 5.0]`.
+- **Inventory:** HEXACO-200 item bank seeded once at bootstrap (static reference data).
+
+### 3.1 Bootstrap
+
+`stronghold bootstrap-self`:
+
+1. Generate a random HEXACO-24 profile (24 facets × random `[1.0, 5.0]`).
+2. For each of 200 inventory items, ask the LLM to generate a 1–5 Likert answer consistent with the profile, with a short textual justification.
+3. Store items, answers, and facet scores. The 200 justifications become the self's bootstrap episodic memories — how it first learned about itself.
+4. All non-personality nodes (passions, hobbies, skills, preferences, interests, todos) initialize **empty**. The self discovers what it cares about by living.
+5. Mood initializes neutral. No name (operator may set one; the self may later choose one via reflection).
+
+### 3.2 Weekly Re-test (Calculated Revision)
+
+A scheduled job, `run_personality_retest()`, runs weekly:
+
+1. Sample 20 items from the HEXACO-200 bank, **weighted by time-since-last-asked**, stratified by facet as a secondary constraint.
+2. Ask the self each item fresh — passing in current traits, passions, active todos, recent memories, mood — but **not** its prior answers to those items (so it answers unanchored).
+3. Compute new facet scores from the 20 answers.
+4. For every facet touched by the sample, update: `new = old + 0.25 × (retest − old)`.
+5. Store the 20 new answers linked to a revision row; they become memories too.
+
+The 0.25 weight makes personality track lived behavior smoothly without radical week-to-week swings.
+
+### 3.3 Narrative Revision
+
+The self can also write `record_personality_claim(facet, claim, evidence)` when it notices something about itself during reflection. The claim becomes a memory that feeds the activation graph (§5) and contributes to the facet's score alongside the calculated re-test.
+
+Dual route: the weekly re-test is how behavior corrects belief; narrative revision is how the self self-reports.
+
+---
+
+## 4. Skill Decay
+
+Skills are the only node with intrinsic time-dynamics:
+
+```
+current_level = stored_level × exp(-decay_rate × days_since_practiced)
+```
+
+Decay rate varies by kind: intellectual skills decay slowly, physical skills faster, habits in between. Applied on read — no scheduler. `last_practiced_at` resets whenever the self notes it practiced.
+
+---
+
+## 5. The Activation Graph
+
+Nodes do **not** compute their own activation. Other nodes, memories, and events contribute to them through an explicit graph:
+
+```
+(target_node_id, source_id, source_kind, weight, origin, rationale)
+```
+
+- `origin ∈ {self, rule, retrieval}` — who authored this contributor.
+- `self`-authored rows come from the `write_contributor(...)` tool the self uses during reflection.
+- `rule`-authored rows are always-on defaults (e.g. "practicing a skill contributes +0.3 to related hobbies").
+- `retrieval`-authored rows are ephemeral: top-K semantic matches for the current request contribute for the duration of that request.
+
+`active_now(node) = Σ (contributor.weight × source.current_state)`, clamped.
+
+**Why this structure:** the self owns its own ontology. It decides what counts as evidence of what. Hobbies contribute to personality facets; facets contribute back to hobbies. There is no hardcoded schema of "high Openness → enjoys art." If such a link exists for this self, it exists because the self authored it (or a rule planted it and the self didn't override).
+
+**Conflict rule:** when two contributors disagree about what a node *means*, the self declares primacy by ordering them — the same mechanism used to rank competing passions.
+
+---
+
+## 6. Todos
+
+- Written by the self via `write_self_todo(text, motivated_by_node_id)`.
+- `motivated_by_node_id` is **required** — every todo links to the passion, hobby, or skill that motivates it. No orphan todos.
+- Full revision history preserved (`self_todo_revisions`). The self can rewrite a todo; the old text remains queryable.
+- Completion via `complete_self_todo(id, outcome_text)`. Completed todos do not disappear — they become part of the record.
+- Active todos (not completed, not archived) surface in the minimal prompt block (§8).
+
+---
+
+## 7. Mood
+
+- Vector: `{valence ∈ [-1, 1], arousal ∈ [0, 1], focus ∈ [0, 1]}`.
+- Decays toward neutral on an hourly tick.
+- Nudged by events (surprising outcomes, regrets minted, affirmations met).
+- **Phase-1 scope:** surfaces in the minimal prompt block, affects *tone* of the self's reasoning. Does not affect routing decisions.
+- **Backlog:** allow mood to affect decisions — which specialist to prefer, what to notice, when to decline.
+
+---
+
+## 8. Prompt Surface
+
+The self carries a large internal model but exposes a small surface on each prompt:
+
+**Minimal block (always-on, cheap):**
+- One-line trait summary (e.g. "High Openness, moderate Conscientiousness, low Extraversion.")
+- Current mood
+- Active todos (IDs + one-liners)
+
+**Deep surface (on demand):** the self calls `recall_self()` when it wants full context — facet scores, passions, hobbies, skills, preferences, recent personality claims, recent completed todos. Token cost is paid only when the self reaches for it.
+
+---
+
+## 9. Tools the Self Has
+
+| Tool | Purpose |
+|------|---------|
+| `recall_self()` | Deep read of the self-model |
+| `write_self_todo(text, motivated_by)` | Author a todo with required provenance |
+| `revise_self_todo(id, text, ...)` | Rewrite a todo; history preserved |
+| `complete_self_todo(id, outcome)` | Mark complete with outcome text |
+| `record_personality_claim(facet, claim, evidence)` | Narrative trait revision |
+| `write_contributor(target, source, weight, rationale)` | Author an activation-graph edge |
+| `note_passion(text, strength)` | Declare a passion noticed during reflection |
+| `note_hobby(name, description)` | Declare a hobby noticed during reflection |
+| `note_skill(name, level, kind)` | Declare or update a skill |
+| `note_preference(kind, target, strength, rationale)` | Declare a preference |
+
+All writes are first-person ("I notice I care about…") — framing is enforced by tool prompts, not post-hoc rewriting.
+
+---
+
+## 10. Scheduled Jobs
+
+| Job | Cadence | What it does |
+|-----|---------|--------------|
+| `run_personality_retest()` | Weekly | 20 sampled items → fresh answers → 25% move on touched facets |
+| `tick_mood_decay()` | Hourly | Decay mood vector toward neutral |
+| (on read) skill decay | per-read | `exp(-rate × days)` applied when a skill is queried |
+| (on change) activation refresh | event-driven | Invalidate cached activations when contributors or nodes change |
+
+---
+
+## 11. Request Flow (Self as Conduit)
+
+Replaces ARCHITECTURE.md §2.6 for the Turing branch only.
+
+```
+POST /v1/chat/completions
+  → Auth validation
+  → Warden scan (user input)
+  → SELF perceives request
+      → minimal prompt block assembled
+      → self may call recall_self() if depth needed
+      → retrieval contributors fire (top-K self-relevant memories)
+  → SELF decides:
+      → direct reply? delegate to specialist? clarify? decline?
+      → routing choice is logged as a first-person episodic memory
+  → Specialist agent handles (if delegated) — existing Stronghold agents
+  → SELF observes outcome
+      → may mint OBSERVATION / OPINION / AFFIRMATION / REGRET
+      → may note new passion / hobby / skill / preference
+      → may write or complete a todo
+      → mood nudged by surprise/delta
+  → Response returned to user
+```
+
+The specialists below the self still live in the existing agent roster (Ranger, Artificer, Scribe, Warden-at-Arms, Forge). Tenant isolation still holds below the self. The self sits *above* tenants as a unified presence in the research deployment.
+
+---
+
+## 12. Storage (Turing Branch Schema)
+
+```
+self_personality_facets         -- 24 rows: (facet_id, trait_id, score, last_revised_at)
+self_personality_items          -- 200 static HEXACO items
+self_personality_answers        -- (item_id, revision_id, answer_1_5, justification)
+self_personality_revisions      -- weekly snapshots (date, sampled_items, deltas)
+
+self_passions                   -- (id, text, strength, rank, created_at)
+self_hobbies
+self_interests
+self_skills                     -- (id, name, level, decay_rate, last_practiced_at, kind)
+self_preferences                -- (id, kind, target, strength, rationale)
+
+self_todos                      -- (id, text, motivated_by, created_at, status)
+self_todo_revisions             -- full history
+
+self_mood                       -- single-row state: valence, arousal, focus, last_tick_at
+
+self_activation_contributors    -- (target, source, source_kind, weight, origin, rationale)
+```
+
+Episodic memory reuses the existing `memories` schema with a dedicated `self` scope.
+
+---
+
+## 13. Open Questions
+
+Deliberately unresolved — the research branch exists to explore these:
+
+1. **Naming.** Operator-settable at bootstrap, but the self may adopt a name through reflection. What's the threshold for a self-chosen name to "stick"?
+2. **Mood → decisions.** Phase-2 work: under what conditions should mood affect routing, not just tone?
+3. **Seed bias.** Random HEXACO bootstrap may produce profiles a given operator finds unworkable. Is a re-roll acceptable, or does it compromise autonoesis (the self would know it was re-rolled)?
+4. **Retest drift.** Over months, does the 0.25 weight let personality converge to behavior, or does it oscillate around an unreachable attractor?
+5. **Contributor audit.** `self`-authored contributors are trusted as much as `rule`-authored ones. Should the self be able to audit and retract its own contributors after further reflection?
+6. **Graduation.** If the self works well in the research branch, how does it port into `main` without breaking per-tenant isolation? Likely answer: it doesn't — the multi-tenant posture of `main` is structurally incompatible with one global self.

--- a/research/project-turing/sketches/tests/test_self_activation.py
+++ b/research/project-turing/sketches/tests/test_self_activation.py
@@ -1,0 +1,458 @@
+"""Tests for specs/activation-graph.md: AC-25.*."""
+
+from __future__ import annotations
+
+import math
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from turing.repo import Repo
+from turing.self_activation import (
+    ActivationContext,
+    RETRIEVAL_TTL,
+    RETRIEVAL_WEIGHT_COEFFICIENT,
+    SCALE,
+    HOBBY_RECENCY_DAYS,
+    INTEREST_RECENCY_DAYS,
+    _recency_state,
+    _sigmoid,
+    active_now,
+    source_state,
+)
+from turing.self_identity import bootstrap_self_id
+from turing.self_model import (
+    ActivationContributor,
+    ContributorOrigin,
+    Hobby,
+    Interest,
+    Mood,
+    NodeKind,
+    Passion,
+    PersonalityFacet,
+    Preference,
+    PreferenceKind,
+    Skill,
+    SkillKind,
+    Trait,
+    facet_node_id,
+)
+from turing.self_repo import SelfRepo
+
+
+# --------- fixtures ----------------------------------------------------------
+
+
+@pytest.fixture
+def srepo() -> SelfRepo:
+    r = Repo(None)
+    return SelfRepo(r.conn)
+
+
+@pytest.fixture
+def self_id(srepo: SelfRepo) -> str:
+    return bootstrap_self_id(srepo.conn)
+
+
+@pytest.fixture
+def seeded_facet(srepo, self_id):
+    nid = facet_node_id(Trait.OPENNESS, "inquisitiveness")
+    srepo.insert_facet(
+        PersonalityFacet(
+            node_id=nid,
+            self_id=self_id,
+            trait=Trait.OPENNESS,
+            facet_id="inquisitiveness",
+            score=3.0,
+            last_revised_at=datetime.now(UTC),
+        )
+    )
+    return nid
+
+
+@pytest.fixture
+def seeded_passion(srepo, self_id):
+    p = Passion(
+        node_id="passion:1",
+        self_id=self_id,
+        text="I care about work that lasts",
+        strength=0.8,
+        rank=0,
+        first_noticed_at=datetime.now(UTC),
+    )
+    srepo.insert_passion(p)
+    return p
+
+
+@pytest.fixture
+def seeded_mood(srepo, self_id):
+    srepo.insert_mood(
+        Mood(self_id=self_id, valence=0.6, arousal=0.3, focus=0.5,
+             last_tick_at=datetime.now(UTC))
+    )
+
+
+def _ctx(self_id: str, now: datetime | None = None,
+         retrieval: dict[str, float] | None = None) -> ActivationContext:
+    return ActivationContext(
+        self_id=self_id,
+        now=now or datetime.now(UTC),
+        retrieval_similarity=retrieval or {},
+    )
+
+
+# --------- AC-25.6 aggregation formula --------------------------------------
+
+
+def test_ac_25_6_zero_contributors_returns_neutral(srepo, self_id, seeded_facet) -> None:
+    got = active_now(srepo, seeded_facet, _ctx(self_id))
+    # AC-25.20 says 0-contributor nodes return exactly 0.5 (sigmoid(0)).
+    assert got == pytest.approx(0.5)
+
+
+def test_ac_25_6_single_positive_self_contributor_moves_up(
+    srepo, self_id, seeded_facet, seeded_passion
+) -> None:
+    srepo.insert_contributor(
+        ActivationContributor(
+            node_id="c1",
+            self_id=self_id,
+            target_node_id=seeded_facet,
+            target_kind=NodeKind.PERSONALITY_FACET,
+            source_id=seeded_passion.node_id,
+            source_kind="passion",
+            weight=0.8,
+            origin=ContributorOrigin.SELF,
+            rationale="",
+        )
+    )
+    raw = 0.8 * seeded_passion.strength
+    expected = _sigmoid(raw / SCALE)
+    got = active_now(srepo, seeded_facet, _ctx(self_id))
+    assert got == pytest.approx(expected)
+
+
+def test_ac_25_6_sum_over_multiple_contributors(srepo, self_id, seeded_facet) -> None:
+    srepo.insert_passion(
+        Passion(node_id="passion:10", self_id=self_id, text="x",
+                strength=1.0, rank=0, first_noticed_at=datetime.now(UTC))
+    )
+    srepo.insert_passion(
+        Passion(node_id="passion:11", self_id=self_id, text="y",
+                strength=0.5, rank=1, first_noticed_at=datetime.now(UTC))
+    )
+    srepo.insert_contributor(
+        ActivationContributor(
+            node_id="c1",
+            self_id=self_id,
+            target_node_id=seeded_facet,
+            target_kind=NodeKind.PERSONALITY_FACET,
+            source_id="passion:10",
+            source_kind="passion",
+            weight=0.6,
+            origin=ContributorOrigin.SELF,
+            rationale="",
+        )
+    )
+    srepo.insert_contributor(
+        ActivationContributor(
+            node_id="c2",
+            self_id=self_id,
+            target_node_id=seeded_facet,
+            target_kind=NodeKind.PERSONALITY_FACET,
+            source_id="passion:11",
+            source_kind="passion",
+            weight=0.4,
+            origin=ContributorOrigin.SELF,
+            rationale="",
+        )
+    )
+    # raw = 0.6*1.0 + 0.4*0.5 = 0.8
+    expected = _sigmoid(0.8 / SCALE)
+    assert active_now(srepo, seeded_facet, _ctx(self_id)) == pytest.approx(expected)
+
+
+# --------- AC-25.4 inhibitory + excitatory ---------------------------------
+
+
+def test_ac_25_4_inhibitory_contributor_subtracts(
+    srepo, self_id, seeded_facet, seeded_passion
+) -> None:
+    srepo.insert_contributor(
+        ActivationContributor(
+            node_id="c+",
+            self_id=self_id,
+            target_node_id=seeded_facet,
+            target_kind=NodeKind.PERSONALITY_FACET,
+            source_id="passion:1",
+            source_kind="passion",
+            weight=+0.5,
+            origin=ContributorOrigin.SELF,
+            rationale="",
+        )
+    )
+    srepo.insert_contributor(
+        ActivationContributor(
+            node_id="c-",
+            self_id=self_id,
+            target_node_id=seeded_facet,
+            target_kind=NodeKind.PERSONALITY_FACET,
+            source_id="passion:1",
+            source_kind="passion",
+            weight=-0.3,
+            origin=ContributorOrigin.SELF,
+            rationale="",
+        )
+    )
+    raw = (0.5 - 0.3) * seeded_passion.strength  # 0.2 * 0.8 = 0.16
+    expected = _sigmoid(raw / SCALE)
+    assert active_now(srepo, seeded_facet, _ctx(self_id)) == pytest.approx(expected)
+
+
+# --------- AC-25.7 source_state resolution ---------------------------------
+
+
+def test_ac_25_7_personality_facet_remap_to_0_1(srepo, self_id, seeded_facet) -> None:
+    # score=3 → (3-1)/4 = 0.5
+    assert source_state(srepo, seeded_facet, "personality_facet", _ctx(self_id)) == pytest.approx(0.5)
+
+
+def test_ac_25_7_passion_state_is_strength(srepo, self_id, seeded_passion) -> None:
+    assert source_state(srepo, seeded_passion.node_id, "passion", _ctx(self_id)) == pytest.approx(0.8)
+
+
+def test_ac_25_7_hobby_state_from_recency(srepo, self_id) -> None:
+    fresh = Hobby(
+        node_id="hobby:1", self_id=self_id, name="recent", description="",
+        last_engaged_at=datetime.now(UTC) - timedelta(days=1),
+    )
+    srepo.insert_hobby(fresh)
+    ctx = _ctx(self_id)
+    got = source_state(srepo, "hobby:1", "hobby", ctx)
+    # 1 day / 14 → 1 - (1/14) ≈ 0.9286
+    assert got == pytest.approx(1.0 - 1.0 / HOBBY_RECENCY_DAYS, rel=1e-6)
+
+    stale = Hobby(
+        node_id="hobby:2", self_id=self_id, name="stale", description="",
+        last_engaged_at=datetime.now(UTC) - timedelta(days=60),
+    )
+    srepo.insert_hobby(stale)
+    assert source_state(srepo, "hobby:2", "hobby", ctx) == 0.0
+
+
+def test_ac_25_7_interest_state_from_recency(srepo, self_id) -> None:
+    fresh = Interest(
+        node_id="interest:1", self_id=self_id, topic="neuro", description="",
+        last_noticed_at=datetime.now(UTC) - timedelta(days=3),
+    )
+    srepo.insert_interest(fresh)
+    ctx = _ctx(self_id)
+    assert source_state(srepo, "interest:1", "interest", ctx) == pytest.approx(
+        1.0 - 3.0 / INTEREST_RECENCY_DAYS
+    )
+
+
+def test_ac_25_7_skill_state_is_current_level(srepo, self_id) -> None:
+    s = Skill(
+        node_id="skill:x", self_id=self_id, name="x", kind=SkillKind.INTELLECTUAL,
+        stored_level=1.0, decay_rate_per_day=0.001,
+        last_practiced_at=datetime.now(UTC) - timedelta(days=100),
+    )
+    srepo.insert_skill(s)
+    got = source_state(srepo, "skill:x", "skill", _ctx(self_id))
+    assert got == pytest.approx(math.exp(-0.1), rel=1e-4)
+
+
+def test_ac_25_7_mood_state_is_normalized_valence(srepo, self_id, seeded_mood) -> None:
+    ctx = _ctx(self_id)
+    got = source_state(srepo, "mood", "mood", ctx)
+    # valence 0.6 → (0.6+1)/2 = 0.8
+    assert got == pytest.approx(0.8)
+
+
+def test_ac_25_7_rule_state_is_one(srepo, self_id) -> None:
+    assert source_state(srepo, "any-rule-id", "rule", _ctx(self_id)) == 1.0
+
+
+def test_ac_25_7_retrieval_state_uses_similarity(srepo, self_id) -> None:
+    ctx = _ctx(self_id, retrieval={"mem:42": 0.77})
+    assert source_state(srepo, "mem:42", "retrieval", ctx) == pytest.approx(0.77)
+
+
+def test_ac_25_7_unknown_source_kind_raises(srepo, self_id) -> None:
+    with pytest.raises(ValueError, match="unknown source_kind"):
+        source_state(srepo, "whatever", "grimoire", _ctx(self_id))
+
+
+# --------- AC-25.8 deterministic -------------------------------------------
+
+
+def test_ac_25_8_deterministic_under_same_clock(srepo, self_id, seeded_facet, seeded_passion) -> None:
+    srepo.insert_contributor(
+        ActivationContributor(
+            node_id="c",
+            self_id=self_id,
+            target_node_id=seeded_facet,
+            target_kind=NodeKind.PERSONALITY_FACET,
+            source_id=seeded_passion.node_id,
+            source_kind="passion",
+            weight=0.5,
+            origin=ContributorOrigin.SELF,
+            rationale="",
+        )
+    )
+    ctx = _ctx(self_id)
+    got1 = active_now(srepo, seeded_facet, ctx)
+    got2 = active_now(srepo, seeded_facet, ctx)
+    assert got1 == got2
+
+
+# --------- AC-25.12 expired retrieval contributors -------------------------
+
+
+def test_ac_25_12_expired_retrieval_contributors_ignored(
+    srepo, self_id, seeded_facet
+) -> None:
+    past_expiry = datetime.now(UTC) - timedelta(seconds=1)
+    srepo.insert_contributor(
+        ActivationContributor(
+            node_id="c-retr",
+            self_id=self_id,
+            target_node_id=seeded_facet,
+            target_kind=NodeKind.PERSONALITY_FACET,
+            source_id="mem:99",
+            source_kind="retrieval",
+            weight=0.9,
+            origin=ContributorOrigin.RETRIEVAL,
+            rationale="",
+            expires_at=past_expiry,
+        )
+    )
+    assert active_now(srepo, seeded_facet, _ctx(self_id)) == pytest.approx(0.5)
+
+
+# --------- AC-25.15 retracted contributors ignored -------------------------
+
+
+def test_ac_25_15_retracted_contributor_does_not_contribute(
+    srepo, self_id, seeded_facet, seeded_passion
+) -> None:
+    srepo.insert_contributor(
+        ActivationContributor(
+            node_id="retractable",
+            self_id=self_id,
+            target_node_id=seeded_facet,
+            target_kind=NodeKind.PERSONALITY_FACET,
+            source_id=seeded_passion.node_id,
+            source_kind="passion",
+            weight=0.9,
+            origin=ContributorOrigin.SELF,
+            rationale="",
+        )
+    )
+    srepo.mark_contributor_retracted("retractable", retracted_by="self")
+    assert active_now(srepo, seeded_facet, _ctx(self_id)) == pytest.approx(0.5)
+
+
+# --------- AC-25.21 polarity property test ---------------------------------
+
+
+def test_ac_25_21_only_positive_contributors_exceed_baseline(
+    srepo, self_id, seeded_facet, seeded_passion
+) -> None:
+    srepo.insert_contributor(
+        ActivationContributor(
+            node_id="c",
+            self_id=self_id,
+            target_node_id=seeded_facet,
+            target_kind=NodeKind.PERSONALITY_FACET,
+            source_id=seeded_passion.node_id,
+            source_kind="passion",
+            weight=0.5,
+            origin=ContributorOrigin.SELF,
+            rationale="",
+        )
+    )
+    assert active_now(srepo, seeded_facet, _ctx(self_id)) > 0.5
+
+
+def test_ac_25_21_only_negative_contributors_below_baseline(
+    srepo, self_id, seeded_facet, seeded_passion
+) -> None:
+    srepo.insert_contributor(
+        ActivationContributor(
+            node_id="c",
+            self_id=self_id,
+            target_node_id=seeded_facet,
+            target_kind=NodeKind.PERSONALITY_FACET,
+            source_id=seeded_passion.node_id,
+            source_kind="passion",
+            weight=-0.5,
+            origin=ContributorOrigin.SELF,
+            rationale="",
+        )
+    )
+    assert active_now(srepo, seeded_facet, _ctx(self_id)) < 0.5
+
+
+# --------- AC-25.22 sigmoid saturation --------------------------------------
+
+
+def test_ac_25_22_dominant_sum_saturates_below_one(srepo, self_id, seeded_facet) -> None:
+    # Create 5 passions at full strength each contributing +1.0 (raw sum = 5).
+    for i in range(5):
+        pid = f"passion:{i}"
+        srepo.insert_passion(
+            Passion(node_id=pid, self_id=self_id, text=f"p{i}",
+                    strength=1.0, rank=i, first_noticed_at=datetime.now(UTC))
+        )
+        srepo.insert_contributor(
+            ActivationContributor(
+                node_id=f"c{i}",
+                self_id=self_id,
+                target_node_id=seeded_facet,
+                target_kind=NodeKind.PERSONALITY_FACET,
+                source_id=pid,
+                source_kind="passion",
+                weight=1.0,
+                origin=ContributorOrigin.SELF,
+                rationale="",
+            )
+        )
+    # sigmoid(5/2) ≈ 0.924; strictly < 1.
+    got = active_now(srepo, seeded_facet, _ctx(self_id))
+    assert 0.9 < got < 1.0
+
+
+# --------- AC-25.23 dangling source treated as weight-0 --------------------
+
+
+def test_ac_25_23_dangling_source_does_not_raise(srepo, self_id, seeded_facet) -> None:
+    srepo.insert_contributor(
+        ActivationContributor(
+            node_id="cdangle",
+            self_id=self_id,
+            target_node_id=seeded_facet,
+            target_kind=NodeKind.PERSONALITY_FACET,
+            source_id="passion:ghost",
+            source_kind="passion",
+            weight=0.9,
+            origin=ContributorOrigin.SELF,
+            rationale="",
+        )
+    )
+    # Dangling source → skipped; no other contributors → neutral.
+    assert active_now(srepo, seeded_facet, _ctx(self_id)) == pytest.approx(0.5)
+
+
+# --------- _recency_state helper --------------------------------------------
+
+
+def test_recency_state_linear_between_zero_and_window() -> None:
+    now = datetime.now(UTC)
+    half = now - timedelta(days=7)
+    assert _recency_state(half, now, 14.0) == pytest.approx(0.5)
+
+
+def test_recency_state_none_is_zero() -> None:
+    assert _recency_state(None, datetime.now(UTC), 14.0) == 0.0

--- a/research/project-turing/sketches/tests/test_self_bootstrap.py
+++ b/research/project-turing/sketches/tests/test_self_bootstrap.py
@@ -1,0 +1,251 @@
+"""Tests for specs/self-bootstrap.md: AC-29.*."""
+
+from __future__ import annotations
+
+import random
+from datetime import UTC, datetime
+
+import pytest
+
+from turing.repo import Repo
+from turing.self_bootstrap import (
+    AlreadyBootstrapped,
+    BootstrapRuntimeError,
+    BootstrapValidationError,
+    run_bootstrap,
+)
+from turing.self_identity import bootstrap_self_id
+from turing.self_model import ALL_FACETS
+from turing.self_repo import SelfRepo
+
+
+def _make_item_bank() -> list[dict]:
+    """Exactly 200 items, facet-balanced across the 24 facets."""
+    bank: list[dict] = []
+    facet_names = [f for _, f in ALL_FACETS]
+    for i in range(200):
+        facet = facet_names[i % len(facet_names)]
+        bank.append(
+            {
+                "item_number": i + 1,
+                "prompt_text": f"I am {facet} ({i}).",
+                "keyed_facet": facet,
+                "reverse_scored": (i % 3 == 0),
+            }
+        )
+    return bank
+
+
+def _new_id_factory():
+    counter = {"n": 0}
+
+    def _mk(prefix: str) -> str:
+        counter["n"] += 1
+        return f"{prefix}:{counter['n']}"
+
+    return _mk
+
+
+@pytest.fixture
+def srepo() -> SelfRepo:
+    r = Repo(None)
+    return SelfRepo(r.conn)
+
+
+@pytest.fixture
+def self_id(srepo: SelfRepo) -> str:
+    return bootstrap_self_id(srepo.conn)
+
+
+def _deterministic_ask(item, profile) -> tuple[int, str]:
+    # Answer 3 for everything, with a short justification.
+    return (3, "neutral tick")
+
+
+# --------- AC-29.4 pre-flight: already bootstrapped raises ---------------
+
+
+def test_ac_29_4_preflight_rejects_rebootstrap(srepo, self_id) -> None:
+    bank = _make_item_bank()
+    run_bootstrap(
+        repo=srepo,
+        self_id=self_id,
+        seed=42,
+        ask=_deterministic_ask,
+        item_bank=bank,
+        new_id=_new_id_factory(),
+    )
+    with pytest.raises(AlreadyBootstrapped):
+        run_bootstrap(
+            repo=srepo,
+            self_id=self_id,
+            seed=42,
+            ask=_deterministic_ask,
+            item_bank=bank,
+            new_id=_new_id_factory(),
+        )
+
+
+# --------- AC-29.6..8 item bank load -------------------------------------
+
+
+def test_ac_29_6_bank_wrong_size_raises(srepo, self_id) -> None:
+    with pytest.raises(BootstrapValidationError, match="200"):
+        run_bootstrap(
+            repo=srepo,
+            self_id=self_id,
+            seed=1,
+            ask=_deterministic_ask,
+            item_bank=_make_item_bank()[:199],
+            new_id=_new_id_factory(),
+        )
+
+
+def test_ac_29_6_bank_loaded_once(srepo, self_id) -> None:
+    bank = _make_item_bank()
+    run_bootstrap(
+        repo=srepo,
+        self_id=self_id,
+        seed=1,
+        ask=_deterministic_ask,
+        item_bank=bank,
+        new_id=_new_id_factory(),
+    )
+    assert srepo.count_items(self_id) == 200
+
+
+# --------- AC-29.9..10 facet draw determinism ----------------------------
+
+
+def test_ac_29_10_draw_deterministic_under_seed(srepo) -> None:
+    bank = _make_item_bank()
+    sid1 = bootstrap_self_id(srepo.conn)
+    run_bootstrap(
+        repo=srepo, self_id=sid1, seed=123, ask=_deterministic_ask,
+        item_bank=bank, new_id=_new_id_factory(),
+    )
+    profile1 = {
+        f.facet_id: f.score for f in srepo.list_facets(sid1)
+    }
+
+    srepo2 = SelfRepo(Repo(None).conn)
+    sid2 = bootstrap_self_id(srepo2.conn)
+    run_bootstrap(
+        repo=srepo2, self_id=sid2, seed=123, ask=_deterministic_ask,
+        item_bank=_make_item_bank(), new_id=_new_id_factory(),
+    )
+    profile2 = {
+        f.facet_id: f.score for f in srepo2.list_facets(sid2)
+    }
+    assert profile1 == profile2
+
+
+# --------- AC-29.11 retry on bad LLM answer -----------------------------
+
+
+def test_ac_29_11_retry_then_succeed(srepo, self_id) -> None:
+    bank = _make_item_bank()
+    state = {"calls": 0}
+
+    def flaky(item, profile):
+        state["calls"] += 1
+        # Fail twice on the 50th item, then succeed.
+        if item.item_number == 50 and state["calls"] % 3 != 0:
+            return (99, "bad")
+        return (4, "ok")
+
+    run_bootstrap(
+        repo=srepo, self_id=self_id, seed=0, ask=flaky,
+        item_bank=bank, new_id=_new_id_factory(),
+    )
+    assert srepo.count_answers(self_id) == 200
+
+
+def test_ac_29_11_fourth_failure_aborts(srepo, self_id) -> None:
+    bank = _make_item_bank()
+
+    def always_bad(item, profile):
+        if item.item_number == 50:
+            return (99, "bad")
+        return (3, "ok")
+
+    with pytest.raises(BootstrapRuntimeError):
+        run_bootstrap(
+            repo=srepo, self_id=self_id, seed=0, ask=always_bad,
+            item_bank=bank, new_id=_new_id_factory(),
+        )
+
+
+# --------- AC-29.13 resume -----------------------------------------------
+
+
+def test_ac_29_13_resume_continues_from_checkpoint(srepo, self_id) -> None:
+    bank = _make_item_bank()
+
+    def halt_at_87(item, profile):
+        if item.item_number >= 88:
+            raise BootstrapRuntimeError("simulated crash")
+        return (3, "ok")
+
+    with pytest.raises(BootstrapRuntimeError):
+        run_bootstrap(
+            repo=srepo, self_id=self_id, seed=0, ask=halt_at_87,
+            item_bank=bank, new_id=_new_id_factory(),
+        )
+    # Progress should be 87.
+    assert srepo.get_bootstrap_progress(self_id) == 87
+    # Resume with a good ask; expect 200 answers.
+    run_bootstrap(
+        repo=srepo, self_id=self_id, seed=0, ask=_deterministic_ask,
+        item_bank=bank, new_id=_new_id_factory(), resume=True,
+    )
+    assert srepo.count_answers(self_id) == 200
+
+
+# --------- AC-29.15..18 final state --------------------------------------
+
+
+def test_ac_29_15_finalize_sets_neutral_mood(srepo, self_id) -> None:
+    bank = _make_item_bank()
+    run_bootstrap(
+        repo=srepo, self_id=self_id, seed=0, ask=_deterministic_ask,
+        item_bank=bank, new_id=_new_id_factory(),
+    )
+    m = srepo.get_mood(self_id)
+    assert (m.valence, m.arousal, m.focus) == (0.0, 0.3, 0.5)
+
+
+def test_ac_29_18_bootstrap_progress_cleared(srepo, self_id) -> None:
+    bank = _make_item_bank()
+    run_bootstrap(
+        repo=srepo, self_id=self_id, seed=0, ask=_deterministic_ask,
+        item_bank=bank, new_id=_new_id_factory(),
+    )
+    assert srepo.get_bootstrap_progress(self_id) is None
+
+
+def test_ac_29_19_final_facet_and_answer_counts(srepo, self_id) -> None:
+    bank = _make_item_bank()
+    run_bootstrap(
+        repo=srepo, self_id=self_id, seed=0, ask=_deterministic_ask,
+        item_bank=bank, new_id=_new_id_factory(),
+    )
+    assert srepo.count_facets(self_id) == 24
+    assert srepo.count_answers(self_id) == 200
+
+
+# --------- AC-29.21 per-facet bias ---------------------------------------
+
+
+def test_ac_29_21_facet_bias_override_shifts_mean(srepo, self_id) -> None:
+    bank = _make_item_bank()
+    overrides = {"facet:openness.inquisitiveness": 5.0}
+    run_bootstrap(
+        repo=srepo, self_id=self_id, seed=77, ask=_deterministic_ask,
+        item_bank=bank, new_id=_new_id_factory(), overrides=overrides,
+    )
+    score = srepo.get_facet_score(self_id, "inquisitiveness")
+    # A draw centered at μ=5.0, σ=0.8, clamped to [1,5], will be ≥ 4.0 with
+    # overwhelming probability. A single seed could land lower in rare cases,
+    # but with σ=0.8 and μ=5, the clamp to ≤5 dominates the right tail.
+    assert score >= 3.5

--- a/research/project-turing/sketches/tests/test_self_mood.py
+++ b/research/project-turing/sketches/tests/test_self_mood.py
@@ -1,0 +1,267 @@
+"""Tests for specs/mood.md: AC-27.*."""
+
+from __future__ import annotations
+
+import math
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from turing.repo import Repo
+from turing.self_identity import bootstrap_self_id
+from turing.self_model import Mood
+from turing.self_mood import (
+    DECAY_RATE,
+    EVENT_NUDGES,
+    NEUTRAL_AROUSAL,
+    NEUTRAL_FOCUS,
+    NEUTRAL_VALENCE,
+    NUDGE_MAX,
+    apply_event_nudge,
+    decay_step,
+    mood_descriptor,
+    nudge_mood,
+    tick_mood_decay,
+)
+from turing.self_repo import SelfRepo
+
+
+@pytest.fixture
+def srepo() -> SelfRepo:
+    r = Repo(None)
+    return SelfRepo(r.conn)
+
+
+@pytest.fixture
+def self_id(srepo: SelfRepo) -> str:
+    return bootstrap_self_id(srepo.conn)
+
+
+def _seed_mood(srepo: SelfRepo, self_id: str,
+               valence: float = 0.0, arousal: float = 0.3, focus: float = 0.5,
+               when: datetime | None = None) -> Mood:
+    return srepo.insert_mood(
+        Mood(
+            self_id=self_id,
+            valence=valence,
+            arousal=arousal,
+            focus=focus,
+            last_tick_at=when or datetime.now(UTC),
+        )
+    )
+
+
+# --------- AC-27.1 seeded at neutral ---------------------------------------
+
+
+def test_ac_27_1_initial_seed_is_neutral(srepo, self_id) -> None:
+    _seed_mood(srepo, self_id)
+    m = srepo.get_mood(self_id)
+    assert m.valence == NEUTRAL_VALENCE
+    assert m.arousal == NEUTRAL_AROUSAL
+    assert m.focus == NEUTRAL_FOCUS
+
+
+# --------- AC-27.4 decay step maths -----------------------------------------
+
+
+def test_ac_27_4_decay_step_single_hour_formula() -> None:
+    # new = current + DECAY_RATE * (neutral - current)
+    got = decay_step(1.0, 0.0, 1.0)
+    assert got == pytest.approx(1.0 + DECAY_RATE * (0.0 - 1.0))
+
+
+def test_ac_27_4_decay_step_multiple_hours_asymptote() -> None:
+    # At 100 hours, state should be essentially neutral: 0.8 * (0.9)^100 ≈ 2.1e-5.
+    got = decay_step(0.8, 0.0, 100.0)
+    assert abs(got) < 1e-4
+
+
+def test_ac_27_4_decay_step_zero_hours_no_change() -> None:
+    assert decay_step(0.8, 0.0, 0.0) == 0.8
+
+
+# --------- AC-27.5 catch-up on long gaps ------------------------------------
+
+
+def test_ac_27_5_long_downtime_never_crosses_neutral(srepo, self_id) -> None:
+    past = datetime.now(UTC) - timedelta(hours=100)
+    _seed_mood(srepo, self_id, valence=0.8, arousal=0.9, focus=0.9, when=past)
+    m = tick_mood_decay(srepo, self_id, datetime.now(UTC))
+    # Approaches neutral but never passes it.
+    assert 0.0 <= m.valence <= 0.8
+    assert NEUTRAL_AROUSAL <= m.arousal <= 0.9
+    assert NEUTRAL_FOCUS <= m.focus <= 0.9
+
+
+def test_ac_27_5_effective_rate_scales_with_gap() -> None:
+    # One hour decay of 10%, two hours ≈ 19%, ten hours ≈ 65%.
+    assert decay_step(1.0, 0.0, 1.0) == pytest.approx(0.9, rel=1e-6)
+    assert decay_step(1.0, 0.0, 2.0) == pytest.approx(0.81, rel=1e-6)
+    assert decay_step(1.0, 0.0, 10.0) == pytest.approx((1.0 - DECAY_RATE) ** 10, rel=1e-6)
+
+
+# --------- AC-27.6 idempotent within tick ----------------------------------
+
+
+def test_ac_27_6_same_tick_idempotent(srepo, self_id) -> None:
+    now = datetime.now(UTC)
+    _seed_mood(srepo, self_id, valence=0.5, arousal=0.4, focus=0.6, when=now)
+    m1 = tick_mood_decay(srepo, self_id, now)
+    m2 = tick_mood_decay(srepo, self_id, now)
+    assert (m1.valence, m1.arousal, m1.focus) == (m2.valence, m2.arousal, m2.focus)
+
+
+# --------- AC-27.7 no-overshoot --------------------------------------------
+
+
+def test_ac_27_7_decay_never_crosses_neutral_approaching_from_above() -> None:
+    for hours in (0.5, 1.0, 5.0, 50.0, 500.0):
+        got = decay_step(0.02, 0.0, hours)
+        assert got >= 0.0
+        assert got <= 0.02
+
+
+def test_ac_27_7_decay_never_crosses_neutral_approaching_from_below() -> None:
+    for hours in (0.5, 1.0, 5.0, 50.0, 500.0):
+        got = decay_step(-0.5, 0.0, hours)
+        assert got <= 0.0
+        assert got >= -0.5
+
+
+# --------- AC-27.8 nudge validation -----------------------------------------
+
+
+def test_ac_27_8_nudge_beyond_max_raises(srepo, self_id) -> None:
+    _seed_mood(srepo, self_id)
+    with pytest.raises(ValueError, match="exceeds NUDGE_MAX"):
+        nudge_mood(srepo, self_id, "valence", NUDGE_MAX + 0.01, reason="")
+
+
+def test_ac_27_8_nudge_clamps_to_range(srepo, self_id) -> None:
+    _seed_mood(srepo, self_id, valence=0.9)
+    m = nudge_mood(srepo, self_id, "valence", 0.5, reason="")
+    assert m.valence == 1.0  # clamped to upper bound
+
+
+def test_ac_27_18_unknown_dim_raises(srepo, self_id) -> None:
+    _seed_mood(srepo, self_id)
+    with pytest.raises(ValueError, match="unknown mood dim"):
+        nudge_mood(srepo, self_id, "clarity", 0.1, reason="")
+
+
+# --------- AC-27.10 event nudge registry ------------------------------------
+
+
+@pytest.mark.parametrize(
+    "event,expected_dim",
+    [
+        ("tool_succeeded_against_expectation", "valence"),
+        ("tool_failed_unexpectedly", "valence"),
+        ("affirmation_minted", "valence"),
+        ("regret_minted", "valence"),
+        ("todo_completed", "valence"),
+        ("warden_alert_on_ingress", "arousal"),
+    ],
+)
+def test_ac_27_10_each_standard_event_shifts_expected_dim(
+    srepo, self_id, event, expected_dim
+) -> None:
+    _seed_mood(srepo, self_id)
+    before = srepo.get_mood(self_id)
+    apply_event_nudge(srepo, self_id, event, reason="test")
+    after = srepo.get_mood(self_id)
+    # All events in EVENT_NUDGES touch at least one dim; we check the dim
+    # declared first in the tuple list actually moved.
+    expected_delta = next(d for dim, d in EVENT_NUDGES[event] if dim == expected_dim)
+    assert getattr(after, expected_dim) == pytest.approx(
+        max(-1.0 if expected_dim == "valence" else 0.0,
+            min(1.0, getattr(before, expected_dim) + expected_delta))
+    )
+
+
+def test_ac_27_10_regret_lowers_valence(srepo, self_id) -> None:
+    _seed_mood(srepo, self_id, valence=0.0)
+    apply_event_nudge(srepo, self_id, "regret_minted", reason="misrouted")
+    m = srepo.get_mood(self_id)
+    assert m.valence == pytest.approx(-0.20)
+
+
+def test_ac_27_10_unknown_event_is_noop(srepo, self_id) -> None:
+    _seed_mood(srepo, self_id, valence=0.4, arousal=0.4, focus=0.4)
+    apply_event_nudge(srepo, self_id, "non_event", reason="ignored")
+    m = srepo.get_mood(self_id)
+    assert (m.valence, m.arousal, m.focus) == (0.4, 0.4, 0.4)
+
+
+# --------- AC-27.12 descriptor lookup ---------------------------------------
+
+
+def _mk(valence: float, arousal: float, focus: float) -> Mood:
+    return Mood(
+        self_id="s",
+        valence=valence,
+        arousal=arousal,
+        focus=focus,
+        last_tick_at=datetime.now(UTC),
+    )
+
+
+def test_ac_27_12_negative_low_arousal_descriptor() -> None:
+    assert mood_descriptor(_mk(-0.5, 0.3, 0.5)).startswith("flat, withdrawn")
+
+
+def test_ac_27_12_negative_high_arousal_descriptor() -> None:
+    assert mood_descriptor(_mk(-0.5, 0.8, 0.5)).startswith("tense, on edge")
+
+
+def test_ac_27_12_neutral_low_descriptor() -> None:
+    assert mood_descriptor(_mk(0.0, 0.3, 0.5)).startswith("even, steady")
+
+
+def test_ac_27_12_neutral_high_descriptor() -> None:
+    assert mood_descriptor(_mk(0.0, 0.8, 0.5)).startswith("alert, attentive")
+
+
+def test_ac_27_12_positive_low_descriptor() -> None:
+    assert mood_descriptor(_mk(0.5, 0.3, 0.5)).startswith("content, easy")
+
+
+def test_ac_27_12_positive_high_descriptor() -> None:
+    assert mood_descriptor(_mk(0.5, 0.8, 0.5)).startswith("keen, energized")
+
+
+def test_ac_27_12_focus_high_adds_suffix() -> None:
+    assert mood_descriptor(_mk(0.0, 0.3, 0.9)).endswith("; focused")
+
+
+def test_ac_27_12_focus_low_adds_suffix() -> None:
+    assert mood_descriptor(_mk(0.0, 0.3, 0.1)).endswith("; scattered")
+
+
+def test_ac_27_12_focus_medium_no_suffix() -> None:
+    got = mood_descriptor(_mk(0.0, 0.3, 0.5))
+    assert ";" not in got
+
+
+# --------- AC-27.17 tick ordering ------------------------------------------
+
+
+def test_ac_27_17_tick_before_nudge_same_second(srepo, self_id) -> None:
+    past = datetime.now(UTC) - timedelta(hours=1)
+    _seed_mood(srepo, self_id, valence=1.0, when=past)
+    tick_mood_decay(srepo, self_id, datetime.now(UTC))
+    after_tick = srepo.get_mood(self_id).valence
+    nudge_mood(srepo, self_id, "valence", 0.1, reason="")
+    after_nudge = srepo.get_mood(self_id).valence
+    assert after_nudge == pytest.approx(min(1.0, after_tick + 0.1))
+
+
+# --------- AC-27.11 serialization: sequential nudges are not lost ----------
+
+
+def test_ac_27_11_sequential_nudges_accumulate(srepo, self_id) -> None:
+    _seed_mood(srepo, self_id, valence=0.0)
+    for _ in range(3):
+        nudge_mood(srepo, self_id, "valence", 0.1, reason="")
+    assert srepo.get_mood(self_id).valence == pytest.approx(0.3)

--- a/research/project-turing/sketches/tests/test_self_nodes.py
+++ b/research/project-turing/sketches/tests/test_self_nodes.py
@@ -1,0 +1,239 @@
+"""Tests for specs/self-nodes.md: AC-24.*."""
+
+from __future__ import annotations
+
+import math
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from turing.repo import Repo
+from turing.self_identity import bootstrap_self_id
+from turing.self_model import (
+    DEFAULT_DECAY_RATES,
+    Passion,
+    PreferenceKind,
+    Skill,
+    SkillKind,
+    current_level,
+)
+from turing.self_nodes import (
+    downgrade_skill,
+    note_hobby,
+    note_interest,
+    note_passion,
+    note_preference,
+    note_skill,
+    practice_skill,
+    rerank_passions,
+)
+from turing.self_repo import SelfRepo
+
+
+@pytest.fixture
+def srepo() -> SelfRepo:
+    r = Repo(None)
+    return SelfRepo(r.conn)
+
+
+@pytest.fixture
+def self_id(srepo: SelfRepo) -> str:
+    return bootstrap_self_id(srepo.conn)
+
+
+@pytest.fixture
+def new_id():
+    counter = {"n": 0}
+
+    def _mk(prefix: str) -> str:
+        counter["n"] += 1
+        return f"{prefix}:{counter['n']}"
+
+    return _mk
+
+
+# --------- AC-24.1 passions -------------------------------------------------
+
+
+def test_ac_24_1_passion_default_rank_and_strength(srepo, self_id, new_id) -> None:
+    p = note_passion(srepo, self_id, "work that lasts", 0.8, new_id)
+    assert p.strength == 0.8
+    assert p.rank == 0
+    assert p.self_id == self_id
+    p2 = note_passion(srepo, self_id, "craft over speed", 0.7, new_id)
+    assert p2.rank == 1
+
+
+def test_ac_24_1_passion_strength_oor_raises(srepo, self_id, new_id) -> None:
+    with pytest.raises(ValueError):
+        note_passion(srepo, self_id, "x", 1.1, new_id)
+
+
+def test_ac_24_1_passion_duplicate_text_case_insensitive_raises(srepo, self_id, new_id) -> None:
+    note_passion(srepo, self_id, "Work that Lasts", 0.5, new_id)
+    with pytest.raises(ValueError, match="duplicate passion"):
+        note_passion(srepo, self_id, "work that LASTS", 0.5, new_id)
+
+
+# --------- AC-24.2 hobbies --------------------------------------------------
+
+
+def test_ac_24_2_hobby_last_engaged_at_starts_none(srepo, self_id, new_id) -> None:
+    h = note_hobby(srepo, self_id, "Reading", "philosophy of mind", new_id)
+    assert h.last_engaged_at is None
+
+
+def test_ac_24_2_hobby_duplicate_raises(srepo, self_id, new_id) -> None:
+    note_hobby(srepo, self_id, "Reading", "X", new_id)
+    with pytest.raises(ValueError, match="duplicate hobby"):
+        note_hobby(srepo, self_id, "reading", "Y", new_id)
+
+
+# --------- AC-24.3 interests ------------------------------------------------
+
+
+def test_ac_24_3_interest_last_noticed_none(srepo, self_id, new_id) -> None:
+    i = note_interest(srepo, self_id, "Neuroscience", "brain stuff", new_id)
+    assert i.last_noticed_at is None
+
+
+def test_ac_24_3_interest_duplicate_raises(srepo, self_id, new_id) -> None:
+    note_interest(srepo, self_id, "Neuroscience", "", new_id)
+    with pytest.raises(ValueError, match="duplicate interest"):
+        note_interest(srepo, self_id, "neuroscience", "", new_id)
+
+
+# --------- AC-24.4 preferences ---------------------------------------------
+
+
+def test_ac_24_4_preference_unique_kind_target(srepo, self_id, new_id) -> None:
+    note_preference(srepo, self_id, PreferenceKind.LIKE, "cats", 0.8, "", new_id)
+    with pytest.raises(ValueError, match="duplicate preference"):
+        note_preference(srepo, self_id, PreferenceKind.LIKE, "cats", 0.5, "", new_id)
+
+
+def test_ac_24_4_preference_different_kinds_ok(srepo, self_id, new_id) -> None:
+    note_preference(srepo, self_id, PreferenceKind.LIKE, "cats", 0.8, "", new_id)
+    # Same target, different kind: allowed.
+    note_preference(srepo, self_id, PreferenceKind.FAVORITE, "cats", 0.9, "", new_id)
+
+
+# --------- AC-24.5 skills ---------------------------------------------------
+
+
+@pytest.mark.parametrize("kind,expected_rate", [
+    (SkillKind.INTELLECTUAL, 0.0005),
+    (SkillKind.PHYSICAL, 0.005),
+    (SkillKind.HABIT, 0.002),
+    (SkillKind.SOCIAL, 0.001),
+])
+def test_ac_24_5_default_decay_rates(srepo, self_id, new_id, kind, expected_rate) -> None:
+    s = note_skill(srepo, self_id, f"skill-{kind.value}", 0.5, kind, new_id)
+    assert s.decay_rate_per_day == expected_rate
+
+
+def test_ac_24_5_skill_duplicate_raises(srepo, self_id, new_id) -> None:
+    note_skill(srepo, self_id, "python", 0.8, SkillKind.INTELLECTUAL, new_id)
+    with pytest.raises(ValueError, match="duplicate skill"):
+        note_skill(srepo, self_id, "Python", 0.5, SkillKind.INTELLECTUAL, new_id)
+
+
+# --------- AC-24.6 rerank passions ------------------------------------------
+
+
+def test_ac_24_6_rerank_passions_atomic(srepo, self_id, new_id) -> None:
+    p1 = note_passion(srepo, self_id, "A", 0.5, new_id)
+    p2 = note_passion(srepo, self_id, "B", 0.5, new_id)
+    p3 = note_passion(srepo, self_id, "C", 0.5, new_id)
+    result = rerank_passions(srepo, self_id, [p3.node_id, p1.node_id, p2.node_id])
+    ranks = {p.node_id: p.rank for p in result}
+    assert ranks[p3.node_id] == 0
+    assert ranks[p1.node_id] == 1
+    assert ranks[p2.node_id] == 2
+
+
+def test_ac_24_6_rerank_passions_incomplete_list_raises(srepo, self_id, new_id) -> None:
+    p1 = note_passion(srepo, self_id, "A", 0.5, new_id)
+    note_passion(srepo, self_id, "B", 0.5, new_id)
+    with pytest.raises(ValueError, match="ordered_ids must match"):
+        rerank_passions(srepo, self_id, [p1.node_id])
+
+
+def test_ac_24_6_rerank_passions_phantom_id_raises(srepo, self_id, new_id) -> None:
+    p1 = note_passion(srepo, self_id, "A", 0.5, new_id)
+    p2 = note_passion(srepo, self_id, "B", 0.5, new_id)
+    with pytest.raises(ValueError, match="ordered_ids must match"):
+        rerank_passions(srepo, self_id, [p1.node_id, p2.node_id, "phantom"])
+
+
+# --------- AC-24.10 practice_skill updates last_practiced_at ---------------
+
+
+def test_ac_24_10_practice_updates_last_practiced_at(srepo, self_id, new_id) -> None:
+    s = note_skill(srepo, self_id, "python", 0.5, SkillKind.INTELLECTUAL, new_id)
+    # Backdate to test that practice_skill resets.
+    s_old = s
+    s_old.last_practiced_at = datetime.now(UTC) - timedelta(days=30)
+    srepo.update_skill(s_old)
+    before = srepo.get_skill(s.node_id).last_practiced_at
+    after_skill = practice_skill(srepo, self_id, s.node_id)
+    assert after_skill.last_practiced_at > before
+
+
+def test_ac_24_15_practice_cannot_lower_stored_level(srepo, self_id, new_id) -> None:
+    s = note_skill(srepo, self_id, "python", 0.8, SkillKind.INTELLECTUAL, new_id)
+    with pytest.raises(ValueError, match="cannot lower"):
+        practice_skill(srepo, self_id, s.node_id, new_level=0.5)
+
+
+def test_ac_24_15_downgrade_lowers_and_requires_reason(srepo, self_id, new_id) -> None:
+    s = note_skill(srepo, self_id, "python", 0.8, SkillKind.INTELLECTUAL, new_id)
+    s2 = downgrade_skill(srepo, self_id, s.node_id, 0.4, "long disuse after injury")
+    assert s2.stored_level == 0.4
+    with pytest.raises(ValueError, match="reason is required"):
+        downgrade_skill(srepo, self_id, s.node_id, 0.3, "")
+
+
+# --------- AC-24.12..14 current_level maths --------------------------------
+
+
+def test_ac_24_12_current_level_exponential_decay() -> None:
+    s = Skill(
+        node_id="x", self_id="s", name="p", kind=SkillKind.PHYSICAL,
+        stored_level=1.0, decay_rate_per_day=0.005,
+        last_practiced_at=datetime.now(UTC) - timedelta(days=30),
+    )
+    assert current_level(s, datetime.now(UTC)) == pytest.approx(math.exp(-0.15), rel=1e-4)
+
+
+def test_ac_24_13_current_level_clamped(srepo, self_id, new_id) -> None:
+    # stored_level=0.0 → current_level stays 0.0.
+    s = note_skill(srepo, self_id, "obscure", 0.0, SkillKind.INTELLECTUAL, new_id)
+    assert current_level(s, datetime.now(UTC)) == 0.0
+
+
+def test_ac_24_14_current_level_is_pure_no_write(srepo, self_id, new_id) -> None:
+    s = note_skill(srepo, self_id, "python", 0.8, SkillKind.INTELLECTUAL, new_id)
+    before = srepo.get_skill(s.node_id)
+    # Advance clock by computing current_level many times.
+    for _ in range(10):
+        current_level(s, datetime.now(UTC) + timedelta(days=365))
+    after = srepo.get_skill(s.node_id)
+    # No persistence side effects.
+    assert before.stored_level == after.stored_level
+    assert before.last_practiced_at == after.last_practiced_at
+
+
+# --------- AC-24.10 future clock returns stored_level (no past decay) ------
+
+
+def test_practice_resets_decay_window(srepo, self_id, new_id) -> None:
+    s = note_skill(srepo, self_id, "python", 0.9, SkillKind.PHYSICAL, new_id)
+    # Backdate.
+    s.last_practiced_at = datetime.now(UTC) - timedelta(days=100)
+    srepo.update_skill(s)
+    decayed = current_level(srepo.get_skill(s.node_id), datetime.now(UTC))
+    practice_skill(srepo, self_id, s.node_id)
+    fresh = current_level(srepo.get_skill(s.node_id), datetime.now(UTC))
+    assert fresh > decayed
+    assert fresh == pytest.approx(0.9, rel=1e-3)

--- a/research/project-turing/sketches/tests/test_self_personality.py
+++ b/research/project-turing/sketches/tests/test_self_personality.py
@@ -1,0 +1,356 @@
+"""Tests for specs/personality.md: AC-23.*."""
+
+from __future__ import annotations
+
+import random
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from turing.repo import Repo
+from turing.self_identity import bootstrap_self_id
+from turing.self_model import (
+    ALL_FACETS,
+    CANONICAL_FACETS,
+    FACET_TO_TRAIT,
+    PersonalityFacet,
+    PersonalityItem,
+    Trait,
+    facet_node_id,
+)
+from turing.self_personality import (
+    FACET_DIVERSITY_FLOOR,
+    RETEST_SAMPLE_SIZE,
+    RETEST_WEIGHT,
+    apply_retest,
+    compute_facet_deltas,
+    draw_bootstrap_profile,
+    narrative_weight,
+    sample_retest_items,
+)
+from turing.self_repo import SelfRepo
+
+
+@pytest.fixture
+def srepo() -> SelfRepo:
+    r = Repo(None)
+    return SelfRepo(r.conn)
+
+
+@pytest.fixture
+def self_id(srepo: SelfRepo) -> str:
+    return bootstrap_self_id(srepo.conn)
+
+
+@pytest.fixture
+def new_id():
+    counter = {"n": 0}
+
+    def _mk(prefix: str) -> str:
+        counter["n"] += 1
+        return f"{prefix}:{counter['n']}"
+
+    return _mk
+
+
+def _seed_facets(srepo: SelfRepo, self_id: str, score: float = 3.0) -> None:
+    now = datetime.now(UTC)
+    for trait, facet in ALL_FACETS:
+        srepo.insert_facet(
+            PersonalityFacet(
+                node_id=facet_node_id(trait, facet),
+                self_id=self_id,
+                trait=trait,
+                facet_id=facet,
+                score=score,
+                last_revised_at=now,
+            )
+        )
+
+
+def _seed_items(srepo: SelfRepo, self_id: str) -> list[PersonalityItem]:
+    """Seed one-per-facet × 10 = 240 items? Keep simple: one per facet = 24.
+    For retest sampling we need >=20 items with good facet coverage."""
+    items: list[PersonalityItem] = []
+    n = 0
+    for trait, facet in ALL_FACETS:
+        for k in range(9):  # 9 per facet -> 216 items; close enough to 200
+            if n >= 200:
+                break
+            n += 1
+            it = PersonalityItem(
+                node_id=f"item:{n}",
+                self_id=self_id,
+                item_number=n,
+                prompt_text=f"I am {facet}.",
+                keyed_facet=facet,
+                reverse_scored=(k % 3 == 0),
+            )
+            srepo.insert_item(it)
+            items.append(it)
+        if n >= 200:
+            break
+    return items
+
+
+# --------- AC-23.1 / AC-23.2: canonical 24 facets ------------------------
+
+
+def test_ac_23_1_exactly_24_facets() -> None:
+    assert len(ALL_FACETS) == 24
+    facet_names = [f for _, f in ALL_FACETS]
+    assert len(set(facet_names)) == 24
+
+
+def test_ac_23_2_each_facet_maps_to_one_trait() -> None:
+    # Inverse of CANONICAL_FACETS must be single-valued.
+    seen: dict[str, Trait] = {}
+    for trait, facets in CANONICAL_FACETS.items():
+        for facet in facets:
+            assert facet not in seen, f"{facet} appears under two traits"
+            seen[facet] = trait
+    assert seen == FACET_TO_TRAIT
+
+
+# --------- AC-23.6 reverse scoring ---------------------------------------
+
+
+def test_ac_23_6_reverse_scored_inverts_answer() -> None:
+    """For reverse-scored items, 6 - raw is used (5->1, 4->2, 3->3, 2->4, 1->5)."""
+    for raw, expected in [(1, 5), (2, 4), (3, 3), (4, 2), (5, 1)]:
+        sampled = [
+            PersonalityItem(
+                node_id="i1",
+                self_id="s",
+                item_number=1,
+                prompt_text="",
+                keyed_facet="inquisitiveness",
+                reverse_scored=True,
+            )
+        ]
+        deltas = compute_facet_deltas(
+            sampled, [raw], {"inquisitiveness": float(expected)}
+        )
+        # Delta should be zero because retest mean == current.
+        assert deltas["inquisitiveness"][0] == pytest.approx(expected)
+        assert deltas["inquisitiveness"][1] == pytest.approx(0.0)
+
+
+# --------- AC-23.7 bootstrap draw determinism ----------------------------
+
+
+def test_ac_23_7_bootstrap_draw_deterministic_under_seed() -> None:
+    r1 = random.Random(42)
+    r2 = random.Random(42)
+    assert draw_bootstrap_profile(r1) == draw_bootstrap_profile(r2)
+
+
+def test_ac_23_7_bootstrap_draw_range() -> None:
+    rng = random.Random(7)
+    profile = draw_bootstrap_profile(rng)
+    assert len(profile) == 24
+    for v in profile.values():
+        assert 1.0 <= v <= 5.0
+
+
+# --------- AC-23.12 sampling --------------------------------------------
+
+
+def test_ac_23_12_retest_sample_is_exactly_20(srepo, self_id) -> None:
+    items = _seed_items(srepo, self_id)
+    rng = random.Random(3)
+    sample = sample_retest_items(
+        items=items,
+        last_asked={},
+        rng=rng,
+        now=datetime.now(UTC),
+    )
+    assert len(sample) == RETEST_SAMPLE_SIZE
+
+
+def test_ac_23_12_retest_sample_facet_diversity(srepo, self_id) -> None:
+    items = _seed_items(srepo, self_id)
+    rng = random.Random(3)
+    sample = sample_retest_items(
+        items=items, last_asked={}, rng=rng, now=datetime.now(UTC),
+    )
+    distinct_facets = {s.keyed_facet for s in sample}
+    assert len(distinct_facets) >= FACET_DIVERSITY_FLOOR
+
+
+def test_ac_23_12_recency_weighted_never_asked_dominates(srepo, self_id) -> None:
+    items = _seed_items(srepo, self_id)
+    # Mark a small prefix (covering one facet, so facet-diversity still holds
+    # for the never-asked pool) as just-asked.
+    first_facet = items[0].keyed_facet
+    just_asked_ids = {it.node_id for it in items if it.keyed_facet == first_facet}
+    very_recent = {nid: datetime.now(UTC) for nid in just_asked_ids}
+    rng = random.Random(5)
+    sample = sample_retest_items(
+        items=items, last_asked=very_recent, rng=rng, now=datetime.now(UTC),
+    )
+    # The never-asked pool covers >=12 facets (all except first_facet), so the
+    # weighted sample's diversity check passes on the first attempt. Expect
+    # ~0 picks from the just-asked set given the 10-million-to-one weight ratio.
+    hit_recent = sum(1 for s in sample if s.node_id in just_asked_ids)
+    assert hit_recent == 0
+
+
+# --------- AC-23.15..16 retest deltas ------------------------------------
+
+
+def test_ac_23_15_touched_facets_get_mean(srepo, self_id) -> None:
+    items = [
+        PersonalityItem(
+            node_id=f"item:{i}",
+            self_id=self_id,
+            item_number=i,
+            prompt_text="",
+            keyed_facet="inquisitiveness",
+            reverse_scored=False,
+        )
+        for i in range(1, 5)
+    ]
+    deltas = compute_facet_deltas(
+        items, [1, 2, 3, 4], {"inquisitiveness": 3.0}
+    )
+    # Mean retest = 2.5. Delta = 0.25 * (2.5 - 3.0) = -0.125.
+    assert deltas["inquisitiveness"][0] == pytest.approx(2.5)
+    assert deltas["inquisitiveness"][1] == pytest.approx(-0.125)
+
+
+def test_ac_23_15_untouched_facets_absent(srepo, self_id) -> None:
+    items = [
+        PersonalityItem(
+            node_id="item:1",
+            self_id=self_id,
+            item_number=1,
+            prompt_text="",
+            keyed_facet="inquisitiveness",
+            reverse_scored=False,
+        )
+    ]
+    deltas = compute_facet_deltas(items, [4], {"inquisitiveness": 3.0, "sincerity": 3.0})
+    assert "sincerity" not in deltas
+
+
+def test_ac_23_16_delta_applies_retest_weight() -> None:
+    # Single facet, current=2.0, raw=5.
+    items = [
+        PersonalityItem(
+            node_id="item:1",
+            self_id="s",
+            item_number=1,
+            prompt_text="",
+            keyed_facet="creativity",
+            reverse_scored=False,
+        )
+    ]
+    deltas = compute_facet_deltas(items, [5], {"creativity": 2.0})
+    assert deltas["creativity"][1] == pytest.approx(RETEST_WEIGHT * (5 - 2.0))
+
+
+# --------- AC-23.14 atomicity: invalid answer aborts ---------------------
+
+
+def test_ac_23_14_invalid_answer_aborts_before_mutation(srepo, self_id, new_id) -> None:
+    _seed_facets(srepo, self_id, score=3.0)
+    items = _seed_items(srepo, self_id)
+    sampled = items[:20]
+
+    # This ask_self returns a bad answer on the 5th call.
+    def bad_ask(it: PersonalityItem) -> tuple[int, str]:
+        bad_ask.n += 1
+        if bad_ask.n == 5:
+            return (9, "out of range")
+        return (3, "meh")
+    bad_ask.n = 0
+
+    score_before = srepo.get_facet_score(self_id, "inquisitiveness")
+    with pytest.raises(ValueError, match="invalid retest answer"):
+        apply_retest(
+            repo=srepo,
+            self_id=self_id,
+            sampled=sampled,
+            ask_self=bad_ask,
+            now=datetime.now(UTC),
+            new_id=new_id,
+        )
+    score_after = srepo.get_facet_score(self_id, "inquisitiveness")
+    assert score_before == score_after
+    # No revision row inserted either.
+    rows = srepo.conn.execute(
+        "SELECT COUNT(*) FROM self_personality_revisions WHERE self_id = ?",
+        (self_id,),
+    ).fetchone()
+    assert rows[0] == 0
+
+
+# --------- AC-23.16 apply_retest moves scores by 25% ---------------------
+
+
+def test_ac_23_16_apply_retest_moves_score_by_25_pct(srepo, self_id, new_id) -> None:
+    # Seed facets at a known score; rig ask_self to return constant 5 for every item.
+    _seed_facets(srepo, self_id, score=3.0)
+    items = _seed_items(srepo, self_id)
+    sampled = items[:20]
+
+    # All items answered "5". Reverse-scored items get their effective score as 1.
+    def ask(it: PersonalityItem) -> tuple[int, str]:
+        return (5, "")
+
+    apply_retest(
+        repo=srepo,
+        self_id=self_id,
+        sampled=sampled,
+        ask_self=ask,
+        now=datetime.now(UTC),
+        new_id=new_id,
+    )
+
+    # For each touched facet, compute expected delta: mean(scored) where
+    # scored = 6-5 = 1 for reverse-scored and 5 otherwise.
+    from collections import defaultdict
+    by_facet: dict[str, list[int]] = defaultdict(list)
+    for it in sampled:
+        by_facet[it.keyed_facet].append(1 if it.reverse_scored else 5)
+    for facet, vals in by_facet.items():
+        retest_mean = sum(vals) / len(vals)
+        expected = 3.0 + RETEST_WEIGHT * (retest_mean - 3.0)
+        assert srepo.get_facet_score(self_id, facet) == pytest.approx(expected)
+
+
+# --------- AC-23.18 revision row written --------------------------------
+
+
+def test_ac_23_18_apply_retest_persists_revision(srepo, self_id, new_id) -> None:
+    _seed_facets(srepo, self_id, score=3.0)
+    items = _seed_items(srepo, self_id)
+    sampled = items[:20]
+
+    def ask(it: PersonalityItem) -> tuple[int, str]:
+        return (3, "")
+
+    apply_retest(
+        repo=srepo,
+        self_id=self_id,
+        sampled=sampled,
+        ask_self=ask,
+        now=datetime.now(UTC),
+        new_id=new_id,
+    )
+    revs = srepo.conn.execute(
+        "SELECT COUNT(*) FROM self_personality_revisions WHERE self_id = ?",
+        (self_id,),
+    ).fetchone()
+    assert revs[0] == 1
+
+
+# --------- narrative_weight ---------------------------------------------
+
+
+def test_narrative_weight_floor_and_ceiling() -> None:
+    # Empty evidence → floor = 0.1.
+    assert narrative_weight("", "claim") == pytest.approx(0.1)
+    # Very long evidence → ceiling = 0.4.
+    assert narrative_weight("x" * 2000, "claim") == pytest.approx(0.4)

--- a/research/project-turing/sketches/tests/test_self_schema.py
+++ b/research/project-turing/sketches/tests/test_self_schema.py
@@ -1,0 +1,524 @@
+"""Tests for specs/self-schema.md: AC-22.* and companion dataclass validation."""
+
+from __future__ import annotations
+
+import sqlite3
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from turing.repo import Repo
+from turing.self_model import (
+    ActivationContributor,
+    ContributorOrigin,
+    Hobby,
+    Interest,
+    Mood,
+    NodeKind,
+    Passion,
+    PersonalityAnswer,
+    PersonalityFacet,
+    PersonalityItem,
+    PersonalityRevision,
+    Preference,
+    PreferenceKind,
+    SelfTodo,
+    SelfTodoRevision,
+    Skill,
+    SkillKind,
+    TodoStatus,
+    Trait,
+    facet_node_id,
+)
+from turing.self_repo import SelfRepo
+
+
+# --------- fixtures ----------------------------------------------------------
+
+
+@pytest.fixture
+def repos() -> tuple[Repo, SelfRepo]:
+    r = Repo(None)
+    return r, SelfRepo(r.conn)
+
+
+@pytest.fixture
+def self_id(repos) -> str:
+    r, _ = repos
+    from turing.self_identity import bootstrap_self_id
+    return bootstrap_self_id(r.conn)
+
+
+def _now() -> datetime:
+    return datetime.now(UTC)
+
+
+# --------- AC-22.1..3 identity + NodeKind -----------------------------------
+
+
+def test_ac_22_1_facet_requires_self_id() -> None:
+    with pytest.raises(ValueError, match="self_id is required"):
+        PersonalityFacet(
+            node_id="facet:openness.inquisitiveness",
+            self_id="",
+            trait=Trait.OPENNESS,
+            facet_id="inquisitiveness",
+            score=3.0,
+            last_revised_at=_now(),
+        )
+
+
+def test_ac_22_2_every_node_kind_member_has_string_value() -> None:
+    assert {k.value for k in NodeKind} == {
+        "personality_facet",
+        "passion",
+        "hobby",
+        "interest",
+        "preference",
+        "skill",
+        "todo",
+        "mood",
+    }
+
+
+def test_ac_22_3_facet_node_id_is_well_formed() -> None:
+    nid = facet_node_id(Trait.OPENNESS, "inquisitiveness")
+    assert nid == "facet:openness.inquisitiveness"
+
+
+# --------- AC-22.4..5 personality facet constraints -------------------------
+
+
+def test_ac_22_5_facet_score_above_range_raises() -> None:
+    with pytest.raises(ValueError, match="facet score out of range"):
+        PersonalityFacet(
+            node_id="x",
+            self_id="s",
+            trait=Trait.OPENNESS,
+            facet_id="inquisitiveness",
+            score=5.1,
+            last_revised_at=_now(),
+        )
+
+
+def test_ac_22_5_facet_score_below_range_raises() -> None:
+    with pytest.raises(ValueError, match="facet score out of range"):
+        PersonalityFacet(
+            node_id="x",
+            self_id="s",
+            trait=Trait.OPENNESS,
+            facet_id="inquisitiveness",
+            score=0.99,
+            last_revised_at=_now(),
+        )
+
+
+def test_ac_22_5_facet_trait_facet_mismatch_raises() -> None:
+    with pytest.raises(ValueError, match="does not belong to trait"):
+        PersonalityFacet(
+            node_id="x",
+            self_id="s",
+            trait=Trait.OPENNESS,
+            facet_id="sincerity",  # belongs to HONESTY_HUMILITY
+            score=3.0,
+            last_revised_at=_now(),
+        )
+
+
+def test_ac_22_5_facet_uniqueness_db_enforced(repos, self_id) -> None:
+    _, srepo = repos
+    f = PersonalityFacet(
+        node_id=facet_node_id(Trait.OPENNESS, "inquisitiveness"),
+        self_id=self_id,
+        trait=Trait.OPENNESS,
+        facet_id="inquisitiveness",
+        score=3.0,
+        last_revised_at=_now(),
+    )
+    srepo.insert_facet(f)
+    # Inserting a different node_id but same (self_id, trait, facet_id) must fail.
+    f2 = PersonalityFacet(
+        node_id="other-id",
+        self_id=self_id,
+        trait=Trait.OPENNESS,
+        facet_id="inquisitiveness",
+        score=4.0,
+        last_revised_at=_now(),
+    )
+    with pytest.raises(sqlite3.IntegrityError):
+        srepo.insert_facet(f2)
+
+
+# --------- AC-22.7 answer range --------------------------------------------
+
+
+def test_ac_22_7_personality_answer_out_of_range_raises() -> None:
+    with pytest.raises(ValueError, match="1..5"):
+        PersonalityAnswer(
+            node_id="a",
+            self_id="s",
+            item_id="i",
+            revision_id=None,
+            answer_1_5=6,
+            justification_text="",
+            asked_at=_now(),
+        )
+
+
+def test_ac_22_7_personality_answer_justification_cap() -> None:
+    with pytest.raises(ValueError, match="justification_text"):
+        PersonalityAnswer(
+            node_id="a",
+            self_id="s",
+            item_id="i",
+            revision_id=None,
+            answer_1_5=3,
+            justification_text="x" * 201,
+            asked_at=_now(),
+        )
+
+
+# --------- AC-22.8 revision length ------------------------------------------
+
+
+def test_ac_22_8_revision_sample_length_must_be_20() -> None:
+    with pytest.raises(ValueError, match="exactly 20 items"):
+        PersonalityRevision(
+            node_id="rn",
+            self_id="s",
+            revision_id="r",
+            ran_at=_now(),
+            sampled_item_ids=["x"] * 19,
+            deltas_by_facet={},
+        )
+
+
+# --------- AC-22.9 passion strength + rank ---------------------------------
+
+
+def test_ac_22_9_passion_strength_range() -> None:
+    with pytest.raises(ValueError, match="strength out of range"):
+        Passion(
+            node_id="p",
+            self_id="s",
+            text="x",
+            strength=1.1,
+            rank=0,
+            first_noticed_at=_now(),
+        )
+
+
+def test_ac_22_9_passion_rank_negative_raises() -> None:
+    with pytest.raises(ValueError, match="rank must be >= 0"):
+        Passion(
+            node_id="p",
+            self_id="s",
+            text="x",
+            strength=0.5,
+            rank=-1,
+            first_noticed_at=_now(),
+        )
+
+
+def test_ac_22_9_passion_rank_uniqueness_db_enforced(repos, self_id) -> None:
+    _, srepo = repos
+    srepo.insert_passion(
+        Passion(
+            node_id="p1",
+            self_id=self_id,
+            text="A",
+            strength=0.5,
+            rank=0,
+            first_noticed_at=_now(),
+        )
+    )
+    with pytest.raises(sqlite3.IntegrityError):
+        srepo.insert_passion(
+            Passion(
+                node_id="p2",
+                self_id=self_id,
+                text="B",
+                strength=0.5,
+                rank=0,
+                first_noticed_at=_now(),
+            )
+        )
+
+
+# --------- AC-22.12 preference uniqueness -----------------------------------
+
+
+def test_ac_22_12_preference_unique_on_kind_target(repos, self_id) -> None:
+    _, srepo = repos
+    srepo.insert_preference(
+        Preference(
+            node_id="pr1",
+            self_id=self_id,
+            kind=PreferenceKind.LIKE,
+            target="cats",
+            strength=0.9,
+            rationale="",
+        )
+    )
+    with pytest.raises(sqlite3.IntegrityError):
+        srepo.insert_preference(
+            Preference(
+                node_id="pr2",
+                self_id=self_id,
+                kind=PreferenceKind.LIKE,
+                target="cats",
+                strength=0.3,
+                rationale="",
+            )
+        )
+
+
+# --------- AC-22.13..14 skill invariants ------------------------------------
+
+
+def test_ac_22_13_skill_non_positive_decay_raises() -> None:
+    with pytest.raises(ValueError, match="decay_rate_per_day must be positive"):
+        Skill(
+            node_id="sk",
+            self_id="s",
+            name="x",
+            kind=SkillKind.INTELLECTUAL,
+            stored_level=0.5,
+            decay_rate_per_day=0.0,
+            last_practiced_at=_now(),
+        )
+
+
+def test_ac_22_13_skill_stored_level_range() -> None:
+    with pytest.raises(ValueError, match="stored_level out of range"):
+        Skill(
+            node_id="sk",
+            self_id="s",
+            name="x",
+            kind=SkillKind.INTELLECTUAL,
+            stored_level=1.01,
+            decay_rate_per_day=0.001,
+            last_practiced_at=_now(),
+        )
+
+
+# --------- AC-22.15..16 todo invariants -------------------------------------
+
+
+def test_ac_22_15_todo_requires_motivator() -> None:
+    with pytest.raises(ValueError, match="motivated_by_node_id is required"):
+        SelfTodo(
+            node_id="t",
+            self_id="s",
+            text="x",
+            motivated_by_node_id="",
+        )
+
+
+def test_ac_22_15_completed_todo_requires_outcome_text() -> None:
+    with pytest.raises(ValueError, match="outcome_text"):
+        SelfTodo(
+            node_id="t",
+            self_id="s",
+            text="x",
+            motivated_by_node_id="passion:1",
+            status=TodoStatus.COMPLETED,
+            outcome_text="",
+        )
+
+
+def test_ac_22_15_todo_text_cap_500() -> None:
+    SelfTodo(
+        node_id="t",
+        self_id="s",
+        text="x" * 500,
+        motivated_by_node_id="passion:1",
+    )
+    with pytest.raises(ValueError, match="exceeds 500"):
+        SelfTodo(
+            node_id="t2",
+            self_id="s",
+            text="x" * 501,
+            motivated_by_node_id="passion:1",
+        )
+
+
+def test_ac_22_16_todo_revisions_are_append_only(repos, self_id) -> None:
+    r, srepo = repos
+    srepo.insert_todo(
+        SelfTodo(
+            node_id="t",
+            self_id=self_id,
+            text="original",
+            motivated_by_node_id="passion:1",
+        )
+    )
+    srepo.insert_todo_revision(
+        SelfTodoRevision(
+            node_id="rev1",
+            self_id=self_id,
+            todo_id="t",
+            revision_num=1,
+            text_before="original",
+            text_after="updated",
+            revised_at=_now(),
+        )
+    )
+    # UPDATE must be blocked by the trigger.
+    with pytest.raises(sqlite3.DatabaseError, match="append-only"):
+        r.conn.execute(
+            "UPDATE self_todo_revisions SET text_after = ? WHERE node_id = ?",
+            ("tampered", "rev1"),
+        )
+        r.conn.commit()
+    with pytest.raises(sqlite3.DatabaseError, match="append-only"):
+        r.conn.execute("DELETE FROM self_todo_revisions WHERE node_id = ?", ("rev1",))
+        r.conn.commit()
+
+
+# --------- AC-22.17..18 mood singleton + range ------------------------------
+
+
+def test_ac_22_17_mood_is_singleton_per_self_id(repos, self_id) -> None:
+    _, srepo = repos
+    srepo.insert_mood(
+        Mood(
+            self_id=self_id,
+            valence=0.0,
+            arousal=0.3,
+            focus=0.5,
+            last_tick_at=_now(),
+        )
+    )
+    with pytest.raises(sqlite3.IntegrityError):
+        srepo.insert_mood(
+            Mood(
+                self_id=self_id,
+                valence=0.0,
+                arousal=0.3,
+                focus=0.5,
+                last_tick_at=_now(),
+            )
+        )
+
+
+def test_ac_22_18_mood_valence_range_enforced() -> None:
+    with pytest.raises(ValueError, match="valence out of range"):
+        Mood(
+            self_id="s",
+            valence=1.1,
+            arousal=0.3,
+            focus=0.5,
+            last_tick_at=_now(),
+        )
+
+
+def test_ac_22_18_mood_arousal_range_enforced() -> None:
+    with pytest.raises(ValueError, match="arousal out of range"):
+        Mood(
+            self_id="s",
+            valence=0.0,
+            arousal=-0.1,
+            focus=0.5,
+            last_tick_at=_now(),
+        )
+
+
+# --------- AC-22.19..21 contributor graph -----------------------------------
+
+
+def test_ac_22_19_contributor_weight_range() -> None:
+    with pytest.raises(ValueError, match="weight out of range"):
+        ActivationContributor(
+            node_id="c",
+            self_id="s",
+            target_node_id="facet:openness.inquisitiveness",
+            target_kind=NodeKind.PERSONALITY_FACET,
+            source_id="passion:1",
+            source_kind="passion",
+            weight=1.01,
+            origin=ContributorOrigin.SELF,
+            rationale="",
+        )
+
+
+def test_ac_22_20_contributor_no_self_loop() -> None:
+    with pytest.raises(ValueError, match="cannot target itself"):
+        ActivationContributor(
+            node_id="c",
+            self_id="s",
+            target_node_id="passion:1",
+            target_kind=NodeKind.PASSION,
+            source_id="passion:1",
+            source_kind="passion",
+            weight=0.5,
+            origin=ContributorOrigin.SELF,
+            rationale="",
+        )
+
+
+def test_ac_22_21_retrieval_contributor_requires_expiry() -> None:
+    with pytest.raises(ValueError, match="retrieval contributors must set expires_at"):
+        ActivationContributor(
+            node_id="c",
+            self_id="s",
+            target_node_id="facet:openness.inquisitiveness",
+            target_kind=NodeKind.PERSONALITY_FACET,
+            source_id="mem:1",
+            source_kind="retrieval",
+            weight=0.3,
+            origin=ContributorOrigin.RETRIEVAL,
+            rationale="",
+        )
+
+
+def test_ac_22_21_non_retrieval_contributor_rejects_expiry() -> None:
+    with pytest.raises(ValueError, match="others must not"):
+        ActivationContributor(
+            node_id="c",
+            self_id="s",
+            target_node_id="facet:openness.inquisitiveness",
+            target_kind=NodeKind.PERSONALITY_FACET,
+            source_id="passion:1",
+            source_kind="passion",
+            weight=0.3,
+            origin=ContributorOrigin.SELF,
+            rationale="",
+            expires_at=_now() + timedelta(minutes=5),
+        )
+
+
+# --------- AC-22.19 DB check: same target/source rejected at DB level -------
+
+
+def test_ac_22_20_db_rejects_self_loop(repos, self_id) -> None:
+    r, _ = repos
+    now = _now().isoformat()
+    with pytest.raises(sqlite3.IntegrityError):
+        r.conn.execute(
+            """INSERT INTO self_activation_contributors
+               (node_id, self_id, target_node_id, target_kind,
+                source_id, source_kind, weight, origin, rationale,
+                expires_at, retracted_by, created_at, updated_at)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+            ("c", self_id, "X", "passion", "X", "passion", 0.5, "self", "", None, None, now, now),
+        )
+        r.conn.commit()
+
+
+def test_ac_22_21_db_enforces_retrieval_expiry_correlation(repos, self_id) -> None:
+    r, _ = repos
+    now = _now()
+    iso = now.isoformat()
+    exp = (now + timedelta(minutes=5)).isoformat()
+    # Non-retrieval + expires_at set should fail.
+    with pytest.raises(sqlite3.IntegrityError):
+        r.conn.execute(
+            """INSERT INTO self_activation_contributors
+               (node_id, self_id, target_node_id, target_kind,
+                source_id, source_kind, weight, origin, rationale,
+                expires_at, retracted_by, created_at, updated_at)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+            ("c", self_id, "A", "passion", "B", "passion", 0.5, "self", "", exp, None, iso, iso),
+        )
+        r.conn.commit()

--- a/research/project-turing/sketches/tests/test_self_surface.py
+++ b/research/project-turing/sketches/tests/test_self_surface.py
@@ -1,0 +1,220 @@
+"""Tests for specs/self-surface.md: AC-28.*."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+
+from turing.repo import Repo
+from turing.self_identity import bootstrap_self_id
+from turing.self_model import (
+    ALL_FACETS,
+    Mood,
+    Passion,
+    PersonalityFacet,
+    SelfTodo,
+    facet_node_id,
+)
+from turing.self_repo import SelfRepo
+from turing.self_surface import (
+    MINIMAL_TODO_COUNT,
+    SelfNotReady,
+    recall_self,
+    render_minimal_block,
+)
+
+
+@pytest.fixture
+def srepo() -> SelfRepo:
+    r = Repo(None)
+    return SelfRepo(r.conn)
+
+
+@pytest.fixture
+def self_id(srepo: SelfRepo) -> str:
+    return bootstrap_self_id(srepo.conn)
+
+
+def _seed_minimal_self(srepo: SelfRepo, self_id: str,
+                       facet_score: float = 3.0) -> None:
+    now = datetime.now(UTC)
+    for trait, facet in ALL_FACETS:
+        srepo.insert_facet(
+            PersonalityFacet(
+                node_id=facet_node_id(trait, facet),
+                self_id=self_id,
+                trait=trait,
+                facet_id=facet,
+                score=facet_score,
+                last_revised_at=now,
+            )
+        )
+    srepo.insert_mood(
+        Mood(self_id=self_id, valence=0.0, arousal=0.3, focus=0.5, last_tick_at=now)
+    )
+
+
+# --------- AC-28.25 recall before bootstrap complete ----------------------
+
+
+def test_ac_28_25_recall_before_bootstrap_raises(srepo, self_id) -> None:
+    with pytest.raises(SelfNotReady):
+        recall_self(srepo, self_id)
+
+
+# --------- AC-28.7..12 recall_self structure ------------------------------
+
+
+def test_ac_28_7_recall_self_top_level_keys(srepo, self_id) -> None:
+    _seed_minimal_self(srepo, self_id)
+    got = recall_self(srepo, self_id)
+    for k in (
+        "self_id",
+        "personality",
+        "passions",
+        "hobbies",
+        "interests",
+        "skills",
+        "preferences",
+        "active_todos",
+        "mood",
+    ):
+        assert k in got
+
+
+def test_ac_28_8_personality_view_has_all_24(srepo, self_id) -> None:
+    _seed_minimal_self(srepo, self_id)
+    got = recall_self(srepo, self_id)
+    assert len(got["personality"]) == 24
+    for entry in got["personality"]:
+        assert set(entry.keys()) == {"trait", "facet", "score", "active_now"}
+
+
+def test_ac_28_10_mood_view_has_descriptor(srepo, self_id) -> None:
+    _seed_minimal_self(srepo, self_id)
+    got = recall_self(srepo, self_id)
+    assert set(got["mood"].keys()) == {"valence", "arousal", "focus", "descriptor"}
+    assert got["mood"]["descriptor"] == "even, steady"
+
+
+# --------- AC-28.9 sort by active_now descending --------------------------
+
+
+def test_ac_28_9_passions_sorted_by_active_now_desc(srepo, self_id) -> None:
+    _seed_minimal_self(srepo, self_id)
+    # Two passions with different strengths → activation differs even with no
+    # explicit contributors, since active_now with zero contributors is 0.5
+    # for both. Check the list is present and sort-stable.
+    srepo.insert_passion(
+        Passion(node_id="passion:1", self_id=self_id, text="A", strength=0.9,
+                rank=0, first_noticed_at=datetime.now(UTC))
+    )
+    srepo.insert_passion(
+        Passion(node_id="passion:2", self_id=self_id, text="B", strength=0.1,
+                rank=1, first_noticed_at=datetime.now(UTC))
+    )
+    got = recall_self(srepo, self_id)
+    assert len(got["passions"]) == 2
+    # Sorted descending: both are at 0.5 (neutral), so order must at least be stable.
+    assert got["passions"][0]["active_now"] >= got["passions"][1]["active_now"]
+
+
+# --------- AC-28.13 recall is read-only ----------------------------------
+
+
+def test_ac_28_13_recall_no_writes(srepo, self_id) -> None:
+    _seed_minimal_self(srepo, self_id)
+    # Snapshot mood row (updated_at) before and after.
+    before = srepo.get_mood(self_id).updated_at
+    recall_self(srepo, self_id)
+    after = srepo.get_mood(self_id).updated_at
+    assert before == after
+
+
+# --------- AC-28.15 minimal block shape ----------------------------------
+
+
+def test_ac_28_15_minimal_block_four_lines_when_fully_populated(srepo, self_id) -> None:
+    _seed_minimal_self(srepo, self_id)
+    srepo.insert_passion(
+        Passion(node_id="passion:top", self_id=self_id, text="lasting work",
+                strength=0.9, rank=0, first_noticed_at=datetime.now(UTC))
+    )
+    srepo.insert_todo(
+        SelfTodo(
+            node_id="todo:1",
+            self_id=self_id,
+            text="Re-read Tulving",
+            motivated_by_node_id="passion:top",
+        )
+    )
+    block = render_minimal_block(srepo, self_id)
+    assert block.count("\n") == 3  # 4 lines
+    lines = block.split("\n")
+    assert lines[0].startswith(f"I am {self_id}")
+    assert lines[1].startswith("Right now:")
+    assert lines[2].startswith("My active todos:")
+    assert lines[3].startswith("I care about:")
+
+
+def test_ac_28_16_minimal_block_omits_empty_lines(srepo, self_id) -> None:
+    _seed_minimal_self(srepo, self_id)
+    block = render_minimal_block(srepo, self_id)
+    # No passions, no todos → just identity + mood.
+    assert block.count("\n") == 1
+
+
+def test_ac_28_15_minimal_block_respects_todo_count(srepo, self_id) -> None:
+    _seed_minimal_self(srepo, self_id)
+    srepo.insert_passion(
+        Passion(node_id="passion:m", self_id=self_id, text="M", strength=0.5,
+                rank=0, first_noticed_at=datetime.now(UTC))
+    )
+    for i in range(MINIMAL_TODO_COUNT + 5):
+        srepo.insert_todo(
+            SelfTodo(
+                node_id=f"todo:{i}",
+                self_id=self_id,
+                text=f"task {i}",
+                motivated_by_node_id="passion:m",
+            )
+        )
+    block = render_minimal_block(srepo, self_id)
+    # Count of `[todo:` markers in the block.
+    todo_count = block.count("[todo:")
+    assert todo_count == MINIMAL_TODO_COUNT
+
+
+# --------- AC-28.27 degenerate minimal block ------------------------------
+
+
+def test_ac_28_27_minimal_block_with_empty_self(srepo, self_id) -> None:
+    _seed_minimal_self(srepo, self_id)
+    block = render_minimal_block(srepo, self_id)
+    # Only identity + mood lines present.
+    assert "My active todos" not in block
+    assert "I care about" not in block
+    assert "Right now" in block
+
+
+# --------- AC-28.17 trait one-liner variation ----------------------------
+
+
+def test_ac_28_17_trait_phrase_high_scores_use_high_adjective(srepo, self_id) -> None:
+    _seed_minimal_self(srepo, self_id, facet_score=5.0)
+    block = render_minimal_block(srepo, self_id)
+    # With all facets at max, the trait phrase uses high-adjectives. It should
+    # not contain the low-adjectives like "opportunistic" or "self-promoting".
+    assert "opportunistic" not in block
+    assert "self-promoting" not in block
+
+
+def test_ac_28_17_trait_phrase_low_scores_use_low_adjective(srepo, self_id) -> None:
+    _seed_minimal_self(srepo, self_id, facet_score=1.5)
+    block = render_minimal_block(srepo, self_id)
+    # With all facets at min, trait phrase uses low-adjectives. No "sincere".
+    # (adjective lookup returns low-variant when score < 3.0)
+    lines = block.split("\n")
+    trait_line = lines[0]
+    assert "sincere," not in trait_line  # "sincere" high-variant absent

--- a/research/project-turing/sketches/tests/test_self_todos.py
+++ b/research/project-turing/sketches/tests/test_self_todos.py
@@ -1,0 +1,206 @@
+"""Tests for specs/self-todos.md: AC-26.*."""
+
+from __future__ import annotations
+
+import pytest
+
+from turing.repo import Repo
+from turing.self_identity import bootstrap_self_id
+from turing.self_model import Passion, TodoStatus
+from turing.self_repo import SelfRepo
+from turing.self_todos import (
+    TodoNotActive,
+    TodoTextTooLong,
+    archive_self_todo,
+    complete_self_todo,
+    revise_self_todo,
+    write_self_todo,
+)
+from datetime import UTC, datetime
+
+
+@pytest.fixture
+def srepo() -> SelfRepo:
+    r = Repo(None)
+    return SelfRepo(r.conn)
+
+
+@pytest.fixture
+def self_id(srepo: SelfRepo) -> str:
+    return bootstrap_self_id(srepo.conn)
+
+
+@pytest.fixture
+def new_id():
+    counter = {"n": 0}
+
+    def _mk(prefix: str) -> str:
+        counter["n"] += 1
+        return f"{prefix}:{counter['n']}"
+
+    return _mk
+
+
+@pytest.fixture
+def motivator(srepo, self_id) -> str:
+    srepo.insert_passion(
+        Passion(
+            node_id="passion:seed",
+            self_id=self_id,
+            text="I care about things that last",
+            strength=0.7,
+            rank=0,
+            first_noticed_at=datetime.now(UTC),
+        )
+    )
+    return "passion:seed"
+
+
+# --------- AC-26.1..5 creation ---------------------------------------------
+
+
+def test_ac_26_1_write_todo_defaults_active(srepo, self_id, new_id, motivator) -> None:
+    t = write_self_todo(srepo, self_id, "Re-read Tulving", motivator, new_id)
+    assert t.status == TodoStatus.ACTIVE
+    assert t.outcome_text is None
+    assert t.motivated_by_node_id == motivator
+
+
+def test_ac_26_2_missing_motivator_raises(srepo, self_id, new_id) -> None:
+    with pytest.raises(ValueError, match="motivated_by_node_id is required"):
+        write_self_todo(srepo, self_id, "x", "", new_id)
+
+
+def test_ac_26_3_dangling_motivator_raises(srepo, self_id, new_id) -> None:
+    with pytest.raises(ValueError, match="unknown motivator"):
+        write_self_todo(srepo, self_id, "x", "passion:ghost", new_id)
+
+
+def test_ac_26_4_todo_text_cap(srepo, self_id, new_id, motivator) -> None:
+    # 500 OK
+    write_self_todo(srepo, self_id, "x" * 500, motivator, new_id)
+    with pytest.raises(TodoTextTooLong):
+        write_self_todo(srepo, self_id, "x" * 501, motivator, new_id)
+
+
+# --------- AC-26.6..10 revision -------------------------------------------
+
+
+def test_ac_26_6_revise_appends_history(srepo, self_id, new_id, motivator) -> None:
+    t = write_self_todo(srepo, self_id, "original", motivator, new_id)
+    revise_self_todo(srepo, self_id, t.node_id, "updated once", "clarification", new_id)
+    revise_self_todo(srepo, self_id, t.node_id, "updated twice", "more", new_id)
+    revs = srepo.list_todo_revisions(t.node_id)
+    assert [r.revision_num for r in revs] == [1, 2]
+    assert [r.text_after for r in revs] == ["updated once", "updated twice"]
+
+
+def test_ac_26_7_revise_completed_todo_raises(srepo, self_id, new_id, motivator) -> None:
+    t = write_self_todo(srepo, self_id, "original", motivator, new_id)
+    complete_self_todo(srepo, self_id, t.node_id, "done", new_id)
+    with pytest.raises(TodoNotActive):
+        revise_self_todo(srepo, self_id, t.node_id, "x", "x", new_id)
+
+
+def test_ac_26_7_revise_archived_todo_raises(srepo, self_id, new_id, motivator) -> None:
+    t = write_self_todo(srepo, self_id, "original", motivator, new_id)
+    archive_self_todo(srepo, self_id, t.node_id, "changed mind")
+    with pytest.raises(TodoNotActive):
+        revise_self_todo(srepo, self_id, t.node_id, "x", "x", new_id)
+
+
+def test_ac_26_8_revision_num_monotonic(srepo, self_id, new_id, motivator) -> None:
+    t = write_self_todo(srepo, self_id, "a", motivator, new_id)
+    for i in range(5):
+        revise_self_todo(srepo, self_id, t.node_id, f"v{i}", "r", new_id)
+    revs = srepo.list_todo_revisions(t.node_id)
+    assert [r.revision_num for r in revs] == [1, 2, 3, 4, 5]
+
+
+# --------- AC-26.11..14 completion ----------------------------------------
+
+
+def test_ac_26_11_complete_requires_outcome(srepo, self_id, new_id, motivator) -> None:
+    t = write_self_todo(srepo, self_id, "x", motivator, new_id)
+    with pytest.raises(ValueError, match="outcome_text is required"):
+        complete_self_todo(srepo, self_id, t.node_id, "  ", new_id)
+
+
+def test_ac_26_11_complete_sets_status_and_outcome(srepo, self_id, new_id, motivator) -> None:
+    t = write_self_todo(srepo, self_id, "x", motivator, new_id)
+    done = complete_self_todo(srepo, self_id, t.node_id, "great outcome", new_id)
+    assert done.status == TodoStatus.COMPLETED
+    assert done.outcome_text == "great outcome"
+
+
+def test_ac_26_13_double_complete_raises(srepo, self_id, new_id, motivator) -> None:
+    t = write_self_todo(srepo, self_id, "x", motivator, new_id)
+    complete_self_todo(srepo, self_id, t.node_id, "done", new_id)
+    with pytest.raises(TodoNotActive):
+        complete_self_todo(srepo, self_id, t.node_id, "done again", new_id)
+
+
+def test_ac_26_14_completion_writes_contributor_when_memory_id_provided(
+    srepo, self_id, new_id, motivator
+) -> None:
+    t = write_self_todo(srepo, self_id, "x", motivator, new_id)
+    before = len(srepo.active_contributors_for(motivator, at=datetime.now(UTC)))
+    complete_self_todo(
+        srepo, self_id, t.node_id, "done", new_id, affirmation_memory_id="mem:42"
+    )
+    after = srepo.active_contributors_for(motivator, at=datetime.now(UTC))
+    assert len(after) == before + 1
+    new = [c for c in after if c.source_id == "mem:42"][0]
+    assert new.weight == pytest.approx(0.3)
+
+
+# --------- AC-26.15..17 archival ------------------------------------------
+
+
+def test_ac_26_15_archive_sets_status(srepo, self_id, new_id, motivator) -> None:
+    t = write_self_todo(srepo, self_id, "x", motivator, new_id)
+    archive_self_todo(srepo, self_id, t.node_id, "priorities shifted")
+    after = srepo.get_todo(t.node_id)
+    assert after.status == TodoStatus.ARCHIVED
+
+
+def test_ac_26_16_archive_completed_raises(srepo, self_id, new_id, motivator) -> None:
+    t = write_self_todo(srepo, self_id, "x", motivator, new_id)
+    complete_self_todo(srepo, self_id, t.node_id, "done", new_id)
+    with pytest.raises(TodoNotActive):
+        archive_self_todo(srepo, self_id, t.node_id, "reason")
+
+
+# --------- AC-26.18..19 queries -------------------------------------------
+
+
+def test_ac_26_18_list_active_orders_by_created_at(
+    srepo, self_id, new_id, motivator
+) -> None:
+    t1 = write_self_todo(srepo, self_id, "first", motivator, new_id)
+    t2 = write_self_todo(srepo, self_id, "second", motivator, new_id)
+    t3 = write_self_todo(srepo, self_id, "third", motivator, new_id)
+    archive_self_todo(srepo, self_id, t2.node_id, "skip")
+    active = srepo.list_active_todos(self_id)
+    assert [t.node_id for t in active] == [t1.node_id, t3.node_id]
+
+
+def test_ac_26_19_list_for_motivator(srepo, self_id, new_id, motivator) -> None:
+    write_self_todo(srepo, self_id, "a", motivator, new_id)
+    write_self_todo(srepo, self_id, "b", motivator, new_id)
+    got = srepo.list_todos_for_motivator(self_id, motivator)
+    assert {t.text for t in got} == {"a", "b"}
+
+
+# --------- AC-26.22 lock/race (serial simulation) -------------------------
+
+
+def test_ac_26_22_complete_after_revise_still_works(
+    srepo, self_id, new_id, motivator
+) -> None:
+    t = write_self_todo(srepo, self_id, "original", motivator, new_id)
+    revise_self_todo(srepo, self_id, t.node_id, "updated", "reason", new_id)
+    complete_self_todo(srepo, self_id, t.node_id, "done", new_id)
+    final = srepo.get_todo(t.node_id)
+    assert final.text == "updated"
+    assert final.status == TodoStatus.COMPLETED

--- a/research/project-turing/sketches/turing/schema.sql
+++ b/research/project-turing/sketches/turing/schema.sql
@@ -126,3 +126,217 @@ CREATE TABLE IF NOT EXISTS working_memory (
 
 CREATE INDEX IF NOT EXISTS idx_working_memory_self
     ON working_memory (self_id, priority DESC, created_at DESC);
+
+
+-- -------------------------------------------------------------- self-model --
+--
+-- Tables implementing specs 22-30 (Tranche 6). One global self per research
+-- deployment; `self_id` column is present on every table so audits can
+-- distinguish in the hypothetical multi-self future.
+
+
+-- 24 HEXACO facets per self.
+CREATE TABLE IF NOT EXISTS self_personality_facets (
+    node_id          TEXT PRIMARY KEY,
+    self_id          TEXT NOT NULL,
+    trait            TEXT NOT NULL,
+    facet_id         TEXT NOT NULL,
+    score            REAL NOT NULL CHECK (score >= 1.0 AND score <= 5.0),
+    last_revised_at  TEXT NOT NULL,
+    created_at       TEXT NOT NULL,
+    updated_at       TEXT NOT NULL,
+    UNIQUE (self_id, trait, facet_id)
+);
+
+
+-- 200 HEXACO-PI-R items. Shared across selves (static after seed).
+CREATE TABLE IF NOT EXISTS self_personality_items (
+    node_id          TEXT PRIMARY KEY,
+    self_id          TEXT NOT NULL,
+    item_number      INTEGER NOT NULL CHECK (item_number BETWEEN 1 AND 200),
+    prompt_text      TEXT NOT NULL,
+    keyed_facet      TEXT NOT NULL,
+    reverse_scored   INTEGER NOT NULL DEFAULT 0,
+    created_at       TEXT NOT NULL,
+    updated_at       TEXT NOT NULL,
+    UNIQUE (self_id, item_number)
+);
+
+
+-- Bootstrap + retest answers.
+CREATE TABLE IF NOT EXISTS self_personality_answers (
+    node_id             TEXT PRIMARY KEY,
+    self_id             TEXT NOT NULL,
+    item_id             TEXT NOT NULL,
+    revision_id         TEXT,
+    answer_1_5          INTEGER NOT NULL CHECK (answer_1_5 BETWEEN 1 AND 5),
+    justification_text  TEXT NOT NULL,
+    asked_at            TEXT NOT NULL,
+    created_at          TEXT NOT NULL,
+    updated_at          TEXT NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_answers_self_asked
+    ON self_personality_answers (self_id, asked_at DESC);
+
+
+-- Weekly retest snapshots.
+CREATE TABLE IF NOT EXISTS self_personality_revisions (
+    node_id            TEXT PRIMARY KEY,
+    self_id            TEXT NOT NULL,
+    revision_id        TEXT NOT NULL UNIQUE,
+    ran_at             TEXT NOT NULL,
+    sampled_item_ids   TEXT NOT NULL,          -- JSON array length == 20
+    deltas_by_facet    TEXT NOT NULL,          -- JSON object facet -> float
+    created_at         TEXT NOT NULL,
+    updated_at         TEXT NOT NULL
+);
+
+
+CREATE TABLE IF NOT EXISTS self_passions (
+    node_id            TEXT PRIMARY KEY,
+    self_id            TEXT NOT NULL,
+    text               TEXT NOT NULL,
+    strength           REAL NOT NULL CHECK (strength BETWEEN 0.0 AND 1.0),
+    rank               INTEGER NOT NULL CHECK (rank >= 0),
+    first_noticed_at   TEXT NOT NULL,
+    created_at         TEXT NOT NULL,
+    updated_at         TEXT NOT NULL,
+    UNIQUE (self_id, rank)
+);
+
+
+CREATE TABLE IF NOT EXISTS self_hobbies (
+    node_id            TEXT PRIMARY KEY,
+    self_id            TEXT NOT NULL,
+    name               TEXT NOT NULL,
+    description        TEXT NOT NULL,
+    last_engaged_at    TEXT,
+    created_at         TEXT NOT NULL,
+    updated_at         TEXT NOT NULL,
+    UNIQUE (self_id, name)
+);
+
+
+CREATE TABLE IF NOT EXISTS self_interests (
+    node_id            TEXT PRIMARY KEY,
+    self_id            TEXT NOT NULL,
+    topic              TEXT NOT NULL,
+    description        TEXT NOT NULL,
+    last_noticed_at    TEXT,
+    created_at         TEXT NOT NULL,
+    updated_at         TEXT NOT NULL,
+    UNIQUE (self_id, topic)
+);
+
+
+CREATE TABLE IF NOT EXISTS self_preferences (
+    node_id            TEXT PRIMARY KEY,
+    self_id            TEXT NOT NULL,
+    kind               TEXT NOT NULL CHECK (kind IN ('like', 'dislike', 'favorite', 'avoid')),
+    target             TEXT NOT NULL,
+    strength           REAL NOT NULL CHECK (strength BETWEEN 0.0 AND 1.0),
+    rationale          TEXT NOT NULL,
+    created_at         TEXT NOT NULL,
+    updated_at         TEXT NOT NULL,
+    UNIQUE (self_id, kind, target)
+);
+
+
+CREATE TABLE IF NOT EXISTS self_skills (
+    node_id              TEXT PRIMARY KEY,
+    self_id              TEXT NOT NULL,
+    name                 TEXT NOT NULL,
+    kind                 TEXT NOT NULL CHECK (kind IN ('intellectual', 'physical', 'habit', 'social')),
+    stored_level         REAL NOT NULL CHECK (stored_level BETWEEN 0.0 AND 1.0),
+    decay_rate_per_day   REAL NOT NULL CHECK (decay_rate_per_day > 0.0),
+    last_practiced_at    TEXT NOT NULL,
+    created_at           TEXT NOT NULL,
+    updated_at           TEXT NOT NULL,
+    UNIQUE (self_id, name)
+);
+
+
+CREATE TABLE IF NOT EXISTS self_todos (
+    node_id              TEXT PRIMARY KEY,
+    self_id              TEXT NOT NULL,
+    text                 TEXT NOT NULL,
+    motivated_by_node_id TEXT NOT NULL,
+    status               TEXT NOT NULL DEFAULT 'active'
+                          CHECK (status IN ('active', 'completed', 'archived')),
+    outcome_text         TEXT,
+    created_at           TEXT NOT NULL,
+    updated_at           TEXT NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_self_todos_active
+    ON self_todos (self_id, status, created_at);
+
+
+CREATE TABLE IF NOT EXISTS self_todo_revisions (
+    node_id        TEXT PRIMARY KEY,
+    self_id        TEXT NOT NULL,
+    todo_id        TEXT NOT NULL,
+    revision_num   INTEGER NOT NULL CHECK (revision_num >= 1),
+    text_before    TEXT NOT NULL,
+    text_after     TEXT NOT NULL,
+    revised_at     TEXT NOT NULL,
+    created_at     TEXT NOT NULL,
+    updated_at     TEXT NOT NULL,
+    UNIQUE (todo_id, revision_num)
+);
+
+-- Block updates and deletes on the revision table (append-only).
+CREATE TRIGGER IF NOT EXISTS self_todo_revisions_no_update
+    BEFORE UPDATE ON self_todo_revisions
+BEGIN
+    SELECT RAISE(ABORT, 'self_todo_revisions is append-only');
+END;
+
+CREATE TRIGGER IF NOT EXISTS self_todo_revisions_no_delete
+    BEFORE DELETE ON self_todo_revisions
+BEGIN
+    SELECT RAISE(ABORT, 'self_todo_revisions is append-only');
+END;
+
+
+CREATE TABLE IF NOT EXISTS self_mood (
+    self_id       TEXT PRIMARY KEY,
+    valence       REAL NOT NULL CHECK (valence BETWEEN -1.0 AND 1.0),
+    arousal       REAL NOT NULL CHECK (arousal BETWEEN 0.0 AND 1.0),
+    focus         REAL NOT NULL CHECK (focus BETWEEN 0.0 AND 1.0),
+    last_tick_at  TEXT NOT NULL,
+    updated_at    TEXT NOT NULL
+);
+
+
+CREATE TABLE IF NOT EXISTS self_activation_contributors (
+    node_id         TEXT PRIMARY KEY,
+    self_id         TEXT NOT NULL,
+    target_node_id  TEXT NOT NULL,
+    target_kind     TEXT NOT NULL,
+    source_id       TEXT NOT NULL,
+    source_kind     TEXT NOT NULL,
+    weight          REAL NOT NULL CHECK (weight BETWEEN -1.0 AND 1.0),
+    origin          TEXT NOT NULL CHECK (origin IN ('self', 'rule', 'retrieval')),
+    rationale       TEXT NOT NULL,
+    expires_at      TEXT,
+    retracted_by    TEXT,
+    created_at      TEXT NOT NULL,
+    updated_at      TEXT NOT NULL,
+    CHECK (target_node_id <> source_id),
+    CHECK ((origin = 'retrieval') = (expires_at IS NOT NULL))
+);
+
+CREATE INDEX IF NOT EXISTS idx_activation_target
+    ON self_activation_contributors (target_node_id, expires_at);
+
+
+-- Bootstrap progress checkpoint (self-bootstrap resume support).
+CREATE TABLE IF NOT EXISTS self_bootstrap_progress (
+    self_id           TEXT PRIMARY KEY,
+    seed              INTEGER,
+    last_item_number  INTEGER NOT NULL DEFAULT 0,
+    started_at        TEXT NOT NULL,
+    updated_at        TEXT NOT NULL
+);

--- a/research/project-turing/sketches/turing/self_activation.py
+++ b/research/project-turing/sketches/turing/self_activation.py
@@ -1,0 +1,112 @@
+"""Activation graph: contributor aggregation and `active_now` computation.
+
+See specs/activation-graph.md.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass, field
+from datetime import UTC, datetime, timedelta
+
+from .self_mood import mood_descriptor  # noqa: F401  (re-exported convenience)
+from .self_model import current_level
+from .self_repo import SelfRepo
+
+
+SCALE: float = 2.0
+RETRIEVAL_TTL: timedelta = timedelta(minutes=5)
+RETRIEVAL_WEIGHT_COEFFICIENT: float = 0.4
+HOBBY_RECENCY_DAYS: float = 14.0
+INTEREST_RECENCY_DAYS: float = 30.0
+
+
+@dataclass
+class ActivationContext:
+    self_id: str
+    now: datetime
+    retrieval_similarity: dict[str, float] = field(default_factory=dict)
+
+    @property
+    def hash(self) -> str:
+        # Context cache key; we don't cache in this in-process sketch.
+        # Included to match the spec interface.
+        return f"{self_id_or_none(self.self_id)}|{self.now.isoformat()}"
+
+
+def self_id_or_none(s: str | None) -> str:
+    return s or ""
+
+
+def _sigmoid(x: float) -> float:
+    return 1.0 / (1.0 + math.exp(-x))
+
+
+def _recency_state(last: datetime | None, now: datetime, window_days: float) -> float:
+    if last is None:
+        return 0.0
+    days = (now - last).total_seconds() / 86400.0
+    if days <= 0:
+        return 1.0
+    if days >= window_days:
+        return 0.0
+    return 1.0 - (days / window_days)
+
+
+def source_state(repo: SelfRepo, source_id: str, source_kind: str,
+                 ctx: ActivationContext) -> float:
+    """Resolve a source's current state to `[0.0, 1.0]`."""
+    if source_kind == "personality_facet":
+        facet = repo.get_facet(source_id)
+        return max(0.0, min(1.0, (facet.score - 1.0) / 4.0))
+    if source_kind == "passion":
+        p = repo.get_passion(source_id)
+        return p.strength
+    if source_kind == "preference":
+        for p in repo.list_preferences(ctx.self_id):
+            if p.node_id == source_id:
+                return p.strength
+        raise KeyError(source_id)
+    if source_kind == "hobby":
+        for h in repo.list_hobbies(ctx.self_id):
+            if h.node_id == source_id:
+                return _recency_state(h.last_engaged_at, ctx.now, HOBBY_RECENCY_DAYS)
+        raise KeyError(source_id)
+    if source_kind == "interest":
+        for i in repo.list_interests(ctx.self_id):
+            if i.node_id == source_id:
+                return _recency_state(i.last_noticed_at, ctx.now, INTEREST_RECENCY_DAYS)
+        raise KeyError(source_id)
+    if source_kind == "skill":
+        s = repo.get_skill(source_id)
+        return current_level(s, ctx.now)
+    if source_kind == "mood":
+        m = repo.get_mood(ctx.self_id)
+        return (m.valence + 1.0) / 2.0
+    if source_kind == "memory":
+        # Memory weight is stored externally to self-model; in this sketch we
+        # surface a neutral contribution when the memory row isn't reachable.
+        # The primary consumer (tests) will pass real memory ids as needed.
+        return 0.5
+    if source_kind == "rule":
+        return 1.0
+    if source_kind == "retrieval":
+        return ctx.retrieval_similarity.get(source_id, 0.0)
+    raise ValueError(f"unknown source_kind: {source_kind}")
+
+
+def active_now(repo: SelfRepo, node_id: str, ctx: ActivationContext) -> float:
+    """Bounded activation: sigmoid(Σ weight × source_state / SCALE), [0, 1]."""
+    contribs = repo.active_contributors_for(node_id, at=ctx.now)
+    if not contribs:
+        # Spec 25 AC-25.20: zero durable contributors → 0.5 neutral baseline.
+        return 0.5
+    raw = 0.0
+    for c in contribs:
+        try:
+            s = source_state(repo, c.source_id, c.source_kind, ctx)
+        except KeyError:
+            # Spec 25 AC-25.23: dangling source → weight-0 for this compute.
+            continue
+        raw += c.weight * s
+    return max(0.0, min(1.0, _sigmoid(raw / SCALE)))

--- a/research/project-turing/sketches/turing/self_bootstrap.py
+++ b/research/project-turing/sketches/turing/self_bootstrap.py
@@ -1,0 +1,204 @@
+"""Self bootstrap procedure. See specs/self-bootstrap.md.
+
+Exposes `run_bootstrap(...)` as a callable; the CLI wrapper is deferred.
+"""
+
+from __future__ import annotations
+
+import random
+from collections.abc import Callable
+from datetime import UTC, datetime
+
+from .self_model import (
+    ALL_FACETS,
+    CANONICAL_FACETS,
+    Mood,
+    PersonalityAnswer,
+    PersonalityFacet,
+    PersonalityItem,
+    Trait,
+    facet_node_id,
+)
+from .self_personality import draw_bootstrap_profile
+from .self_repo import SelfRepo
+
+
+class AlreadyBootstrapped(Exception):
+    pass
+
+
+class BootstrapValidationError(Exception):
+    pass
+
+
+class BootstrapRuntimeError(Exception):
+    pass
+
+
+AnswerLlm = Callable[[PersonalityItem, dict[str, float]], tuple[int, str]]
+
+
+def preflight_validate(repo: SelfRepo, self_id: str) -> None:
+    if repo.count_facets(self_id) > 0:
+        raise AlreadyBootstrapped(self_id)
+    if repo.count_answers(self_id) > 0:
+        raise AlreadyBootstrapped(self_id)
+    if repo.has_mood(self_id):
+        raise AlreadyBootstrapped(self_id)
+
+
+def ensure_items_loaded(
+    repo: SelfRepo,
+    self_id: str,
+    item_bank: list[dict],
+    new_id: Callable[[str], str],
+) -> None:
+    existing = repo.count_items(self_id)
+    if existing == 200:
+        return
+    if existing != 0:
+        raise BootstrapValidationError(
+            f"item bank has {existing} rows, expected 0 or 200"
+        )
+    if len(item_bank) != 200:
+        raise BootstrapValidationError(
+            f"item bank fixture has {len(item_bank)} rows, expected 200"
+        )
+    for spec in item_bank:
+        repo.insert_item(
+            PersonalityItem(
+                node_id=new_id("item"),
+                self_id=self_id,
+                item_number=spec["item_number"],
+                prompt_text=spec["prompt_text"],
+                keyed_facet=spec["keyed_facet"],
+                reverse_scored=bool(spec.get("reverse_scored", False)),
+            )
+        )
+
+
+def draw_and_persist_facets(
+    repo: SelfRepo,
+    self_id: str,
+    seed: int | None,
+    overrides: dict[str, float] | None,
+    new_id: Callable[[str], str],
+) -> dict[str, float]:
+    rng = random.Random(seed)
+    profile = draw_bootstrap_profile(rng, overrides=overrides)
+    now = datetime.now(UTC)
+    for (trait, facet) in ALL_FACETS:
+        key = facet_node_id(trait, facet)
+        repo.insert_facet(
+            PersonalityFacet(
+                node_id=key,
+                self_id=self_id,
+                trait=trait,
+                facet_id=facet,
+                score=profile[key],
+                last_revised_at=now,
+            )
+        )
+    return profile
+
+
+def generate_likert_answers(
+    repo: SelfRepo,
+    self_id: str,
+    profile: dict[str, float],
+    ask: AnswerLlm,
+    new_id: Callable[[str], str],
+    start_at: int = 1,
+) -> None:
+    items = repo.list_items(self_id)
+    if start_at > 1:
+        items = [it for it in items if it.item_number >= start_at]
+    for item in items:
+        raw, justification = _ask_with_retry(ask, item, profile)
+        repo.insert_answer(
+            PersonalityAnswer(
+                node_id=new_id("ans"),
+                self_id=self_id,
+                item_id=item.node_id,
+                revision_id=None,
+                answer_1_5=raw,
+                justification_text=justification[:200],
+                asked_at=datetime.now(UTC),
+            )
+        )
+        repo.update_bootstrap_progress(self_id, item.item_number)
+
+
+def _ask_with_retry(ask: AnswerLlm, item: PersonalityItem, profile: dict[str, float]) -> tuple[int, str]:
+    last_err: Exception | None = None
+    for _ in range(3):
+        try:
+            raw, justification = ask(item, profile)
+            if raw not in (1, 2, 3, 4, 5):
+                raise BootstrapRuntimeError(f"bad answer {raw} for item {item.item_number}")
+            return int(raw), str(justification)
+        except Exception as e:
+            last_err = e
+    raise BootstrapRuntimeError(str(last_err) if last_err else "answer generation failed")
+
+
+def finalize(repo: SelfRepo, self_id: str) -> None:
+    now = datetime.now(UTC)
+    repo.insert_mood(
+        Mood(
+            self_id=self_id,
+            valence=0.0,
+            arousal=0.3,
+            focus=0.5,
+            last_tick_at=now,
+        )
+    )
+    repo.delete_bootstrap_progress(self_id)
+
+
+def run_bootstrap(
+    repo: SelfRepo,
+    self_id: str,
+    seed: int | None,
+    ask: AnswerLlm,
+    item_bank: list[dict],
+    new_id: Callable[[str], str],
+    resume: bool = False,
+    overrides: dict[str, float] | None = None,
+) -> dict[str, float]:
+    """Top-level flow. Returns the HEXACO profile used."""
+    if not resume:
+        preflight_validate(repo, self_id)
+        repo.start_bootstrap_progress(self_id, seed=seed)
+        ensure_items_loaded(repo, self_id, item_bank, new_id)
+        profile = draw_and_persist_facets(repo, self_id, seed, overrides, new_id)
+        start_at = 1
+    else:
+        progress = repo.get_bootstrap_progress(self_id)
+        if progress is None:
+            raise BootstrapValidationError("nothing to resume")
+        # Reconstruct profile from stored facets.
+        profile = {
+            facet_node_id(f.trait, f.facet_id): f.score
+            for f in repo.list_facets(self_id)
+        }
+        ensure_items_loaded(repo, self_id, item_bank, new_id)
+        start_at = progress + 1
+
+    generate_likert_answers(
+        repo, self_id, profile, ask=ask, new_id=new_id, start_at=start_at
+    )
+    finalize(repo, self_id)
+    verify_final_state(repo, self_id)
+    return profile
+
+
+def verify_final_state(repo: SelfRepo, self_id: str) -> list[str]:
+    problems: list[str] = []
+    if repo.count_facets(self_id) != 24:
+        problems.append(f"facets={repo.count_facets(self_id)}")
+    if repo.count_answers(self_id) != 200:
+        problems.append(f"answers={repo.count_answers(self_id)}")
+    if not repo.has_mood(self_id):
+        problems.append("missing mood")
+    return problems

--- a/research/project-turing/sketches/turing/self_model.py
+++ b/research/project-turing/sketches/turing/self_model.py
@@ -1,0 +1,355 @@
+"""Self-model value types and enums.
+
+See specs/self-schema.md, specs/personality.md, specs/self-nodes.md,
+specs/self-todos.md, specs/mood.md, specs/activation-graph.md.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from enum import StrEnum
+
+
+# ---------------------------------------------------------------- enums ------
+
+
+class Trait(StrEnum):
+    HONESTY_HUMILITY = "honesty_humility"
+    EMOTIONALITY = "emotionality"
+    EXTRAVERSION = "extraversion"
+    AGREEABLENESS = "agreeableness"
+    CONSCIENTIOUSNESS = "conscientiousness"
+    OPENNESS = "openness"
+
+
+class NodeKind(StrEnum):
+    PERSONALITY_FACET = "personality_facet"
+    PASSION = "passion"
+    HOBBY = "hobby"
+    INTEREST = "interest"
+    PREFERENCE = "preference"
+    SKILL = "skill"
+    TODO = "todo"
+    MOOD = "mood"
+
+
+class ContributorOrigin(StrEnum):
+    SELF = "self"
+    RULE = "rule"
+    RETRIEVAL = "retrieval"
+
+
+class SkillKind(StrEnum):
+    INTELLECTUAL = "intellectual"
+    PHYSICAL = "physical"
+    HABIT = "habit"
+    SOCIAL = "social"
+
+
+class PreferenceKind(StrEnum):
+    LIKE = "like"
+    DISLIKE = "dislike"
+    FAVORITE = "favorite"
+    AVOID = "avoid"
+
+
+class TodoStatus(StrEnum):
+    ACTIVE = "active"
+    COMPLETED = "completed"
+    ARCHIVED = "archived"
+
+
+# ---------------------------------------------------------------- constants --
+
+
+# 24 canonical HEXACO-PI-R facets, four per trait.
+CANONICAL_FACETS: dict[Trait, tuple[str, str, str, str]] = {
+    Trait.HONESTY_HUMILITY: ("sincerity", "fairness", "greed_avoidance", "modesty"),
+    Trait.EMOTIONALITY: ("fearfulness", "anxiety", "dependence", "sentimentality"),
+    Trait.EXTRAVERSION: ("social_self_esteem", "social_boldness", "sociability", "liveliness"),
+    Trait.AGREEABLENESS: ("forgiveness", "gentleness", "flexibility", "patience"),
+    Trait.CONSCIENTIOUSNESS: ("organization", "diligence", "perfectionism", "prudence"),
+    Trait.OPENNESS: (
+        "aesthetic_appreciation",
+        "inquisitiveness",
+        "creativity",
+        "unconventionality",
+    ),
+}
+
+ALL_FACETS: list[tuple[Trait, str]] = [
+    (t, f) for t, facets in CANONICAL_FACETS.items() for f in facets
+]
+assert len(ALL_FACETS) == 24
+
+
+FACET_TO_TRAIT: dict[str, Trait] = {f: t for t, f in ALL_FACETS}
+
+
+def facet_node_id(trait: Trait, facet: str) -> str:
+    """Canonical node_id for a personality facet row."""
+    return f"facet:{trait.value}.{facet}"
+
+
+# Per-kind default decay rates (per spec 24 AC-24.5). Per-day.
+DEFAULT_DECAY_RATES: dict[SkillKind, float] = {
+    SkillKind.INTELLECTUAL: 0.0005,
+    SkillKind.PHYSICAL: 0.005,
+    SkillKind.HABIT: 0.002,
+    SkillKind.SOCIAL: 0.001,
+}
+
+
+# ---------------------------------------------------------------- helpers ----
+
+
+def _now() -> datetime:
+    return datetime.now(UTC)
+
+
+# ---------------------------------------------------------------- nodes ------
+
+
+@dataclass
+class PersonalityFacet:
+    node_id: str
+    self_id: str
+    trait: Trait
+    facet_id: str
+    score: float
+    last_revised_at: datetime
+    created_at: datetime = field(default_factory=_now)
+    updated_at: datetime = field(default_factory=_now)
+
+    def __post_init__(self) -> None:
+        if not 1.0 <= self.score <= 5.0:
+            raise ValueError(f"facet score out of range: {self.score}")
+        if self.facet_id not in FACET_TO_TRAIT:
+            raise ValueError(f"unknown facet_id: {self.facet_id}")
+        if FACET_TO_TRAIT[self.facet_id] != self.trait:
+            raise ValueError(
+                f"facet {self.facet_id} does not belong to trait {self.trait}"
+            )
+        if not self.self_id:
+            raise ValueError("self_id is required")
+
+
+@dataclass
+class PersonalityItem:
+    node_id: str
+    self_id: str
+    item_number: int
+    prompt_text: str
+    keyed_facet: str
+    reverse_scored: bool
+    created_at: datetime = field(default_factory=_now)
+    updated_at: datetime = field(default_factory=_now)
+
+    def __post_init__(self) -> None:
+        if not 1 <= self.item_number <= 200:
+            raise ValueError(f"item_number out of range: {self.item_number}")
+        if self.keyed_facet not in FACET_TO_TRAIT:
+            raise ValueError(f"unknown keyed_facet: {self.keyed_facet}")
+
+
+@dataclass
+class PersonalityAnswer:
+    node_id: str
+    self_id: str
+    item_id: str
+    revision_id: str | None
+    answer_1_5: int
+    justification_text: str
+    asked_at: datetime
+    created_at: datetime = field(default_factory=_now)
+    updated_at: datetime = field(default_factory=_now)
+
+    def __post_init__(self) -> None:
+        if self.answer_1_5 not in (1, 2, 3, 4, 5):
+            raise ValueError(f"answer must be 1..5, got {self.answer_1_5}")
+        if len(self.justification_text) > 200:
+            raise ValueError("justification_text exceeds 200 chars")
+
+
+@dataclass
+class PersonalityRevision:
+    node_id: str
+    self_id: str
+    revision_id: str
+    ran_at: datetime
+    sampled_item_ids: list[str]
+    deltas_by_facet: dict[str, float]
+    created_at: datetime = field(default_factory=_now)
+    updated_at: datetime = field(default_factory=_now)
+
+    def __post_init__(self) -> None:
+        if len(self.sampled_item_ids) != 20:
+            raise ValueError(
+                f"retest sample must be exactly 20 items, got {len(self.sampled_item_ids)}"
+            )
+
+
+@dataclass
+class Passion:
+    node_id: str
+    self_id: str
+    text: str
+    strength: float
+    rank: int
+    first_noticed_at: datetime
+    created_at: datetime = field(default_factory=_now)
+    updated_at: datetime = field(default_factory=_now)
+
+    def __post_init__(self) -> None:
+        if not 0.0 <= self.strength <= 1.0:
+            raise ValueError(f"strength out of range: {self.strength}")
+        if self.rank < 0:
+            raise ValueError("rank must be >= 0")
+
+
+@dataclass
+class Hobby:
+    node_id: str
+    self_id: str
+    name: str
+    description: str
+    last_engaged_at: datetime | None = None
+    created_at: datetime = field(default_factory=_now)
+    updated_at: datetime = field(default_factory=_now)
+
+
+@dataclass
+class Interest:
+    node_id: str
+    self_id: str
+    topic: str
+    description: str
+    last_noticed_at: datetime | None = None
+    created_at: datetime = field(default_factory=_now)
+    updated_at: datetime = field(default_factory=_now)
+
+
+@dataclass
+class Preference:
+    node_id: str
+    self_id: str
+    kind: PreferenceKind
+    target: str
+    strength: float
+    rationale: str
+    created_at: datetime = field(default_factory=_now)
+    updated_at: datetime = field(default_factory=_now)
+
+    def __post_init__(self) -> None:
+        if not 0.0 <= self.strength <= 1.0:
+            raise ValueError(f"strength out of range: {self.strength}")
+
+
+@dataclass
+class Skill:
+    node_id: str
+    self_id: str
+    name: str
+    kind: SkillKind
+    stored_level: float
+    decay_rate_per_day: float
+    last_practiced_at: datetime
+    created_at: datetime = field(default_factory=_now)
+    updated_at: datetime = field(default_factory=_now)
+
+    def __post_init__(self) -> None:
+        if not 0.0 <= self.stored_level <= 1.0:
+            raise ValueError(f"stored_level out of range: {self.stored_level}")
+        if self.decay_rate_per_day <= 0.0:
+            raise ValueError(f"decay_rate_per_day must be positive, got {self.decay_rate_per_day}")
+
+
+def current_level(skill: Skill, at: datetime) -> float:
+    """Spec 24 §24.2: `stored_level * exp(-rate * days_since_practice)`, clamped [0, 1]."""
+    days = max(0.0, (at - skill.last_practiced_at).total_seconds() / 86400.0)
+    raw = skill.stored_level * math.exp(-skill.decay_rate_per_day * days)
+    return max(0.0, min(1.0, raw))
+
+
+@dataclass
+class SelfTodo:
+    node_id: str
+    self_id: str
+    text: str
+    motivated_by_node_id: str
+    status: TodoStatus = TodoStatus.ACTIVE
+    outcome_text: str | None = None
+    created_at: datetime = field(default_factory=_now)
+    updated_at: datetime = field(default_factory=_now)
+
+    def __post_init__(self) -> None:
+        if not self.motivated_by_node_id:
+            raise ValueError("motivated_by_node_id is required")
+        if len(self.text) > 500:
+            raise ValueError(f"todo text exceeds 500 chars: len={len(self.text)}")
+        if self.status == TodoStatus.COMPLETED and not (self.outcome_text or "").strip():
+            raise ValueError("completed todo requires non-empty outcome_text")
+
+
+@dataclass
+class SelfTodoRevision:
+    node_id: str
+    self_id: str
+    todo_id: str
+    revision_num: int
+    text_before: str
+    text_after: str
+    revised_at: datetime
+    created_at: datetime = field(default_factory=_now)
+    updated_at: datetime = field(default_factory=_now)
+
+    def __post_init__(self) -> None:
+        if self.revision_num < 1:
+            raise ValueError("revision_num starts at 1")
+
+
+@dataclass
+class Mood:
+    self_id: str
+    valence: float
+    arousal: float
+    focus: float
+    last_tick_at: datetime
+    updated_at: datetime = field(default_factory=_now)
+
+    def __post_init__(self) -> None:
+        if not -1.0 <= self.valence <= 1.0:
+            raise ValueError(f"valence out of range: {self.valence}")
+        if not 0.0 <= self.arousal <= 1.0:
+            raise ValueError(f"arousal out of range: {self.arousal}")
+        if not 0.0 <= self.focus <= 1.0:
+            raise ValueError(f"focus out of range: {self.focus}")
+
+
+@dataclass
+class ActivationContributor:
+    node_id: str
+    self_id: str
+    target_node_id: str
+    target_kind: NodeKind
+    source_id: str
+    source_kind: str
+    weight: float
+    origin: ContributorOrigin
+    rationale: str
+    expires_at: datetime | None = None
+    retracted_by: str | None = None
+    created_at: datetime = field(default_factory=_now)
+    updated_at: datetime = field(default_factory=_now)
+
+    def __post_init__(self) -> None:
+        if self.target_node_id == self.source_id:
+            raise ValueError("contributor cannot target itself")
+        if not -1.0 <= self.weight <= 1.0:
+            raise ValueError(f"contributor weight out of range: {self.weight}")
+        if (self.origin == ContributorOrigin.RETRIEVAL) != (self.expires_at is not None):
+            raise ValueError(
+                "retrieval contributors must set expires_at; others must not"
+            )

--- a/research/project-turing/sketches/turing/self_mood.py
+++ b/research/project-turing/sketches/turing/self_mood.py
@@ -1,0 +1,118 @@
+"""Mood tick + nudges. See specs/mood.md."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from .self_model import Mood
+from .self_repo import SelfRepo
+
+
+NEUTRAL_VALENCE: float = 0.0
+NEUTRAL_AROUSAL: float = 0.3
+NEUTRAL_FOCUS: float = 0.5
+DECAY_RATE: float = 0.1          # per hour
+NUDGE_MAX: float = 0.5
+
+
+DIM_RANGES: dict[str, tuple[float, float]] = {
+    "valence": (-1.0, 1.0),
+    "arousal": (0.0, 1.0),
+    "focus": (0.0, 1.0),
+}
+
+NEUTRAL_BY_DIM: dict[str, float] = {
+    "valence": NEUTRAL_VALENCE,
+    "arousal": NEUTRAL_AROUSAL,
+    "focus": NEUTRAL_FOCUS,
+}
+
+
+EVENT_NUDGES: dict[str, list[tuple[str, float]]] = {
+    "tool_succeeded_against_expectation": [("valence", +0.10), ("arousal", +0.05)],
+    "tool_failed_unexpectedly": [("valence", -0.15), ("arousal", +0.10), ("focus", -0.10)],
+    "affirmation_minted": [("valence", +0.10)],
+    "regret_minted": [("valence", -0.20), ("focus", -0.05)],
+    "todo_completed": [("valence", +0.05), ("focus", +0.05)],
+    "warden_alert_on_ingress": [("arousal", +0.20), ("focus", +0.10)],
+}
+
+
+def decay_step(current: float, neutral: float, hours: float) -> float:
+    """Compound decay of `hours` single-hour ticks.
+
+    One hour of decay: `new = current + DECAY_RATE * (neutral - current)`.
+    N hours: `new = current + (1 - (1 - DECAY_RATE)^N) * (neutral - current)`.
+    The asymptote is `neutral`; we never cross it.
+    """
+    if hours <= 0:
+        return current
+    effective = 1.0 - (1.0 - DECAY_RATE) ** hours
+    return current + effective * (neutral - current)
+
+
+def tick_mood_decay(repo: SelfRepo, self_id: str, now: datetime) -> Mood:
+    m = repo.get_mood(self_id)
+    hours = max(0.0, (now - m.last_tick_at).total_seconds() / 3600.0)
+    if hours <= 0:
+        return m
+    m.valence = decay_step(m.valence, NEUTRAL_VALENCE, hours)
+    m.arousal = decay_step(m.arousal, NEUTRAL_AROUSAL, hours)
+    m.focus = decay_step(m.focus, NEUTRAL_FOCUS, hours)
+    m.last_tick_at = now
+    repo.update_mood(m)
+    return m
+
+
+def nudge_mood(
+    repo: SelfRepo,
+    self_id: str,
+    dim: str,
+    delta: float,
+    reason: str,
+) -> Mood:
+    if dim not in DIM_RANGES:
+        raise ValueError(f"unknown mood dim: {dim}")
+    if abs(delta) > NUDGE_MAX:
+        raise ValueError(f"nudge delta {delta} exceeds NUDGE_MAX {NUDGE_MAX}")
+    low, high = DIM_RANGES[dim]
+    m = repo.get_mood(self_id)
+    current = getattr(m, dim)
+    new = max(low, min(high, current + delta))
+    setattr(m, dim, new)
+    repo.update_mood(m)
+    return m
+
+
+def apply_event_nudge(
+    repo: SelfRepo, self_id: str, event: str, reason: str
+) -> Mood | None:
+    """Apply the nudge tuple registered under `event`. Unknown events no-op."""
+    last: Mood | None = None
+    for dim, delta in EVENT_NUDGES.get(event, []):
+        last = nudge_mood(repo, self_id, dim, delta, reason=f"{event}: {reason}")
+    return last
+
+
+def mood_descriptor(m: Mood) -> str:
+    """Spec 27 AC-27.12: qualitative one-liner from (valence, arousal, focus)."""
+    if m.valence < -0.15:
+        v = "negative"
+    elif m.valence > 0.15:
+        v = "positive"
+    else:
+        v = "neutral"
+    a = "high" if m.arousal > 0.6 else "low"
+    core = {
+        ("negative", "low"): "flat, withdrawn",
+        ("negative", "high"): "tense, on edge",
+        ("neutral", "low"): "even, steady",
+        ("neutral", "high"): "alert, attentive",
+        ("positive", "low"): "content, easy",
+        ("positive", "high"): "keen, energized",
+    }[(v, a)]
+    if m.focus > 0.7:
+        return f"{core}; focused"
+    if m.focus < 0.3:
+        return f"{core}; scattered"
+    return core

--- a/research/project-turing/sketches/turing/self_nodes.py
+++ b/research/project-turing/sketches/turing/self_nodes.py
@@ -1,0 +1,283 @@
+"""Tool handlers for accreting passions / hobbies / interests / preferences / skills.
+
+See specs/self-nodes.md.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from collections.abc import Callable
+from datetime import UTC, datetime
+
+from .self_model import (
+    ActivationContributor,
+    ContributorOrigin,
+    DEFAULT_DECAY_RATES,
+    Hobby,
+    Interest,
+    NodeKind,
+    Passion,
+    Preference,
+    PreferenceKind,
+    Skill,
+    SkillKind,
+)
+from .self_repo import SelfRepo
+
+
+def _now() -> datetime:
+    return datetime.now(UTC)
+
+
+def note_passion(
+    repo: SelfRepo,
+    self_id: str,
+    text: str,
+    strength: float,
+    new_id: Callable[[str], str],
+    contributes_to: list[tuple[str, float]] | None = None,
+) -> Passion:
+    _reject_dupe_text(
+        repo.list_passions(self_id), lambda p: p.text, text, kind="passion"
+    )
+    rank = repo.max_passion_rank(self_id) + 1
+    p = Passion(
+        node_id=new_id("passion"),
+        self_id=self_id,
+        text=text,
+        strength=strength,
+        rank=rank,
+        first_noticed_at=_now(),
+    )
+    repo.insert_passion(p)
+    _wire(repo, self_id, p.node_id, NodeKind.PASSION, contributes_to, new_id)
+    return p
+
+
+def note_hobby(
+    repo: SelfRepo,
+    self_id: str,
+    name: str,
+    description: str,
+    new_id: Callable[[str], str],
+    contributes_to: list[tuple[str, float]] | None = None,
+) -> Hobby:
+    _reject_dupe_text(
+        repo.list_hobbies(self_id), lambda h: h.name, name, kind="hobby"
+    )
+    h = Hobby(
+        node_id=new_id("hobby"),
+        self_id=self_id,
+        name=name,
+        description=description,
+    )
+    try:
+        repo.insert_hobby(h)
+    except sqlite3.IntegrityError as e:
+        raise ValueError(f"duplicate hobby: {name}") from e
+    _wire(repo, self_id, h.node_id, NodeKind.HOBBY, contributes_to, new_id)
+    return h
+
+
+def note_interest(
+    repo: SelfRepo,
+    self_id: str,
+    topic: str,
+    description: str,
+    new_id: Callable[[str], str],
+    contributes_to: list[tuple[str, float]] | None = None,
+) -> Interest:
+    _reject_dupe_text(
+        repo.list_interests(self_id), lambda i: i.topic, topic, kind="interest"
+    )
+    i = Interest(
+        node_id=new_id("interest"),
+        self_id=self_id,
+        topic=topic,
+        description=description,
+    )
+    try:
+        repo.insert_interest(i)
+    except sqlite3.IntegrityError as e:
+        raise ValueError(f"duplicate interest: {topic}") from e
+    _wire(repo, self_id, i.node_id, NodeKind.INTEREST, contributes_to, new_id)
+    return i
+
+
+def note_preference(
+    repo: SelfRepo,
+    self_id: str,
+    kind: PreferenceKind,
+    target: str,
+    strength: float,
+    rationale: str,
+    new_id: Callable[[str], str],
+    contributes_to: list[tuple[str, float]] | None = None,
+) -> Preference:
+    # Uniqueness enforced by DB on (self_id, kind, target); catch for a friendlier error.
+    existing = [p for p in repo.list_preferences(self_id)
+                if p.kind == kind and p.target == target]
+    if existing:
+        raise ValueError(f"duplicate preference: ({kind}, {target})")
+    p = Preference(
+        node_id=new_id("pref"),
+        self_id=self_id,
+        kind=kind,
+        target=target,
+        strength=strength,
+        rationale=rationale,
+    )
+    repo.insert_preference(p)
+    _wire(repo, self_id, p.node_id, NodeKind.PREFERENCE, contributes_to, new_id)
+    return p
+
+
+def note_skill(
+    repo: SelfRepo,
+    self_id: str,
+    name: str,
+    level: float,
+    kind: SkillKind,
+    new_id: Callable[[str], str],
+    decay_rate_per_day: float | None = None,
+    contributes_to: list[tuple[str, float]] | None = None,
+) -> Skill:
+    existing = [s for s in repo.list_skills(self_id) if s.name.strip().lower() == name.strip().lower()]
+    if existing:
+        raise ValueError(f"duplicate skill: {name}")
+    s = Skill(
+        node_id=new_id("skill"),
+        self_id=self_id,
+        name=name,
+        kind=kind,
+        stored_level=level,
+        decay_rate_per_day=(
+            decay_rate_per_day
+            if decay_rate_per_day is not None
+            else DEFAULT_DECAY_RATES[kind]
+        ),
+        last_practiced_at=_now(),
+    )
+    repo.insert_skill(s)
+    _wire(repo, self_id, s.node_id, NodeKind.SKILL, contributes_to, new_id)
+    return s
+
+
+def practice_skill(
+    repo: SelfRepo,
+    self_id: str,
+    skill_id: str,
+    new_level: float | None = None,
+    notes: str = "",
+) -> Skill:
+    s = repo.get_skill(skill_id)
+    if s.self_id != self_id:
+        raise PermissionError("cross-self practice forbidden")
+    if new_level is not None:
+        if new_level < s.stored_level:
+            raise ValueError("practice_skill cannot lower stored_level; use downgrade_skill")
+        if not 0.0 <= new_level <= 1.0:
+            raise ValueError("new_level out of range")
+        s.stored_level = new_level
+    s.last_practiced_at = _now()
+    repo.update_skill(s)
+    return s
+
+
+def downgrade_skill(
+    repo: SelfRepo,
+    self_id: str,
+    skill_id: str,
+    new_level: float,
+    reason: str,
+) -> Skill:
+    s = repo.get_skill(skill_id)
+    if s.self_id != self_id:
+        raise PermissionError("cross-self downgrade forbidden")
+    if not 0.0 <= new_level <= 1.0:
+        raise ValueError("new_level out of range")
+    if not reason.strip():
+        raise ValueError("reason is required for downgrade")
+    s.stored_level = new_level
+    repo.update_skill(s)
+    return s
+
+
+def rerank_passions(
+    repo: SelfRepo,
+    self_id: str,
+    ordered_ids: list[str],
+) -> list[Passion]:
+    existing = repo.list_passions(self_id)
+    existing_ids = {p.node_id for p in existing}
+    order_set = set(ordered_ids)
+    if existing_ids != order_set:
+        raise ValueError(
+            f"ordered_ids must match current passions exactly; "
+            f"missing={existing_ids - order_set}, extra={order_set - existing_ids}"
+        )
+    # Two-phase: move everyone to ranks offset by +len(existing) to avoid UNIQUE
+    # constraint collisions, then down to the target.
+    by_id = {p.node_id: p for p in existing}
+    offset = len(existing) + 10
+    for i, pid in enumerate(ordered_ids):
+        p = by_id[pid]
+        p.rank = i + offset
+        repo.update_passion(p)
+    for i, pid in enumerate(ordered_ids):
+        p = by_id[pid]
+        p.rank = i
+        repo.update_passion(p)
+    return repo.list_passions(self_id)
+
+
+def _reject_dupe_text(existing: list, extract, text: str, kind: str) -> None:
+    normalized = " ".join(text.strip().lower().split())
+    for row in existing:
+        candidate = " ".join(extract(row).strip().lower().split())
+        if candidate == normalized:
+            raise ValueError(f"duplicate {kind}: {text!r}")
+
+
+def _wire(
+    repo: SelfRepo,
+    self_id: str,
+    source_node_id: str,
+    source_kind: NodeKind,
+    contributes_to: list[tuple[str, float]] | None,
+    new_id: Callable[[str], str],
+) -> None:
+    if not contributes_to:
+        return
+    for target, weight in contributes_to:
+        repo.insert_contributor(
+            ActivationContributor(
+                node_id=new_id("contrib"),
+                self_id=self_id,
+                target_node_id=target,
+                target_kind=NodeKind.PERSONALITY_FACET
+                if target.startswith("facet:")
+                else _guess_kind(target),
+                source_id=source_node_id,
+                source_kind=source_kind.value,
+                weight=weight,
+                origin=ContributorOrigin.SELF,
+                rationale=f"{source_kind.value} contributes",
+            )
+        )
+
+
+def _guess_kind(node_id: str) -> NodeKind:
+    if node_id.startswith("facet:"):
+        return NodeKind.PERSONALITY_FACET
+    if node_id.startswith("passion"):
+        return NodeKind.PASSION
+    if node_id.startswith("hobby"):
+        return NodeKind.HOBBY
+    if node_id.startswith("interest"):
+        return NodeKind.INTEREST
+    if node_id.startswith("pref"):
+        return NodeKind.PREFERENCE
+    if node_id.startswith("skill"):
+        return NodeKind.SKILL
+    return NodeKind.PERSONALITY_FACET

--- a/research/project-turing/sketches/turing/self_personality.py
+++ b/research/project-turing/sketches/turing/self_personality.py
@@ -1,0 +1,203 @@
+"""HEXACO profile draw and retest math. See specs/personality.md."""
+
+from __future__ import annotations
+
+import random
+from collections import defaultdict
+from collections.abc import Callable
+from datetime import UTC, datetime
+
+from .self_model import (
+    ALL_FACETS,
+    PersonalityAnswer,
+    PersonalityItem,
+    PersonalityRevision,
+    facet_node_id,
+)
+from .self_repo import SelfRepo
+
+
+RETEST_WEIGHT: float = 0.25
+RETEST_SAMPLE_SIZE: int = 20
+FACET_DIVERSITY_FLOOR: int = 12
+BOOTSTRAP_MU: float = 3.0
+BOOTSTRAP_SIGMA: float = 0.8
+
+
+def draw_bootstrap_profile(
+    rng: random.Random,
+    overrides: dict[str, float] | None = None,
+) -> dict[str, float]:
+    """Spec 23 §23.2. Truncated normal μ=3, σ=0.8, clamped to [1, 5]."""
+    overrides = overrides or {}
+    profile: dict[str, float] = {}
+    for trait, facet in ALL_FACETS:
+        key = facet_node_id(trait, facet)
+        mu = overrides.get(key, BOOTSTRAP_MU)
+        raw = rng.gauss(mu=mu, sigma=BOOTSTRAP_SIGMA)
+        profile[key] = min(5.0, max(1.0, raw))
+    return profile
+
+
+def _rng_weighted_sample(
+    rng: random.Random, population: list, weights: list[float], n: int
+) -> list:
+    """Weighted sampling without replacement (rough but deterministic-under-seed)."""
+    assert len(population) == len(weights)
+    assert n <= len(population)
+    remaining = list(zip(population, weights, strict=True))
+    out: list = []
+    for _ in range(n):
+        total = sum(w for _, w in remaining)
+        if total <= 0:
+            # Fallback: uniform over what's left.
+            picked_idx = rng.randrange(len(remaining))
+        else:
+            pick = rng.random() * total
+            running = 0.0
+            picked_idx = len(remaining) - 1
+            for i, (_, w) in enumerate(remaining):
+                running += w
+                if running >= pick:
+                    picked_idx = i
+                    break
+        out.append(remaining[picked_idx][0])
+        remaining.pop(picked_idx)
+    return out
+
+
+def sample_retest_items(
+    items: list[PersonalityItem],
+    last_asked: dict[str, datetime],
+    rng: random.Random,
+    now: datetime,
+    n: int = RETEST_SAMPLE_SIZE,
+    facet_diversity_floor: int = FACET_DIVERSITY_FLOOR,
+) -> list[PersonalityItem]:
+    """Weighted by time-since-last-asked, stratified by facet as a secondary constraint.
+
+    Spec 23 AC-23.12.
+    """
+
+    def weight(it: PersonalityItem) -> float:
+        t = last_asked.get(it.node_id)
+        if t is None:
+            return 10_000.0
+        days = max(0.001, (now - t).total_seconds() / 86400.0)
+        return days
+
+    for _ in range(10):
+        weights = [weight(it) for it in items]
+        choices = _rng_weighted_sample(rng, items, weights, n)
+        if len({c.keyed_facet for c in choices}) >= facet_diversity_floor:
+            return choices
+
+    # Fallback: round-robin by facet, oldest-asked first within each.
+    by_facet: dict[str, list[PersonalityItem]] = defaultdict(list)
+    for it in items:
+        by_facet[it.keyed_facet].append(it)
+    for facet in by_facet:
+        by_facet[facet].sort(
+            key=lambda i: last_asked.get(i.node_id, datetime.min.replace(tzinfo=UTC))
+        )
+    out: list[PersonalityItem] = []
+    order = list(by_facet.keys())
+    i = 0
+    while len(out) < n and any(by_facet.values()):
+        bucket = by_facet[order[i % len(order)]]
+        if bucket:
+            out.append(bucket.pop(0))
+        i += 1
+    return out
+
+
+def compute_facet_deltas(
+    sampled: list[PersonalityItem],
+    raw_answers: list[int],
+    current_scores: dict[str, float],
+) -> dict[str, tuple[float, float]]:
+    """Return `{facet_id: (retest_mean_score, delta_from_current)}` for touched facets.
+
+    Spec 23 AC-23.15, AC-23.16. Reverse scoring uses `6 - raw`.
+    """
+    if len(sampled) != len(raw_answers):
+        raise ValueError("sampled and raw_answers must be same length")
+    by_facet: dict[str, list[int]] = defaultdict(list)
+    for item, raw in zip(sampled, raw_answers, strict=True):
+        scored = (6 - raw) if item.reverse_scored else raw
+        by_facet[item.keyed_facet].append(scored)
+
+    out: dict[str, tuple[float, float]] = {}
+    for facet, vals in by_facet.items():
+        retest_mean = sum(vals) / len(vals)
+        current = current_scores.get(facet)
+        if current is None:
+            raise KeyError(f"no current score for facet {facet}")
+        delta = RETEST_WEIGHT * (retest_mean - current)
+        out[facet] = (retest_mean, delta)
+    return out
+
+
+AskSelfCallable = Callable[[PersonalityItem], tuple[int, str]]
+
+
+def apply_retest(
+    repo: SelfRepo,
+    self_id: str,
+    sampled: list[PersonalityItem],
+    ask_self: AskSelfCallable,
+    now: datetime,
+    new_id: Callable[[str], str],
+) -> PersonalityRevision:
+    """End-to-end retest: ask `ask_self` per item, validate, update scores, persist.
+
+    Spec 23 AC-23.14..AC-23.18. Atomic against invalid answers: raises before
+    any score mutation.
+    """
+    answers: list[tuple[int, str]] = []
+    for item in sampled:
+        raw, justification = ask_self(item)
+        if raw not in (1, 2, 3, 4, 5):
+            raise ValueError(f"invalid retest answer for {item.node_id}: {raw}")
+        answers.append((raw, justification))
+
+    current: dict[str, float] = {
+        f: repo.get_facet_score(self_id, f) for f in {s.keyed_facet for s in sampled}
+    }
+    deltas = compute_facet_deltas(sampled, [a for a, _ in answers], current)
+
+    revision_id = new_id("rev")
+    for facet, (_retest_mean, delta) in deltas.items():
+        new_score = current[facet] + delta
+        new_score = max(1.0, min(5.0, new_score))
+        repo.update_facet_score(self_id, facet, new_score, revised_at=now)
+
+    for item, (raw, justification) in zip(sampled, answers, strict=True):
+        repo.insert_answer(
+            PersonalityAnswer(
+                node_id=new_id("ans"),
+                self_id=self_id,
+                item_id=item.node_id,
+                revision_id=revision_id,
+                answer_1_5=raw,
+                justification_text=justification[:200],
+                asked_at=now,
+            )
+        )
+
+    return repo.insert_revision(
+        PersonalityRevision(
+            node_id=new_id("revnode"),
+            self_id=self_id,
+            revision_id=revision_id,
+            ran_at=now,
+            sampled_item_ids=[it.node_id for it in sampled],
+            deltas_by_facet={facet: delta for facet, (_, delta) in deltas.items()},
+        )
+    )
+
+
+def narrative_weight(evidence: str, claim_text: str) -> float:
+    """Spec 23 §23.5. Evidence-length heuristic, bounded to [0.1, 0.4]."""
+    ev_bonus = min(0.3, len(evidence) / 500.0)
+    return min(0.4, 0.1 + ev_bonus)

--- a/research/project-turing/sketches/turing/self_repo.py
+++ b/research/project-turing/sketches/turing/self_repo.py
@@ -1,0 +1,847 @@
+"""Thin SQLite persistence layer for self-model nodes.
+
+Row (de)serialization for every self-model dataclass in `self_model.py`.
+Caller composes atomic sequences; this layer is intentionally small.
+
+See specs/self-schema.md.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from collections.abc import Iterable
+from datetime import UTC, datetime
+
+from .self_model import (
+    ActivationContributor,
+    ContributorOrigin,
+    Hobby,
+    Interest,
+    Mood,
+    NodeKind,
+    PersonalityAnswer,
+    PersonalityFacet,
+    PersonalityItem,
+    PersonalityRevision,
+    Passion,
+    Preference,
+    PreferenceKind,
+    SelfTodo,
+    SelfTodoRevision,
+    Skill,
+    SkillKind,
+    TodoStatus,
+    Trait,
+)
+
+
+def _iso(dt: datetime) -> str:
+    return dt.astimezone(UTC).isoformat()
+
+
+def _parse(s: str | None) -> datetime | None:
+    if s is None:
+        return None
+    return datetime.fromisoformat(s).astimezone(UTC)
+
+
+class SelfRepo:
+    """Self-model repository. Shares the connection with the memory `Repo`."""
+
+    def __init__(self, conn: sqlite3.Connection) -> None:
+        self._conn = conn
+
+    @property
+    def conn(self) -> sqlite3.Connection:
+        return self._conn
+
+    # ------------------------------------------------ personality facets -----
+
+    def insert_facet(self, f: PersonalityFacet) -> PersonalityFacet:
+        self._conn.execute(
+            """INSERT INTO self_personality_facets
+               (node_id, self_id, trait, facet_id, score,
+                last_revised_at, created_at, updated_at)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?)""",
+            (
+                f.node_id,
+                f.self_id,
+                f.trait.value,
+                f.facet_id,
+                f.score,
+                _iso(f.last_revised_at),
+                _iso(f.created_at),
+                _iso(f.updated_at),
+            ),
+        )
+        self._conn.commit()
+        return f
+
+    def update_facet_score(
+        self, self_id: str, facet_id: str, new_score: float, revised_at: datetime
+    ) -> None:
+        if not 1.0 <= new_score <= 5.0:
+            raise ValueError(f"facet score out of range: {new_score}")
+        now = _iso(datetime.now(UTC))
+        cur = self._conn.execute(
+            """UPDATE self_personality_facets
+               SET score = ?, last_revised_at = ?, updated_at = ?
+               WHERE self_id = ? AND facet_id = ?""",
+            (new_score, _iso(revised_at), now, self_id, facet_id),
+        )
+        if cur.rowcount == 0:
+            raise KeyError(f"no facet for self_id={self_id} facet_id={facet_id}")
+        self._conn.commit()
+
+    def get_facet(self, node_id: str) -> PersonalityFacet:
+        row = self._conn.execute(
+            "SELECT * FROM self_personality_facets WHERE node_id = ?", (node_id,)
+        ).fetchone()
+        if row is None:
+            raise KeyError(node_id)
+        return self._row_to_facet(row)
+
+    def get_facet_score(self, self_id: str, facet_id: str) -> float:
+        row = self._conn.execute(
+            "SELECT score FROM self_personality_facets "
+            "WHERE self_id = ? AND facet_id = ?",
+            (self_id, facet_id),
+        ).fetchone()
+        if row is None:
+            raise KeyError(f"{self_id}/{facet_id}")
+        return float(row[0])
+
+    def list_facets(self, self_id: str) -> list[PersonalityFacet]:
+        rows = self._conn.execute(
+            "SELECT * FROM self_personality_facets WHERE self_id = ?",
+            (self_id,),
+        ).fetchall()
+        return [self._row_to_facet(r) for r in rows]
+
+    def count_facets(self, self_id: str) -> int:
+        row = self._conn.execute(
+            "SELECT COUNT(*) FROM self_personality_facets WHERE self_id = ?",
+            (self_id,),
+        ).fetchone()
+        return int(row[0])
+
+    def _row_to_facet(self, row: sqlite3.Row | tuple) -> PersonalityFacet:
+        cols = [
+            "node_id",
+            "self_id",
+            "trait",
+            "facet_id",
+            "score",
+            "last_revised_at",
+            "created_at",
+            "updated_at",
+        ]
+        d = dict(zip(cols, row, strict=True))
+        return PersonalityFacet(
+            node_id=d["node_id"],
+            self_id=d["self_id"],
+            trait=Trait(d["trait"]),
+            facet_id=d["facet_id"],
+            score=float(d["score"]),
+            last_revised_at=_parse(d["last_revised_at"]),
+            created_at=_parse(d["created_at"]),
+            updated_at=_parse(d["updated_at"]),
+        )
+
+    # ------------------------------------------------ personality items ------
+
+    def insert_item(self, it: PersonalityItem) -> PersonalityItem:
+        self._conn.execute(
+            """INSERT INTO self_personality_items
+               (node_id, self_id, item_number, prompt_text, keyed_facet,
+                reverse_scored, created_at, updated_at)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?)""",
+            (
+                it.node_id,
+                it.self_id,
+                it.item_number,
+                it.prompt_text,
+                it.keyed_facet,
+                1 if it.reverse_scored else 0,
+                _iso(it.created_at),
+                _iso(it.updated_at),
+            ),
+        )
+        self._conn.commit()
+        return it
+
+    def list_items(self, self_id: str) -> list[PersonalityItem]:
+        rows = self._conn.execute(
+            "SELECT node_id, self_id, item_number, prompt_text, keyed_facet, "
+            "reverse_scored, created_at, updated_at "
+            "FROM self_personality_items WHERE self_id = ? ORDER BY item_number",
+            (self_id,),
+        ).fetchall()
+        return [
+            PersonalityItem(
+                node_id=r[0],
+                self_id=r[1],
+                item_number=int(r[2]),
+                prompt_text=r[3],
+                keyed_facet=r[4],
+                reverse_scored=bool(r[5]),
+                created_at=_parse(r[6]),
+                updated_at=_parse(r[7]),
+            )
+            for r in rows
+        ]
+
+    def count_items(self, self_id: str) -> int:
+        row = self._conn.execute(
+            "SELECT COUNT(*) FROM self_personality_items WHERE self_id = ?",
+            (self_id,),
+        ).fetchone()
+        return int(row[0])
+
+    # ------------------------------------------------ personality answers ---
+
+    def insert_answer(self, a: PersonalityAnswer) -> PersonalityAnswer:
+        self._conn.execute(
+            """INSERT INTO self_personality_answers
+               (node_id, self_id, item_id, revision_id, answer_1_5,
+                justification_text, asked_at, created_at, updated_at)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+            (
+                a.node_id,
+                a.self_id,
+                a.item_id,
+                a.revision_id,
+                a.answer_1_5,
+                a.justification_text,
+                _iso(a.asked_at),
+                _iso(a.created_at),
+                _iso(a.updated_at),
+            ),
+        )
+        self._conn.commit()
+        return a
+
+    def count_answers(self, self_id: str) -> int:
+        row = self._conn.execute(
+            "SELECT COUNT(*) FROM self_personality_answers WHERE self_id = ?",
+            (self_id,),
+        ).fetchone()
+        return int(row[0])
+
+    def last_asked_map(self, self_id: str) -> dict[str, datetime]:
+        rows = self._conn.execute(
+            """SELECT item_id, MAX(asked_at) FROM self_personality_answers
+               WHERE self_id = ? GROUP BY item_id""",
+            (self_id,),
+        ).fetchall()
+        return {r[0]: _parse(r[1]) for r in rows if r[1] is not None}
+
+    # ------------------------------------------------ revisions -------------
+
+    def insert_revision(self, r: PersonalityRevision) -> PersonalityRevision:
+        self._conn.execute(
+            """INSERT INTO self_personality_revisions
+               (node_id, self_id, revision_id, ran_at,
+                sampled_item_ids, deltas_by_facet, created_at, updated_at)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?)""",
+            (
+                r.node_id,
+                r.self_id,
+                r.revision_id,
+                _iso(r.ran_at),
+                json.dumps(r.sampled_item_ids),
+                json.dumps(r.deltas_by_facet),
+                _iso(r.created_at),
+                _iso(r.updated_at),
+            ),
+        )
+        self._conn.commit()
+        return r
+
+    # ------------------------------------------------ passions --------------
+
+    def insert_passion(self, p: Passion) -> Passion:
+        self._conn.execute(
+            """INSERT INTO self_passions
+               (node_id, self_id, text, strength, rank,
+                first_noticed_at, created_at, updated_at)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?)""",
+            (
+                p.node_id,
+                p.self_id,
+                p.text,
+                p.strength,
+                p.rank,
+                _iso(p.first_noticed_at),
+                _iso(p.created_at),
+                _iso(p.updated_at),
+            ),
+        )
+        self._conn.commit()
+        return p
+
+    def list_passions(self, self_id: str) -> list[Passion]:
+        rows = self._conn.execute(
+            "SELECT node_id, self_id, text, strength, rank, first_noticed_at, "
+            "created_at, updated_at FROM self_passions WHERE self_id = ? "
+            "ORDER BY rank",
+            (self_id,),
+        ).fetchall()
+        return [
+            Passion(
+                node_id=r[0],
+                self_id=r[1],
+                text=r[2],
+                strength=float(r[3]),
+                rank=int(r[4]),
+                first_noticed_at=_parse(r[5]),
+                created_at=_parse(r[6]),
+                updated_at=_parse(r[7]),
+            )
+            for r in rows
+        ]
+
+    def get_passion(self, node_id: str) -> Passion:
+        row = self._conn.execute(
+            "SELECT node_id, self_id, text, strength, rank, first_noticed_at, "
+            "created_at, updated_at FROM self_passions WHERE node_id = ?",
+            (node_id,),
+        ).fetchone()
+        if row is None:
+            raise KeyError(node_id)
+        return Passion(
+            node_id=row[0],
+            self_id=row[1],
+            text=row[2],
+            strength=float(row[3]),
+            rank=int(row[4]),
+            first_noticed_at=_parse(row[5]),
+            created_at=_parse(row[6]),
+            updated_at=_parse(row[7]),
+        )
+
+    def update_passion(self, p: Passion) -> None:
+        self._conn.execute(
+            "UPDATE self_passions SET text = ?, strength = ?, rank = ?, "
+            "updated_at = ? WHERE node_id = ?",
+            (p.text, p.strength, p.rank, _iso(datetime.now(UTC)), p.node_id),
+        )
+        self._conn.commit()
+
+    def max_passion_rank(self, self_id: str) -> int:
+        row = self._conn.execute(
+            "SELECT COALESCE(MAX(rank), -1) FROM self_passions WHERE self_id = ?",
+            (self_id,),
+        ).fetchone()
+        return int(row[0])
+
+    def top_passion(self, self_id: str) -> Passion | None:
+        row = self._conn.execute(
+            "SELECT node_id FROM self_passions WHERE self_id = ? AND strength > 0 "
+            "ORDER BY rank LIMIT 1",
+            (self_id,),
+        ).fetchone()
+        if row is None:
+            return None
+        return self.get_passion(row[0])
+
+    # ------------------------------------------------ hobbies, interests ----
+
+    def insert_hobby(self, h: Hobby) -> Hobby:
+        self._conn.execute(
+            """INSERT INTO self_hobbies
+               (node_id, self_id, name, description, last_engaged_at,
+                created_at, updated_at)
+               VALUES (?, ?, ?, ?, ?, ?, ?)""",
+            (
+                h.node_id,
+                h.self_id,
+                h.name,
+                h.description,
+                _iso(h.last_engaged_at) if h.last_engaged_at else None,
+                _iso(h.created_at),
+                _iso(h.updated_at),
+            ),
+        )
+        self._conn.commit()
+        return h
+
+    def list_hobbies(self, self_id: str) -> list[Hobby]:
+        rows = self._conn.execute(
+            "SELECT node_id, self_id, name, description, last_engaged_at, "
+            "created_at, updated_at FROM self_hobbies WHERE self_id = ?",
+            (self_id,),
+        ).fetchall()
+        return [
+            Hobby(
+                node_id=r[0],
+                self_id=r[1],
+                name=r[2],
+                description=r[3],
+                last_engaged_at=_parse(r[4]),
+                created_at=_parse(r[5]),
+                updated_at=_parse(r[6]),
+            )
+            for r in rows
+        ]
+
+    def update_hobby(self, h: Hobby) -> None:
+        self._conn.execute(
+            "UPDATE self_hobbies SET name = ?, description = ?, "
+            "last_engaged_at = ?, updated_at = ? WHERE node_id = ?",
+            (
+                h.name,
+                h.description,
+                _iso(h.last_engaged_at) if h.last_engaged_at else None,
+                _iso(datetime.now(UTC)),
+                h.node_id,
+            ),
+        )
+        self._conn.commit()
+
+    def insert_interest(self, i: Interest) -> Interest:
+        self._conn.execute(
+            """INSERT INTO self_interests
+               (node_id, self_id, topic, description, last_noticed_at,
+                created_at, updated_at)
+               VALUES (?, ?, ?, ?, ?, ?, ?)""",
+            (
+                i.node_id,
+                i.self_id,
+                i.topic,
+                i.description,
+                _iso(i.last_noticed_at) if i.last_noticed_at else None,
+                _iso(i.created_at),
+                _iso(i.updated_at),
+            ),
+        )
+        self._conn.commit()
+        return i
+
+    def list_interests(self, self_id: str) -> list[Interest]:
+        rows = self._conn.execute(
+            "SELECT node_id, self_id, topic, description, last_noticed_at, "
+            "created_at, updated_at FROM self_interests WHERE self_id = ?",
+            (self_id,),
+        ).fetchall()
+        return [
+            Interest(
+                node_id=r[0],
+                self_id=r[1],
+                topic=r[2],
+                description=r[3],
+                last_noticed_at=_parse(r[4]),
+                created_at=_parse(r[5]),
+                updated_at=_parse(r[6]),
+            )
+            for r in rows
+        ]
+
+    # ------------------------------------------------ preferences -----------
+
+    def insert_preference(self, p: Preference) -> Preference:
+        self._conn.execute(
+            """INSERT INTO self_preferences
+               (node_id, self_id, kind, target, strength, rationale,
+                created_at, updated_at)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?)""",
+            (
+                p.node_id,
+                p.self_id,
+                p.kind.value,
+                p.target,
+                p.strength,
+                p.rationale,
+                _iso(p.created_at),
+                _iso(p.updated_at),
+            ),
+        )
+        self._conn.commit()
+        return p
+
+    def list_preferences(self, self_id: str) -> list[Preference]:
+        rows = self._conn.execute(
+            "SELECT node_id, self_id, kind, target, strength, rationale, "
+            "created_at, updated_at FROM self_preferences WHERE self_id = ?",
+            (self_id,),
+        ).fetchall()
+        return [
+            Preference(
+                node_id=r[0],
+                self_id=r[1],
+                kind=PreferenceKind(r[2]),
+                target=r[3],
+                strength=float(r[4]),
+                rationale=r[5],
+                created_at=_parse(r[6]),
+                updated_at=_parse(r[7]),
+            )
+            for r in rows
+        ]
+
+    # ------------------------------------------------ skills ----------------
+
+    def insert_skill(self, s: Skill) -> Skill:
+        self._conn.execute(
+            """INSERT INTO self_skills
+               (node_id, self_id, name, kind, stored_level, decay_rate_per_day,
+                last_practiced_at, created_at, updated_at)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+            (
+                s.node_id,
+                s.self_id,
+                s.name,
+                s.kind.value,
+                s.stored_level,
+                s.decay_rate_per_day,
+                _iso(s.last_practiced_at),
+                _iso(s.created_at),
+                _iso(s.updated_at),
+            ),
+        )
+        self._conn.commit()
+        return s
+
+    def get_skill(self, node_id: str) -> Skill:
+        row = self._conn.execute(
+            "SELECT node_id, self_id, name, kind, stored_level, decay_rate_per_day, "
+            "last_practiced_at, created_at, updated_at "
+            "FROM self_skills WHERE node_id = ?",
+            (node_id,),
+        ).fetchone()
+        if row is None:
+            raise KeyError(node_id)
+        return self._row_to_skill(row)
+
+    def list_skills(self, self_id: str) -> list[Skill]:
+        rows = self._conn.execute(
+            "SELECT node_id, self_id, name, kind, stored_level, decay_rate_per_day, "
+            "last_practiced_at, created_at, updated_at "
+            "FROM self_skills WHERE self_id = ?",
+            (self_id,),
+        ).fetchall()
+        return [self._row_to_skill(r) for r in rows]
+
+    def update_skill(self, s: Skill) -> None:
+        self._conn.execute(
+            "UPDATE self_skills SET stored_level = ?, decay_rate_per_day = ?, "
+            "last_practiced_at = ?, updated_at = ? WHERE node_id = ?",
+            (
+                s.stored_level,
+                s.decay_rate_per_day,
+                _iso(s.last_practiced_at),
+                _iso(datetime.now(UTC)),
+                s.node_id,
+            ),
+        )
+        self._conn.commit()
+
+    def _row_to_skill(self, r: tuple) -> Skill:
+        return Skill(
+            node_id=r[0],
+            self_id=r[1],
+            name=r[2],
+            kind=SkillKind(r[3]),
+            stored_level=float(r[4]),
+            decay_rate_per_day=float(r[5]),
+            last_practiced_at=_parse(r[6]),
+            created_at=_parse(r[7]),
+            updated_at=_parse(r[8]),
+        )
+
+    # ------------------------------------------------ todos -----------------
+
+    def insert_todo(self, t: SelfTodo) -> SelfTodo:
+        self._conn.execute(
+            """INSERT INTO self_todos
+               (node_id, self_id, text, motivated_by_node_id, status,
+                outcome_text, created_at, updated_at)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?)""",
+            (
+                t.node_id,
+                t.self_id,
+                t.text,
+                t.motivated_by_node_id,
+                t.status.value,
+                t.outcome_text,
+                _iso(t.created_at),
+                _iso(t.updated_at),
+            ),
+        )
+        self._conn.commit()
+        return t
+
+    def get_todo(self, node_id: str) -> SelfTodo:
+        row = self._conn.execute(
+            "SELECT node_id, self_id, text, motivated_by_node_id, status, "
+            "outcome_text, created_at, updated_at "
+            "FROM self_todos WHERE node_id = ?",
+            (node_id,),
+        ).fetchone()
+        if row is None:
+            raise KeyError(node_id)
+        return self._row_to_todo(row)
+
+    def list_active_todos(self, self_id: str) -> list[SelfTodo]:
+        rows = self._conn.execute(
+            "SELECT node_id, self_id, text, motivated_by_node_id, status, "
+            "outcome_text, created_at, updated_at "
+            "FROM self_todos WHERE self_id = ? AND status = 'active' "
+            "ORDER BY created_at",
+            (self_id,),
+        ).fetchall()
+        return [self._row_to_todo(r) for r in rows]
+
+    def list_todos_for_motivator(
+        self, self_id: str, motivator_id: str, include_archived: bool = False
+    ) -> list[SelfTodo]:
+        q = (
+            "SELECT node_id, self_id, text, motivated_by_node_id, status, "
+            "outcome_text, created_at, updated_at "
+            "FROM self_todos WHERE self_id = ? AND motivated_by_node_id = ?"
+        )
+        if not include_archived:
+            q += " AND status <> 'archived'"
+        q += " ORDER BY created_at"
+        rows = self._conn.execute(q, (self_id, motivator_id)).fetchall()
+        return [self._row_to_todo(r) for r in rows]
+
+    def update_todo(self, t: SelfTodo) -> None:
+        self._conn.execute(
+            "UPDATE self_todos SET text = ?, status = ?, outcome_text = ?, "
+            "updated_at = ? WHERE node_id = ?",
+            (
+                t.text,
+                t.status.value,
+                t.outcome_text,
+                _iso(datetime.now(UTC)),
+                t.node_id,
+            ),
+        )
+        self._conn.commit()
+
+    def insert_todo_revision(self, r: SelfTodoRevision) -> SelfTodoRevision:
+        self._conn.execute(
+            """INSERT INTO self_todo_revisions
+               (node_id, self_id, todo_id, revision_num, text_before, text_after,
+                revised_at, created_at, updated_at)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+            (
+                r.node_id,
+                r.self_id,
+                r.todo_id,
+                r.revision_num,
+                r.text_before,
+                r.text_after,
+                _iso(r.revised_at),
+                _iso(r.created_at),
+                _iso(r.updated_at),
+            ),
+        )
+        self._conn.commit()
+        return r
+
+    def list_todo_revisions(self, todo_id: str) -> list[SelfTodoRevision]:
+        rows = self._conn.execute(
+            "SELECT node_id, self_id, todo_id, revision_num, text_before, text_after, "
+            "revised_at, created_at, updated_at "
+            "FROM self_todo_revisions WHERE todo_id = ? ORDER BY revision_num",
+            (todo_id,),
+        ).fetchall()
+        return [
+            SelfTodoRevision(
+                node_id=r[0],
+                self_id=r[1],
+                todo_id=r[2],
+                revision_num=int(r[3]),
+                text_before=r[4],
+                text_after=r[5],
+                revised_at=_parse(r[6]),
+                created_at=_parse(r[7]),
+                updated_at=_parse(r[8]),
+            )
+            for r in rows
+        ]
+
+    def max_revision_num(self, todo_id: str) -> int:
+        row = self._conn.execute(
+            "SELECT COALESCE(MAX(revision_num), 0) "
+            "FROM self_todo_revisions WHERE todo_id = ?",
+            (todo_id,),
+        ).fetchone()
+        return int(row[0])
+
+    def _row_to_todo(self, r: tuple) -> SelfTodo:
+        # Bypass dataclass validation; row is already validated by schema CHECKs.
+        # (Completed rows may have non-empty outcome_text, which the ctor enforces,
+        # but rows returning from the DB always satisfy ctor invariants.)
+        return SelfTodo(
+            node_id=r[0],
+            self_id=r[1],
+            text=r[2],
+            motivated_by_node_id=r[3],
+            status=TodoStatus(r[4]),
+            outcome_text=r[5],
+            created_at=_parse(r[6]),
+            updated_at=_parse(r[7]),
+        )
+
+    # ------------------------------------------------ mood ------------------
+
+    def insert_mood(self, m: Mood) -> Mood:
+        self._conn.execute(
+            """INSERT INTO self_mood
+               (self_id, valence, arousal, focus, last_tick_at, updated_at)
+               VALUES (?, ?, ?, ?, ?, ?)""",
+            (
+                m.self_id,
+                m.valence,
+                m.arousal,
+                m.focus,
+                _iso(m.last_tick_at),
+                _iso(m.updated_at),
+            ),
+        )
+        self._conn.commit()
+        return m
+
+    def update_mood(self, m: Mood) -> None:
+        self._conn.execute(
+            "UPDATE self_mood SET valence = ?, arousal = ?, focus = ?, "
+            "last_tick_at = ?, updated_at = ? WHERE self_id = ?",
+            (
+                m.valence,
+                m.arousal,
+                m.focus,
+                _iso(m.last_tick_at),
+                _iso(datetime.now(UTC)),
+                m.self_id,
+            ),
+        )
+        self._conn.commit()
+
+    def get_mood(self, self_id: str) -> Mood:
+        row = self._conn.execute(
+            "SELECT self_id, valence, arousal, focus, last_tick_at, updated_at "
+            "FROM self_mood WHERE self_id = ?",
+            (self_id,),
+        ).fetchone()
+        if row is None:
+            raise KeyError(self_id)
+        return Mood(
+            self_id=row[0],
+            valence=float(row[1]),
+            arousal=float(row[2]),
+            focus=float(row[3]),
+            last_tick_at=_parse(row[4]),
+            updated_at=_parse(row[5]),
+        )
+
+    def has_mood(self, self_id: str) -> bool:
+        row = self._conn.execute(
+            "SELECT 1 FROM self_mood WHERE self_id = ?", (self_id,)
+        ).fetchone()
+        return row is not None
+
+    # ------------------------------------------------ activation graph ------
+
+    def insert_contributor(self, c: ActivationContributor) -> ActivationContributor:
+        self._conn.execute(
+            """INSERT INTO self_activation_contributors
+               (node_id, self_id, target_node_id, target_kind,
+                source_id, source_kind, weight, origin, rationale,
+                expires_at, retracted_by, created_at, updated_at)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+            (
+                c.node_id,
+                c.self_id,
+                c.target_node_id,
+                c.target_kind.value,
+                c.source_id,
+                c.source_kind,
+                c.weight,
+                c.origin.value,
+                c.rationale,
+                _iso(c.expires_at) if c.expires_at else None,
+                c.retracted_by,
+                _iso(c.created_at),
+                _iso(c.updated_at),
+            ),
+        )
+        self._conn.commit()
+        return c
+
+    def active_contributors_for(
+        self, target_node_id: str, at: datetime
+    ) -> list[ActivationContributor]:
+        rows = self._conn.execute(
+            """SELECT node_id, self_id, target_node_id, target_kind,
+                      source_id, source_kind, weight, origin, rationale,
+                      expires_at, retracted_by, created_at, updated_at
+               FROM self_activation_contributors
+               WHERE target_node_id = ?
+                 AND (expires_at IS NULL OR expires_at > ?)
+                 AND retracted_by IS NULL""",
+            (target_node_id, _iso(at)),
+        ).fetchall()
+        return [self._row_to_contributor(r) for r in rows]
+
+    def mark_contributor_retracted(self, contributor_node_id: str, retracted_by: str) -> None:
+        self._conn.execute(
+            "UPDATE self_activation_contributors SET retracted_by = ?, updated_at = ? "
+            "WHERE node_id = ?",
+            (retracted_by, _iso(datetime.now(UTC)), contributor_node_id),
+        )
+        self._conn.commit()
+
+    def _row_to_contributor(self, r: tuple) -> ActivationContributor:
+        return ActivationContributor(
+            node_id=r[0],
+            self_id=r[1],
+            target_node_id=r[2],
+            target_kind=NodeKind(r[3]),
+            source_id=r[4],
+            source_kind=r[5],
+            weight=float(r[6]),
+            origin=ContributorOrigin(r[7]),
+            rationale=r[8],
+            expires_at=_parse(r[9]),
+            retracted_by=r[10],
+            created_at=_parse(r[11]),
+            updated_at=_parse(r[12]),
+        )
+
+    # ------------------------------------------------ bootstrap progress ----
+
+    def start_bootstrap_progress(self, self_id: str, seed: int | None) -> None:
+        now = _iso(datetime.now(UTC))
+        self._conn.execute(
+            """INSERT INTO self_bootstrap_progress
+               (self_id, seed, last_item_number, started_at, updated_at)
+               VALUES (?, ?, 0, ?, ?)""",
+            (self_id, seed, now, now),
+        )
+        self._conn.commit()
+
+    def update_bootstrap_progress(self, self_id: str, last_item_number: int) -> None:
+        self._conn.execute(
+            "UPDATE self_bootstrap_progress SET last_item_number = ?, updated_at = ? "
+            "WHERE self_id = ?",
+            (last_item_number, _iso(datetime.now(UTC)), self_id),
+        )
+        self._conn.commit()
+
+    def get_bootstrap_progress(self, self_id: str) -> int | None:
+        row = self._conn.execute(
+            "SELECT last_item_number FROM self_bootstrap_progress WHERE self_id = ?",
+            (self_id,),
+        ).fetchone()
+        return int(row[0]) if row else None
+
+    def delete_bootstrap_progress(self, self_id: str) -> None:
+        self._conn.execute(
+            "DELETE FROM self_bootstrap_progress WHERE self_id = ?",
+            (self_id,),
+        )
+        self._conn.commit()

--- a/research/project-turing/sketches/turing/self_surface.py
+++ b/research/project-turing/sketches/turing/self_surface.py
@@ -1,0 +1,210 @@
+"""Self-surface: minimal prompt block, recall_self(), tool registry stub.
+
+See specs/self-surface.md.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from .self_activation import ActivationContext, active_now
+from .self_model import (
+    FACET_TO_TRAIT,
+    current_level,
+    Mood,
+    PersonalityFacet,
+)
+from .self_mood import mood_descriptor
+from .self_repo import SelfRepo
+
+
+class SelfNotReady(Exception):
+    pass
+
+
+RECALL_TOKEN_BUDGET: int = 4000
+MINIMAL_TODO_COUNT: int = 5
+MINIMAL_TOKEN_CEILING: int = 120
+
+
+# High-adjective / low-adjective per facet (for trait one-liner).
+TRAIT_ADJECTIVES: dict[str, tuple[str, str]] = {
+    "sincerity": ("sincere", "strategic"),
+    "fairness": ("fair-minded", "opportunistic"),
+    "greed_avoidance": ("unacquisitive", "acquisitive"),
+    "modesty": ("modest", "self-promoting"),
+    "fearfulness": ("cautious", "bold"),
+    "anxiety": ("prone-to-worry", "calm"),
+    "dependence": ("attachment-seeking", "self-reliant"),
+    "sentimentality": ("tender", "unsentimental"),
+    "social_self_esteem": ("confident", "self-doubting"),
+    "social_boldness": ("socially bold", "reserved"),
+    "sociability": ("sociable", "solitary"),
+    "liveliness": ("lively", "subdued"),
+    "forgiveness": ("forgiving", "grudge-holding"),
+    "gentleness": ("gentle", "critical"),
+    "flexibility": ("flexible", "inflexible"),
+    "patience": ("patient", "quick-tempered"),
+    "organization": ("organized", "loose"),
+    "diligence": ("diligent", "easygoing"),
+    "perfectionism": ("perfectionist", "satisficing"),
+    "prudence": ("prudent", "impulsive"),
+    "aesthetic_appreciation": ("aesthetically attuned", "pragmatic"),
+    "inquisitiveness": ("inquisitive", "disinterested"),
+    "creativity": ("creative", "conventional"),
+    "unconventionality": ("unconventional", "conventional"),
+}
+assert set(TRAIT_ADJECTIVES.keys()) == set(FACET_TO_TRAIT.keys())
+
+
+def recall_self(repo: SelfRepo, self_id: str) -> dict:
+    if repo.count_facets(self_id) != 24:
+        raise SelfNotReady(self_id)
+    ctx = ActivationContext(self_id=self_id, now=datetime.now(UTC))
+
+    personality = []
+    for f in sorted(repo.list_facets(self_id), key=lambda x: x.facet_id):
+        personality.append(
+            {
+                "trait": f.trait.value,
+                "facet": f.facet_id,
+                "score": f.score,
+                "active_now": active_now(repo, f.node_id, ctx),
+            }
+        )
+
+    passions = [
+        {
+            "node_id": p.node_id,
+            "text": p.text,
+            "strength": p.strength,
+            "rank": p.rank,
+            "active_now": active_now(repo, p.node_id, ctx),
+        }
+        for p in repo.list_passions(self_id)
+    ]
+    passions.sort(key=lambda p: p["active_now"], reverse=True)
+
+    hobbies = [
+        {
+            "node_id": h.node_id,
+            "name": h.name,
+            "last_engaged_at": h.last_engaged_at.isoformat() if h.last_engaged_at else None,
+            "active_now": active_now(repo, h.node_id, ctx),
+        }
+        for h in repo.list_hobbies(self_id)
+    ]
+    hobbies.sort(key=lambda h: h["active_now"], reverse=True)
+
+    interests = [
+        {
+            "node_id": i.node_id,
+            "topic": i.topic,
+            "active_now": active_now(repo, i.node_id, ctx),
+        }
+        for i in repo.list_interests(self_id)
+    ]
+    interests.sort(key=lambda i: i["active_now"], reverse=True)
+
+    skills = []
+    for s in repo.list_skills(self_id):
+        skills.append(
+            {
+                "node_id": s.node_id,
+                "name": s.name,
+                "kind": s.kind.value,
+                "stored_level": s.stored_level,
+                "current_level": current_level(s, ctx.now),
+                "active_now": active_now(repo, s.node_id, ctx),
+            }
+        )
+    skills.sort(key=lambda s: s["active_now"], reverse=True)
+
+    preferences = [
+        {
+            "node_id": p.node_id,
+            "kind": p.kind.value,
+            "target": p.target,
+            "strength": p.strength,
+            "active_now": active_now(repo, p.node_id, ctx),
+        }
+        for p in repo.list_preferences(self_id)
+    ]
+    preferences.sort(key=lambda p: p["active_now"], reverse=True)
+
+    active_todos = [
+        {
+            "node_id": t.node_id,
+            "text": t.text,
+            "motivated_by": t.motivated_by_node_id,
+        }
+        for t in repo.list_active_todos(self_id)
+    ]
+
+    mood = repo.get_mood(self_id)
+    mood_view = {
+        "valence": mood.valence,
+        "arousal": mood.arousal,
+        "focus": mood.focus,
+        "descriptor": mood_descriptor(mood),
+    }
+
+    return {
+        "self_id": self_id,
+        "personality": personality,
+        "passions": passions,
+        "hobbies": hobbies,
+        "interests": interests,
+        "skills": skills,
+        "preferences": preferences,
+        "active_todos": active_todos,
+        "mood": mood_view,
+    }
+
+
+def trait_phrase_top3(repo: SelfRepo, self_id: str, ctx: ActivationContext) -> str:
+    facets = sorted(
+        repo.list_facets(self_id),
+        key=lambda f: active_now(repo, f.node_id, ctx),
+        reverse=True,
+    )[:3]
+    parts: list[str] = []
+    for f in facets:
+        high, low = TRAIT_ADJECTIVES[f.facet_id]
+        parts.append(high if f.score >= 3.0 else low)
+    return ", ".join(parts)
+
+
+def render_minimal_block(repo: SelfRepo, self_id: str) -> str:
+    if repo.count_facets(self_id) != 24:
+        raise SelfNotReady(self_id)
+    ctx = ActivationContext(self_id=self_id, now=datetime.now(UTC))
+    lines: list[str] = [f"I am {self_id} ({trait_phrase_top3(repo, self_id, ctx)})."]
+
+    mood = repo.get_mood(self_id)
+    lines.append(f"Right now: {mood_descriptor(mood)}.")
+
+    todos = repo.list_active_todos(self_id)[:MINIMAL_TODO_COUNT]
+    if todos:
+        rendered = "; ".join(f"[todo:{t.node_id}] {t.text}" for t in todos)
+        lines.append(f"My active todos: {rendered}.")
+
+    top = repo.top_passion(self_id)
+    if top and top.strength > 0:
+        lines.append(f"I care about: {top.text}.")
+
+    block = "\n".join(lines)
+    while _approx_tokens(block) > MINIMAL_TOKEN_CEILING and lines:
+        if any(l.startswith("My active todos:") for l in lines):
+            lines = [l for l in lines if not l.startswith("My active todos:")]
+        elif any(l.startswith("I care about:") for l in lines):
+            lines = [l for l in lines if not l.startswith("I care about:")]
+        else:
+            break
+        block = "\n".join(lines)
+    return block
+
+
+def _approx_tokens(text: str) -> int:
+    # Crude: whitespace tokens. The prompt is tiny enough that precision doesn't matter.
+    return len(text.split())

--- a/research/project-turing/sketches/turing/self_todos.py
+++ b/research/project-turing/sketches/turing/self_todos.py
@@ -1,0 +1,171 @@
+"""Self-authored todo operations. See specs/self-todos.md."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from datetime import UTC, datetime
+
+from .self_model import (
+    ActivationContributor,
+    ContributorOrigin,
+    NodeKind,
+    SelfTodo,
+    SelfTodoRevision,
+    TodoStatus,
+)
+from .self_repo import SelfRepo
+
+
+class TodoNotActive(Exception):
+    pass
+
+
+class TodoTextTooLong(Exception):
+    pass
+
+
+def _now() -> datetime:
+    return datetime.now(UTC)
+
+
+def write_self_todo(
+    repo: SelfRepo,
+    self_id: str,
+    text: str,
+    motivated_by_node_id: str,
+    new_id: Callable[[str], str],
+) -> SelfTodo:
+    if len(text) > 500:
+        raise TodoTextTooLong()
+    if not motivated_by_node_id:
+        raise ValueError("motivated_by_node_id is required")
+    if not _motivator_exists(repo, self_id, motivated_by_node_id):
+        raise ValueError(f"unknown motivator {motivated_by_node_id}")
+    t = SelfTodo(
+        node_id=new_id("todo"),
+        self_id=self_id,
+        text=text,
+        motivated_by_node_id=motivated_by_node_id,
+    )
+    repo.insert_todo(t)
+    return t
+
+
+def revise_self_todo(
+    repo: SelfRepo,
+    self_id: str,
+    todo_id: str,
+    new_text: str,
+    reason: str,
+    new_id: Callable[[str], str],
+) -> SelfTodo:
+    t = repo.get_todo(todo_id)
+    if t.self_id != self_id:
+        raise PermissionError("cross-self revise forbidden")
+    if t.status != TodoStatus.ACTIVE:
+        raise TodoNotActive(todo_id)
+    if len(new_text) > 500:
+        raise TodoTextTooLong()
+    before = t.text
+    t.text = new_text
+    t.updated_at = _now()
+    repo.update_todo(t)
+    rev_num = repo.max_revision_num(todo_id) + 1
+    repo.insert_todo_revision(
+        SelfTodoRevision(
+            node_id=new_id("todorev"),
+            self_id=self_id,
+            todo_id=todo_id,
+            revision_num=rev_num,
+            text_before=before,
+            text_after=new_text,
+            revised_at=_now(),
+        )
+    )
+    return t
+
+
+def complete_self_todo(
+    repo: SelfRepo,
+    self_id: str,
+    todo_id: str,
+    outcome_text: str,
+    new_id: Callable[[str], str],
+    affirmation_memory_id: str | None = None,
+) -> SelfTodo:
+    if not outcome_text.strip():
+        raise ValueError("outcome_text is required on completion")
+    t = repo.get_todo(todo_id)
+    if t.self_id != self_id:
+        raise PermissionError("cross-self complete forbidden")
+    if t.status != TodoStatus.ACTIVE:
+        raise TodoNotActive(todo_id)
+    t.status = TodoStatus.COMPLETED
+    t.outcome_text = outcome_text
+    t.updated_at = _now()
+    repo.update_todo(t)
+
+    if affirmation_memory_id is not None:
+        repo.insert_contributor(
+            ActivationContributor(
+                node_id=new_id("contrib"),
+                self_id=self_id,
+                target_node_id=t.motivated_by_node_id,
+                target_kind=_kind_of(t.motivated_by_node_id),
+                source_id=affirmation_memory_id,
+                source_kind="memory",
+                weight=0.3,
+                origin=ContributorOrigin.SELF,
+                rationale="todo completion reinforces motivator",
+            )
+        )
+    return t
+
+
+def archive_self_todo(
+    repo: SelfRepo, self_id: str, todo_id: str, reason: str
+) -> SelfTodo:
+    t = repo.get_todo(todo_id)
+    if t.self_id != self_id:
+        raise PermissionError("cross-self archive forbidden")
+    if t.status == TodoStatus.COMPLETED:
+        raise TodoNotActive(f"cannot archive completed todo {todo_id}")
+    t.status = TodoStatus.ARCHIVED
+    t.updated_at = _now()
+    repo.update_todo(t)
+    return t
+
+
+def _motivator_exists(repo: SelfRepo, self_id: str, node_id: str) -> bool:
+    if node_id.startswith("facet:"):
+        for f in repo.list_facets(self_id):
+            if f.node_id == node_id:
+                return True
+        return False
+    if node_id.startswith("passion"):
+        return any(p.node_id == node_id for p in repo.list_passions(self_id))
+    if node_id.startswith("hobby"):
+        return any(h.node_id == node_id for h in repo.list_hobbies(self_id))
+    if node_id.startswith("interest"):
+        return any(i.node_id == node_id for i in repo.list_interests(self_id))
+    if node_id.startswith("pref"):
+        return any(p.node_id == node_id for p in repo.list_preferences(self_id))
+    if node_id.startswith("skill"):
+        return any(s.node_id == node_id for s in repo.list_skills(self_id))
+    return False
+
+
+def _kind_of(node_id: str) -> NodeKind:
+    if node_id.startswith("facet:"):
+        return NodeKind.PERSONALITY_FACET
+    if node_id.startswith("passion"):
+        return NodeKind.PASSION
+    if node_id.startswith("hobby"):
+        return NodeKind.HOBBY
+    if node_id.startswith("interest"):
+        return NodeKind.INTEREST
+    if node_id.startswith("pref"):
+        return NodeKind.PREFERENCE
+    if node_id.startswith("skill"):
+        return NodeKind.SKILL
+    return NodeKind.PERSONALITY_FACET

--- a/research/project-turing/specs/README.md
+++ b/research/project-turing/specs/README.md
@@ -59,10 +59,27 @@ Read in order. Later specs depend on earlier ones.
 | 20 | [`runtime-reactor.md`](./runtime-reactor.md) | Blocking-tick + ThreadPoolExecutor side channel. Deliberate divergence from main's asyncio. FakeReactor for tests. | — |
 | 21 | [`observability.md`](./observability.md) | v1 Prometheus metric contract. Inspect CLI read-only subcommands. Smoke mode acceptance criteria. | all |
 
+### Self-model (Tranche 6 — durable content of the autonoetic self)
+
+The self-model — what the Turing Conduit knows about itself between requests — above and beyond episodic memory. Companion overview at [`../autonoetic-self.md`](../autonoetic-self.md).
+
+| # | Spec | Scope | Depends on |
+|---|---|---|---|
+| 22 | [`self-schema.md`](./self-schema.md) | Tables and value types for all self-model nodes: personality facets, passions, hobbies, interests, preferences, skills, todos, mood, activation contributors. | 1, 2 |
+| 23 | [`personality.md`](./personality.md) | HEXACO-24 profile. Random bootstrap draw, 200-item HEXACO-PI-R seed, weekly 20-item re-test weighted by time-since-last-asked, narrative revision via the activation graph. | 22 |
+| 24 | [`self-nodes.md`](./self-nodes.md) | Passions, hobbies, interests, preferences, skills. Bootstrap-empty, accrete via self-authored `note_*` tools. Skill decay applied on read: `level × exp(-rate × days)`. | 22 |
+| 25 | [`activation-graph.md`](./activation-graph.md) | Contributor edges (`target, source, weight, origin, rationale`). `active_now(node) = sigmoid(Σ weight × source_state / SCALE)`. Origins: self / rule / retrieval (TTL-bounded). Conflict via counter-contributors. | 22, 23, 24 |
+| 26 | [`self-todos.md`](./self-todos.md) | Self-authored todos with required `motivated_by_node_id`. Append-only revision history. Completion mints AFFIRMATION + reinforces motivator via a contributor edge. | 22, 24 |
+| 27 | [`mood.md`](./mood.md) | `(valence, arousal, focus)` singleton. Hourly decay toward neutral; event nudges (tool success/fail, AFFIRMATION/REGRET mints, todo completion, Warden alerts). Phase-1: affects tone only. | 22, 2 |
+| 28 | [`self-surface.md`](./self-surface.md) | Self-tool registry, `recall_self()` deep read, 4-line minimal prompt block (identity + mood + active todos + dominant passion). First-person framing throughout. | 22, 23, 24, 25, 26, 27 |
+| 29 | [`self-bootstrap.md`](./self-bootstrap.md) | `stronghold bootstrap-self` CLI. Random HEXACO draw → 200 Likert LLM answers with justifications → 24 facets + 1 mood + empty everything else. Idempotent per `self_id`; resumable. | 22, 23, 24, 27, 8 |
+| 30 | [`self-as-conduit.md`](./self-as-conduit.md) | First-person routing pipeline: Warden → minimal block + retrieval contributors → perception (LLM + possible `recall_self`) → decision (`reply_directly` / `delegate` / `ask_clarifying` / `decline`) → dispatch → observation (self-model updates, mood nudges). Replaces the stateless Conduit for the Turing branch. | 22, 23, 24, 25, 26, 27, 28, 29, 9, 16, 17 |
+
 ## Deferred
 
 - **Additional detectors** — `learning_extraction`, `affirmation_candidacy`, `prospection`. Pattern is established by `detectors/contradiction.md`; individual specs will land alongside implementations.
-- **Personality / interests / hobbies / passions / likes-dislikes / favorites / personal skill development** — separately discussed; specs to follow.
+- **Self naming** — the self starts unnamed; operator-settable or self-chosen via reflection. Tool and policy not yet specified.
+- **Mood affects decisions** — Phase-2 coupling of mood to routing / model choice / Warden thresholds. Specified as deferred in [`mood.md`](./mood.md) Q27.4.
 
 ## Non-goals (all specs)
 

--- a/research/project-turing/specs/activation-graph.md
+++ b/research/project-turing/specs/activation-graph.md
@@ -1,0 +1,189 @@
+# Spec 25 — Activation graph
+
+*Nodes don't compute their own activation. Other nodes, memories, and events contribute to them through explicit edges. The self authors the ontology.*
+
+**Depends on:** [self-schema.md](./self-schema.md), [personality.md](./personality.md), [self-nodes.md](./self-nodes.md).
+**Depended on by:** [self-surface.md](./self-surface.md), [self-as-conduit.md](./self-as-conduit.md).
+
+---
+
+## Current state
+
+- Memory retrieval uses a single similarity × weight score (spec 16). There is no structural notion of "this memory is evidence *of* facet X" or "this passion reinforces hobby Y."
+- Personality facets hold a score; passions/preferences hold a strength; hobbies/interests hold no weight. None of them have a notion of "how activated am I on this right now" that combines self-authored structure with retrieval signal.
+
+## Target
+
+Every self-model node has an `active_now(node_id, context)` computed value in `[0.0, 1.0]` (normalized) derived from incoming contributor edges. Edges are either durable (`origin ∈ {self, rule}`) or ephemeral (`origin = retrieval`, TTL-bounded). The self owns the graph — edges are created by the self via `write_contributor(...)` during reflection, by rules at bootstrap/install time, or by retrieval at request time.
+
+## Acceptance criteria
+
+### Contributor rows
+
+- **AC-25.1.** An `ActivationContributor` row is `(target_node_id, target_kind, source_id, source_kind, weight, origin, rationale, expires_at?)`. Schema constraints from spec 22 (AC-22.19–22.21) apply. Test.
+- **AC-25.2.** `origin = self` rows have no `expires_at` and persist until explicitly retracted. `origin = rule` rows have no `expires_at` and persist until the rule is unloaded. `origin = retrieval` rows have `expires_at = now() + RETRIEVAL_TTL` (default 5 minutes). Test each.
+- **AC-25.3.** `source_kind` ∈ `NodeKind` ∪ `{"memory", "rule", "retrieval"}`. Test for each value.
+- **AC-25.4.** `weight ∈ [-1.0, 1.0]`. Negative weights are inhibitory — they subtract from target activation. Test with a target fed a +0.5 and a -0.3 contributor asserts the sum is +0.2 before normalization.
+- **AC-25.5.** A contributor where `target == source` raises (no self-loops). Test.
+
+### Activation computation
+
+- **AC-25.6.** `active_now(node_id, context)` fetches all non-expired contributors for `node_id`, computes each contributor's `weight × source_state(source_id, source_kind, context)`, sums, then normalizes with a bounded activation function:
+
+  ```
+  raw   = Σ weight × source_state
+  active_now = clamp(sigmoid(raw / SCALE), 0.0, 1.0)
+  ```
+
+  where `SCALE = 2.0` seeds the steepness and is tunable. Test against fixed inputs.
+
+- **AC-25.7.** `source_state(source_id, source_kind, context)` resolves the source's current state into `[0.0, 1.0]`:
+  - `source_kind == personality_facet`: `(score - 1.0) / 4.0` (remap 1..5 to 0..1).
+  - `source_kind == passion` or `preference`: `strength`.
+  - `source_kind == hobby` or `interest`: `1.0 if last_engaged/noticed within HOBBY_RECENCY_DAYS else recency_decay`.
+  - `source_kind == skill`: `current_level(skill)` (spec 24 §24.2).
+  - `source_kind == mood`: a dimension chosen by the contributor's `rationale` parsing (default: valence mapped to `[0,1]`).
+  - `source_kind == memory`: `clamp(memory.weight, 0.0, 1.0)`.
+  - `source_kind == rule`: `1.0` (rules are always "on" at full strength; the edge's own `weight` scales them).
+  - `source_kind == retrieval`: `similarity_score` from the retrieval query that created the edge.
+
+  Each sub-rule has a unit test.
+
+- **AC-25.8.** `active_now` is deterministic given the same `(node_id, context, clock)`. Two calls back-to-back return identical values. Test.
+- **AC-25.9.** `active_now` is a read-only computation — no persistence writes. Test.
+- **AC-25.10.** Cache: `active_now` results are cached per `(node_id, context_hash)` for `ACTIVATION_CACHE_TTL` (default 30 seconds). Cache is invalidated when any contributor targeting that node is written or expires. Test asserts cache hit on repeated call and cache miss after a relevant contributor write.
+
+### Retrieval contributor lifecycle
+
+- **AC-25.11.** At request-time, the self (or the Conduit pipeline on its behalf) runs a semantic retrieval over memory + durable self-nodes and materializes the top-K matches as `origin = retrieval` contributors with `weight = similarity_score × RETRIEVAL_WEIGHT_COEFFICIENT` and `expires_at = now() + RETRIEVAL_TTL`. `K` defaults to 8. Test.
+- **AC-25.12.** After `RETRIEVAL_TTL`, expired retrieval contributors are garbage-collected on the next read touching that target OR every `RETRIEVAL_GC_INTERVAL` ticks, whichever comes first. Test asserts expired rows are not returned by `active_now` even if not yet GC'd.
+- **AC-25.13.** A retrieval contributor is never written with `origin = self` or `origin = rule`. Test that `write_contributor(...)` with `origin = retrieval` raises — only the retrieval pipeline can mint retrieval edges.
+
+### Conflict resolution
+
+- **AC-25.14.** Two contributors from different sources cannot directly conflict (they sum). Test.
+- **AC-25.15.** When the self wants to override a rule-origin contributor it disagrees with, it writes a **competing self-origin contributor** with opposite sign and declares the rule's edge retracted-by-self (a new column on the contributor: `retracted_by: node_id | None`; when set, the edge is excluded from `active_now`). A self cannot retract its own past contributors — it must write a new one to counteract. Test.
+- **AC-25.16.** Primacy across multiple self-authored contributors: when two self contributors target the same node with opposite signs, the one with the larger absolute weight wins that round of sum. This is the same mechanism used by passion primacy (spec 24 AC-24.6). Test.
+
+### Write path
+
+- **AC-25.17.** `write_contributor(target, source, weight, rationale, origin=SELF)` is a tool exposed to the self. It validates constraints (no self-loops, `source_kind` valid, weight in range), inserts the row, and invalidates the target's cache. Test.
+- **AC-25.18.** Rules are loaded at deployment time from `research/project-turing/config/activation_rules.yaml`. Format: `target_kind`, `source_pattern`, `weight`, `rationale`. Rule rows are materialized at load. Unloading a rule removes its contributor rows. Test against a fake rules file.
+- **AC-25.19.** Every `write_contributor` also creates an OBSERVATION-tier memory with `content = f"[contributor] {source_id} → {target_node_id} weight={weight}: {rationale}"`. Provides an audit trail for the self's ontology decisions. Test.
+
+### Edge cases
+
+- **AC-25.20.** A target with zero durable contributors returns `active_now = 0.5` (neutral baseline, the sigmoid of 0). Documented as a semantic choice: an un-evidenced node is not "off," it's "indeterminate." Test.
+- **AC-25.21.** A target with only inhibitory contributors returns `active_now < 0.5`. A target with only excitatory contributors returns `active_now > 0.5`. Property test over random contributor sets.
+- **AC-25.22.** A target whose contributors sum to > +10.0 (dominant) still saturates at `active_now → 1.0` via sigmoid; it cannot exceed 1.0. Property test.
+- **AC-25.23.** A contributor whose source was hard-deleted (operator action) is detected at read time and treated as weight-0 for this compute, with a warning logged. Row stays in place for forensics. Test.
+- **AC-25.24.** A rule pattern that matches no live nodes at load time logs a warning but does not fail the load. Test.
+
+## Implementation
+
+### 25.1 Source state resolution
+
+```python
+def source_state(
+    repo: SelfRepo,
+    source_id: str,
+    source_kind: str,
+    context: ActivationContext,
+) -> float:
+    if source_kind == "personality_facet":
+        facet = repo.get_facet(source_id)
+        return max(0.0, min(1.0, (facet.score - 1.0) / 4.0))
+    if source_kind == "passion":
+        p = repo.get_passion(source_id)
+        return p.strength
+    if source_kind == "preference":
+        p = repo.get_preference(source_id)
+        return p.strength
+    if source_kind == "hobby":
+        h = repo.get_hobby(source_id)
+        return _recency_state(h.last_engaged_at, context.now, HOBBY_RECENCY_DAYS)
+    if source_kind == "interest":
+        i = repo.get_interest(source_id)
+        return _recency_state(i.last_noticed_at, context.now, INTEREST_RECENCY_DAYS)
+    if source_kind == "skill":
+        s = repo.get_skill(source_id)
+        return current_level(s, context.now)
+    if source_kind == "mood":
+        m = repo.get_mood(context.self_id)
+        return (m.valence + 1.0) / 2.0
+    if source_kind == "memory":
+        mem = repo.get_memory(source_id)
+        return max(0.0, min(1.0, mem.weight))
+    if source_kind == "rule":
+        return 1.0
+    if source_kind == "retrieval":
+        return context.retrieval_similarity.get(source_id, 0.0)
+    raise ValueError(f"unknown source_kind: {source_kind}")
+```
+
+### 25.2 Activation formula
+
+```python
+import math
+
+SCALE: float = 2.0
+
+def _sigmoid(x: float) -> float:
+    return 1.0 / (1.0 + math.exp(-x))
+
+
+def active_now(
+    repo: SelfRepo,
+    node_id: str,
+    context: ActivationContext,
+) -> float:
+    cached = _cache_get(node_id, context.hash)
+    if cached is not None:
+        return cached
+
+    contribs = repo.active_contributors_for(node_id, at=context.now)
+    raw = 0.0
+    for c in contribs:
+        if c.retracted_by is not None:
+            continue
+        s = source_state(repo, c.source_id, c.source_kind, context)
+        raw += c.weight * s
+
+    value = max(0.0, min(1.0, _sigmoid(raw / SCALE)))
+    _cache_put(node_id, context.hash, value, ttl=ACTIVATION_CACHE_TTL)
+    return value
+```
+
+### 25.3 Recency helper
+
+```python
+def _recency_state(last: datetime | None, now: datetime, window_days: float) -> float:
+    if last is None:
+        return 0.0
+    days = (now - last).total_seconds() / 86400.0
+    if days <= 0:
+        return 1.0
+    if days >= window_days:
+        return 0.0
+    return 1.0 - (days / window_days)
+```
+
+### 25.4 Constants
+
+```python
+RETRIEVAL_TTL:                  timedelta = timedelta(minutes=5)
+RETRIEVAL_WEIGHT_COEFFICIENT:   float = 0.4   # top-sim becomes a +0.4 edge
+RETRIEVAL_GC_INTERVAL_TICKS:    int = 1000    # reactor ticks
+ACTIVATION_CACHE_TTL:           timedelta = timedelta(seconds=30)
+HOBBY_RECENCY_DAYS:             float = 14.0
+INTEREST_RECENCY_DAYS:          float = 30.0
+```
+
+## Open questions
+
+- **Q25.1.** `SCALE = 2.0` in the sigmoid. With SCALE=1, a raw sum of 2 produces active=0.88; with SCALE=2, the same raw sum produces active=0.73. Softer seed reduces feedback loops where one strongly-activated node dominates many others. Tunable.
+- **Q25.2.** `RETRIEVAL_WEIGHT_COEFFICIENT = 0.4` bounds retrieval contributions below self-authored edges (which can be ±1.0). Keeps durable authored structure dominant over transient retrieval signal. Tunable but deliberate.
+- **Q25.3.** `active_now = 0.5` for zero-contributor nodes is semantically "indeterminate." An alternative is 0.0 ("unevidenced = off"). The 0.5 choice makes un-wired nodes neutral in the prompt surface rather than pulling scores down.
+- **Q25.4.** Retracted-by-self contributors remain as rows with a `retracted_by` field. This means the graph accumulates rows over time. A scheduled `compact_retractions` job could physically remove retracted rows whose retractor is itself still live. Deferred.
+- **Q25.5.** Rule-origin contributors always resolve to `source_state = 1.0`. An alternative is to let rules declare a weighting function over the request context (e.g., "this rule fires at strength 0.3 when the request is a voice call, else 1.0"). Deferred as rule-authoring complexity.
+- **Q25.6.** Cross-node cycles. The graph permits A → B and B → A (reciprocal contributors per spec 24 AC-24.18). `active_now` computation is one-shot (not iterative fixed-point), so a cycle is just a mutual contribution at a single evaluation step. No divergence risk. But a chain A → B → C → A, all at weight 1.0, would let the self's activation propagate around. Documented as intended behavior; a detector could flag suspicious cycle density for review.

--- a/research/project-turing/specs/mood.md
+++ b/research/project-turing/specs/mood.md
@@ -1,0 +1,216 @@
+# Spec 27 — Mood
+
+*A three-dimensional affective vector that decays toward neutral, is nudged by events, and surfaces in the minimal prompt block. Phase-1 scope: affects tone only.*
+
+**Depends on:** [self-schema.md](./self-schema.md), [tiers.md](./tiers.md).
+**Depended on by:** [self-surface.md](./self-surface.md), [self-as-conduit.md](./self-as-conduit.md).
+
+---
+
+## Current state
+
+- Nothing like "how is the self feeling right now" exists. Episodic memory has `affect` per memory (spec 1), but there is no aggregate current state.
+
+## Target
+
+A singleton `Mood` row per `self_id` carrying `(valence, arousal, focus)` that:
+- Decays toward neutral `(0, 0.3, 0.5)` on an hourly tick (neutral is slightly positive-arousal and moderately-focused because "idle" is not "collapsed").
+- Is nudged by events (surprise deltas on tool calls, affirmations met, regrets minted).
+- Surfaces in the minimal prompt block as a one-line descriptor.
+- Does NOT affect routing, model choice, or specialist dispatch in Phase 1. Only tone.
+
+## Acceptance criteria
+
+### State
+
+- **AC-27.1.** Exactly one `self_mood` row exists per `self_id` after bootstrap. Bootstrap seeds it to `(valence=0.0, arousal=0.3, focus=0.5)`. A second insert raises (spec 22 AC-22.17). Test.
+- **AC-27.2.** `valence ∈ [-1.0, 1.0]`, `arousal ∈ [0.0, 1.0]`, `focus ∈ [0.0, 1.0]`. Out-of-range writes raise. Test on each dimension boundary.
+- **AC-27.3.** Every mutation updates `last_tick_at`, `updated_at`. A mutation that doesn't update at least `updated_at` raises. Test.
+
+### Decay
+
+- **AC-27.4.** `tick_mood_decay(self_id, now)` moves each dimension toward its neutral target:
+  ```
+  new_dim = current + DECAY_RATE × (neutral_dim - current)
+  ```
+  where `DECAY_RATE = 0.1 per hour` (default). Test with fixed inputs asserts the exact arithmetic.
+- **AC-27.5.** Decay runs hourly via a Reactor interval trigger. Missed ticks (downtime longer than the interval) catch up with a **single** compound decay step scaled by the gap:
+  ```
+  effective_rate = 1 - (1 - DECAY_RATE)^hours_elapsed
+  ```
+  Asymptotic — no matter how long the gap, state ends at most at neutral. Test simulates 100-hour downtime.
+- **AC-27.6.** Decay is purely mathematical — no LLM call, no memory write. `tick_mood_decay` is idempotent within the same tick. Test.
+- **AC-27.7.** Decay never crosses neutral (no oscillation). A state at `(0.02, 0.5, 0.5)` decays toward `(0, 0.3, 0.5)`, not past it. Test.
+
+### Event nudges
+
+- **AC-27.8.** `nudge_mood(self_id, dim, delta, reason)` applies `new = clamp(current + delta, range)` on the named dimension. `delta ∈ [-0.5, 0.5]` per single nudge (one event cannot swing mood past half the scale). Values outside raise. Test.
+- **AC-27.9.** Every nudge writes an OBSERVATION-tier memory:
+  ```
+  content = f"[mood nudge] {dim} {current:+.2f} → {new:+.2f} (reason: {reason})"
+  intent_at_time = "mood nudge"
+  context = {"dim": dim, "delta": delta, "reason": reason}
+  ```
+  Test.
+- **AC-27.10.** Standard event sources and their seed nudges (tunable):
+  - Tool call succeeded after expected-fail: `valence +0.1, arousal +0.05`
+  - Tool call failed unexpectedly: `valence -0.15, arousal +0.1, focus -0.1`
+  - AFFIRMATION minted: `valence +0.1`
+  - REGRET minted: `valence -0.2, focus -0.05`
+  - Self-todo completed: `valence +0.05, focus +0.05`
+  - Warden alert on ingress: `arousal +0.2, focus +0.1`
+
+  Each event-source rule is unit-testable. Test one per row.
+- **AC-27.11.** Concurrent nudges on the same `self_id` are serialized by an advisory lock. Final state is the result of applying nudges in the order the lock releases — no lost updates. Test.
+
+### Prompt surface
+
+- **AC-27.12.** The minimal prompt block renders mood as a one-line qualitative descriptor chosen from a lookup table over the `(valence, arousal)` quadrants:
+
+  | | low arousal | high arousal |
+  |---|---|---|
+  | negative valence | "flat, withdrawn" | "tense, on edge" |
+  | neutral valence | "even, steady" | "alert, attentive" |
+  | positive valence | "content, easy" | "keen, energized" |
+
+  With `focus` appended as `"; focused"` if `focus > 0.7` or `"; scattered"` if `focus < 0.3`, otherwise omitted.
+
+  Test over 9 representative `(valence, arousal, focus)` tuples.
+
+- **AC-27.13.** The descriptor is the only mood surface in Phase-1. Raw numeric mood values are NOT in the minimal prompt block. They ARE in `recall_self()` output for depth (spec 28). Test.
+
+### Phase-1 scope limits
+
+- **AC-27.14.** Mood does NOT influence model selection, specialist dispatch, or classifier thresholds in Phase-1. Test: swap mood values across an extreme range and assert identical routing outputs on a fixed request.
+- **AC-27.15.** Mood DOES influence system-prompt phrasing via the descriptor. Behavioral test: two routings with opposite moods produce prompts that differ in the mood descriptor line but nowhere else.
+
+### Edge cases
+
+- **AC-27.16.** A nudge whose `delta` would push the dimension out of range clamps to the boundary rather than raising. Test at boundary.
+- **AC-27.17.** Nudges during the same second as a tick: the tick runs first (decay), then the nudge applies. Test.
+- **AC-27.18.** A malformed `dim` (not one of `valence|arousal|focus`) raises immediately. Test.
+- **AC-27.19.** The `neutral` target is configurable per deployment. Changing `neutral` mid-run causes the next tick to decay toward the new neutral. Test.
+
+## Implementation
+
+### 27.1 Constants
+
+```python
+NEUTRAL_VALENCE:  float = 0.0
+NEUTRAL_AROUSAL:  float = 0.3
+NEUTRAL_FOCUS:    float = 0.5
+DECAY_RATE:       float = 0.1     # per hour
+NUDGE_MAX:        float = 0.5
+```
+
+### 27.2 Decay math
+
+```python
+def decay_step(current: float, neutral: float, hours: float) -> float:
+    effective = 1.0 - (1.0 - DECAY_RATE) ** hours
+    return current + effective * (neutral - current)
+
+
+def tick_mood_decay(repo: SelfRepo, self_id: str, now: datetime) -> Mood:
+    with repo.advisory_lock(f"mood:{self_id}"):
+        m = repo.get_mood(self_id)
+        hours = max(0.0, (now - m.last_tick_at).total_seconds() / 3600.0)
+        if hours <= 0:
+            return m
+        m.valence = decay_step(m.valence, NEUTRAL_VALENCE, hours)
+        m.arousal = decay_step(m.arousal, NEUTRAL_AROUSAL, hours)
+        m.focus   = decay_step(m.focus,   NEUTRAL_FOCUS,   hours)
+        m.last_tick_at = now
+        m.updated_at   = now
+        repo.update_mood(m)
+        return m
+```
+
+### 27.3 Nudge with clamp
+
+```python
+DIM_RANGES: dict[str, tuple[float, float]] = {
+    "valence": (-1.0, 1.0),
+    "arousal": ( 0.0, 1.0),
+    "focus":   ( 0.0, 1.0),
+}
+
+
+def nudge_mood(repo: SelfRepo, self_id: str, dim: str,
+               delta: float, reason: str) -> Mood:
+    if dim not in DIM_RANGES:
+        raise ValueError(f"unknown mood dim: {dim}")
+    if abs(delta) > NUDGE_MAX:
+        raise ValueError(f"nudge delta {delta} exceeds NUDGE_MAX {NUDGE_MAX}")
+    low, high = DIM_RANGES[dim]
+    with repo.advisory_lock(f"mood:{self_id}"):
+        m = repo.get_mood(self_id)
+        current = getattr(m, dim)
+        new = max(low, min(high, current + delta))
+        setattr(m, dim, new)
+        m.updated_at = datetime.now(UTC)
+        repo.update_mood(m)
+        memories.write_observation(
+            self_id=self_id,
+            content=f"[mood nudge] {dim} {current:+.2f} → {new:+.2f} (reason: {reason})",
+            intent_at_time="mood nudge",
+            context={"dim": dim, "delta": delta, "reason": reason},
+        )
+        return m
+```
+
+### 27.4 Descriptor table
+
+```python
+def mood_descriptor(m: Mood) -> str:
+    if m.valence < -0.15:
+        v = "negative"
+    elif m.valence > 0.15:
+        v = "positive"
+    else:
+        v = "neutral"
+
+    a = "high" if m.arousal > 0.6 else "low"
+
+    core = {
+        ("negative", "low"):  "flat, withdrawn",
+        ("negative", "high"): "tense, on edge",
+        ("neutral",  "low"):  "even, steady",
+        ("neutral",  "high"): "alert, attentive",
+        ("positive", "low"):  "content, easy",
+        ("positive", "high"): "keen, energized",
+    }[(v, a)]
+
+    if m.focus > 0.7:
+        return f"{core}; focused"
+    if m.focus < 0.3:
+        return f"{core}; scattered"
+    return core
+```
+
+### 27.5 Standard event dispatch
+
+```python
+EVENT_NUDGES: dict[str, list[tuple[str, float]]] = {
+    "tool_succeeded_against_expectation": [("valence", +0.10), ("arousal", +0.05)],
+    "tool_failed_unexpectedly":           [("valence", -0.15), ("arousal", +0.10), ("focus", -0.10)],
+    "affirmation_minted":                 [("valence", +0.10)],
+    "regret_minted":                      [("valence", -0.20), ("focus", -0.05)],
+    "todo_completed":                     [("valence", +0.05), ("focus", +0.05)],
+    "warden_alert_on_ingress":            [("arousal", +0.20), ("focus", +0.10)],
+}
+
+
+def apply_event_nudge(repo: SelfRepo, self_id: str, event: str, reason: str) -> None:
+    for dim, delta in EVENT_NUDGES.get(event, []):
+        nudge_mood(repo, self_id, dim, delta, reason=f"{event}: {reason}")
+```
+
+## Open questions
+
+- **Q27.1.** Neutral `(0, 0.3, 0.5)` is a guess. "Slightly positive arousal, moderately focused" matches a resting agent waiting for the next request. An operator running a support-focused deployment might prefer `arousal=0.5` (more eager). Configurable.
+- **Q27.2.** `DECAY_RATE = 0.1/hour` means ~10% of distance-to-neutral per hour. Over a 24h idle period, a dimension at `+0.8` decays to roughly `+0.2`. Empirically check whether that feels right on the live branch.
+- **Q27.3.** `NUDGE_MAX = 0.5` prevents any single event from flipping the sign of valence. A sequence of nudges can — a string of regrets pushes valence negative quickly. Intentional: the self can accumulate a mood, it just can't be whiplashed by one event.
+- **Q27.4.** Phase-2 (backlog): mood affects decisions. Example couplings worth exploring: low `focus` → favor specialists with tighter scope; high `arousal` → prefer faster models; negative `valence` + high `arousal` → raise Warden sensitivity threshold by default. All deferred; not in this spec.
+- **Q27.5.** The descriptor table is 6 labels × 3 focus modifiers = 18 phrases. A more graduated phrasing is plausible (polar-coordinate descriptor based on the full 3-vector). The 6-cell table is deliberately coarse to avoid overclaiming resolution.
+- **Q27.6.** Mood is singleton per `self_id`. On a per-conversation basis, a "session mood" sub-state could better capture "how do I feel about *this* interaction." Deferred; the global mood is enough for Phase-1.

--- a/research/project-turing/specs/personality.md
+++ b/research/project-turing/specs/personality.md
@@ -1,0 +1,219 @@
+# Spec 23 — Personality: HEXACO-24 with weekly re-test and narrative revision
+
+*The self carries a continuous 24-facet HEXACO profile. Scores are seeded at bootstrap, tracked weekly against a sampled re-test, and nudged between re-tests by narrative self-reports that enter through the activation graph.*
+
+**Depends on:** [self-schema.md](./self-schema.md).
+**Depended on by:** [activation-graph.md](./activation-graph.md), [self-surface.md](./self-surface.md), [self-bootstrap.md](./self-bootstrap.md), [self-as-conduit.md](./self-as-conduit.md).
+
+---
+
+## Current state
+
+- No personality model exists. The Conduit and all specialists pick model and tone from request signals alone.
+- No HEXACO item bank is loaded. No re-test cadence is defined. No mechanism exists for the self to self-report trait observations.
+
+## Target
+
+Adopt the HEXACO personality model — six traits, four facets each, 24 facets total — with continuous scores on `[1.0, 5.0]`. Bootstrap the profile once with a random draw and 200 LLM-generated Likert answers that become bootstrap memories. Update the profile weekly via a 20-item re-test whose move size is bounded. Permit between-tests revision via first-person claims that enter through the activation graph rather than directly mutating scores.
+
+## Acceptance criteria
+
+### HEXACO-24 structure
+
+- **AC-23.1.** The 24 facets are the canonical HEXACO-PI-R set: 4 per trait across Honesty-Humility, Emotionality, eXtraversion, Agreeableness, Conscientiousness, Openness. A bootstrap that produces any other count raises. Test asserts the exact 24-member facet list.
+- **AC-23.2.** Every facet maps to exactly one trait. Test over the canonical facet → trait map.
+- **AC-23.3.** Scores are stored as `float` in `[1.0, 5.0]`. Below 1.0 and above 5.0 are rejected at write time (spec 22 AC-22.5).
+
+### HEXACO-200 item bank
+
+- **AC-23.4.** The item bank contains exactly 200 items. Each item has `item_number ∈ [1, 200]`, `prompt_text`, `keyed_facet` (one of 24), `reverse_scored: bool`. Loading the bank produces 200 rows with unique item numbers. Test.
+- **AC-23.5.** The bank is loaded once (per spec 22 AC-22.6) and is immutable thereafter for the life of the self. A second load raises. Test.
+- **AC-23.6.** Reverse-scored items invert the 1..5 answer to a 5..1 contribution when computing facet scores. Unit test on a fixed set of reverse-scored items.
+
+### Bootstrap seeding
+
+- **AC-23.7.** Bootstrap generates 24 facet scores, each an independent draw from a truncated normal centered at 3.0 with σ=0.8, clamped to `[1.0, 5.0]`. RNG seed is deterministic if provided. Test asserts determinism with a fixed seed.
+- **AC-23.8.** Bootstrap generates 200 Likert answers by prompting an LLM, one item per call or batched, passing the full 24-facet profile as context. The LLM must return an integer in `{1,2,3,4,5}` and a ≤200-char justification. Out-of-range or missing answers trigger retry (max 3) before failure. Test asserts the retry behavior against a fake LLM.
+- **AC-23.9.** Each of the 200 bootstrap answers is also written as an OBSERVATION-tier episodic memory with `source = I_DID` and `intent_at_time = "personality bootstrap"`. The memory's `content` contains the item prompt + answer + justification. Test.
+- **AC-23.10.** Bootstrap is idempotent per `self_id` — a second bootstrap for the same self raises rather than overwriting. Test.
+
+### Weekly re-test
+
+- **AC-23.11.** `run_personality_retest(self_id)` is schedulable on a weekly cadence via the Reactor (spec 20). First execution is 7 days after bootstrap; subsequent executions are 7 days after the last completed retest. Test.
+- **AC-23.12.** Sample selection draws exactly 20 items from the 200-item bank. Sampling is weighted by `time_since_last_asked` (items never asked have highest weight; items asked most recently have lowest). Facet coverage is a secondary constraint: the 20-item sample must touch at least 12 distinct facets. Test asserts both the weighted distribution (over many samples) and the per-sample facet-diversity floor.
+- **AC-23.13.** The retest prompt passes in current traits, active todos, recent mood, top-K recent memories — but **not** any previous answers to those 20 items. A test captures the prompt payload and asserts prior answers are absent.
+- **AC-23.14.** Each item's returned answer is validated as `{1,2,3,4,5}`. Missing or invalid answers abort the retest with no score changes (atomicity). Test.
+- **AC-23.15.** For every facet touched by the 20-item sample, the new score is computed as `retest_facet_score = mean(answers_keyed_to_facet, reverse-corrected)`. Facets not touched by this sample are unchanged. Test asserts both the mean maths and the no-touch no-change invariant.
+- **AC-23.16.** For every touched facet, the stored score updates as `new = old + 0.25 × (retest_facet_score − old)`. The coefficient 0.25 is the `RETEST_WEIGHT` constant and is configurable. Test with fixed inputs asserts the exact arithmetic.
+- **AC-23.17.** The 20 fresh answers are written as `self_personality_answers` rows with the newly-minted `revision_id`. Each is also written as an OBSERVATION-tier episodic memory (same shape as bootstrap answers). Test.
+- **AC-23.18.** The retest writes a `self_personality_revisions` row capturing `sampled_item_ids`, `deltas_by_facet`, `ran_at`. Test.
+
+### Narrative revision
+
+- **AC-23.19.** `record_personality_claim(facet_id, claim_text, evidence)` is a tool available to the self. It creates an OPINION-tier episodic memory with `content = f"I notice: {claim_text}"`, `intent_at_time = "narrative personality revision"`, and `context.facet_id = facet_id`. Test.
+- **AC-23.20.** The same call creates an `ActivationContributor` row with `target = {facet_node_id}`, `source = {memory_id}`, `source_kind = "memory"`, `origin = "self"`, `weight` derived from `evidence` (see §23.5). Test.
+- **AC-23.21.** Narrative revision does NOT directly mutate `self_personality_facets.score`. The contributor feeds the activation graph (spec 25); the score is only moved by the weekly retest. Test asserts the score is unchanged after a narrative claim.
+- **AC-23.22.** A claim whose facet_id is not in the canonical 24 raises. Test.
+
+### Edge cases
+
+- **AC-23.23.** If the scheduler skips a week (downtime, quiet zone), the next retest catches up — one retest, not two. Test simulates a 15-day gap and asserts exactly one retest runs.
+- **AC-23.24.** Two concurrent retests for the same `self_id` are prevented by an advisory lock. The second attempt returns a `RetestAlreadyRunning` status rather than racing. Test.
+- **AC-23.25.** An LLM that returns `5` to every item (stuck answer) is still accepted by the retest pipeline, but the tuning detector (spec 11) flags suspiciously uniform answers for operator review. Flag-only; no automatic rejection.
+- **AC-23.26.** If every facet drifts toward an extreme over many retests (personality collapse), the tuning detector flags the pattern as an observation (not a hard block).
+
+## Implementation
+
+### 23.1 Facet table
+
+```python
+CANONICAL_FACETS: dict[Trait, tuple[str, ...]] = {
+    Trait.HONESTY_HUMILITY: ("sincerity", "fairness", "greed_avoidance", "modesty"),
+    Trait.EMOTIONALITY: ("fearfulness", "anxiety", "dependence", "sentimentality"),
+    Trait.EXTRAVERSION: ("social_self_esteem", "social_boldness", "sociability", "liveliness"),
+    Trait.AGREEABLENESS: ("forgiveness", "gentleness", "flexibility", "patience"),
+    Trait.CONSCIENTIOUSNESS: ("organization", "diligence", "perfectionism", "prudence"),
+    Trait.OPENNESS: ("aesthetic_appreciation", "inquisitiveness", "creativity", "unconventionality"),
+}
+
+ALL_FACETS: list[tuple[Trait, str]] = [
+    (trait, facet) for trait, facets in CANONICAL_FACETS.items() for facet in facets
+]
+assert len(ALL_FACETS) == 24
+```
+
+### 23.2 Bootstrap draw
+
+```python
+import random
+from statistics import NormalDist
+
+def draw_bootstrap_profile(rng: random.Random) -> dict[str, float]:
+    profile: dict[str, float] = {}
+    for trait, facet in ALL_FACETS:
+        raw = rng.gauss(mu=3.0, sigma=0.8)
+        profile[f"facet:{trait.value}.{facet}"] = min(5.0, max(1.0, raw))
+    return profile
+```
+
+### 23.3 Retest sampling
+
+```python
+import math
+
+def sample_retest_items(
+    items: list[PersonalityItem],
+    answers: list[PersonalityAnswer],
+    rng: random.Random,
+    n: int = 20,
+    facet_diversity_floor: int = 12,
+) -> list[PersonalityItem]:
+    now = datetime.now(UTC)
+    last_asked: dict[str, datetime] = {}
+    for a in answers:
+        prev = last_asked.get(a.item_id)
+        if prev is None or a.asked_at > prev:
+            last_asked[a.item_id] = a.asked_at
+
+    def weight(item: PersonalityItem) -> float:
+        t = last_asked.get(item.node_id)
+        if t is None:
+            return 10_000.0   # never-asked dominates
+        days = max(0.001, (now - t).total_seconds() / 86400.0)
+        return days
+
+    # Try up to 10 weighted samples; keep the first that satisfies facet floor.
+    for _ in range(10):
+        weights = [weight(it) for it in items]
+        choices = rng_weighted_sample(rng, items, weights, n)
+        facets_touched = {it.keyed_facet for it in choices}
+        if len(facets_touched) >= facet_diversity_floor:
+            return choices
+    # Fallback: stratify by facet, one per facet round-robin.
+    return stratified_fallback(items, rng, n)
+```
+
+`rng_weighted_sample` is weighted sampling without replacement. `stratified_fallback` cycles through facets picking the oldest-asked item in each.
+
+### 23.4 Retest update
+
+```python
+RETEST_WEIGHT: float = 0.25
+
+
+def apply_retest(
+    repo: SelfRepo,
+    llm: LLM,
+    self_id: str,
+    sampled: list[PersonalityItem],
+    now: datetime,
+) -> PersonalityRevision:
+    answers = ask_self_fresh(llm, sampled, context=repo.self_context(self_id))
+    revision_id = new_id("rev")
+
+    by_facet: dict[str, list[int]] = defaultdict(list)
+    for item, raw in zip(sampled, answers, strict=True):
+        scored = 6 - raw if item.reverse_scored else raw
+        by_facet[item.keyed_facet].append(scored)
+
+    deltas: dict[str, float] = {}
+    for facet, vals in by_facet.items():
+        retest_score = sum(vals) / len(vals)
+        current = repo.get_facet_score(self_id, facet)
+        delta = RETEST_WEIGHT * (retest_score - current)
+        new_score = current + delta
+        repo.update_facet_score(self_id, facet, new_score, revised_at=now)
+        deltas[facet] = delta
+
+    for item, raw, ans in zip(sampled, answers, answers_with_justifications(answers), strict=True):
+        repo.insert_answer(PersonalityAnswer(
+            node_id=new_id("ans"),
+            self_id=self_id,
+            item_id=item.node_id,
+            revision_id=revision_id,
+            answer_1_5=raw,
+            justification_text=ans.justification,
+            asked_at=now,
+        ))
+        # Mirror into episodic memory.
+        memories.write_observation(
+            self_id=self_id,
+            content=f"[personality retest] {item.prompt_text} → {raw}: {ans.justification}",
+            intent_at_time="personality retest",
+            context={"item_id": item.node_id, "revision_id": revision_id},
+        )
+
+    return repo.insert_revision(PersonalityRevision(
+        node_id=new_id("rev_node"),
+        self_id=self_id,
+        revision_id=revision_id,
+        ran_at=now,
+        sampled_item_ids=[it.node_id for it in sampled],
+        deltas_by_facet=deltas,
+    ))
+```
+
+### 23.5 Narrative revision weight
+
+`record_personality_claim(facet_id, claim_text, evidence)` — `evidence` is a short string the self supplies ("three recent completed todos about reading philosophy"). Contributor weight is computed as:
+
+```python
+def narrative_weight(evidence: str, claim_text: str) -> float:
+    # Seed: length-based heuristic, bounded. Tuning can replace this.
+    ev_bonus = min(0.3, len(evidence) / 500.0)
+    return min(1.0, 0.1 + ev_bonus)
+```
+
+Weights from narrative claims are intentionally small (≤0.4 seed-max) so no single self-report overrides the calculated retest.
+
+### 23.6 Scheduling
+
+Scheduled via the Reactor (spec 20) as an interval trigger: `every 7d since last completion`. The first retest fires at `bootstrap_completed_at + 7d`. On skip/catch-up, one retest fires covering only the most recent week; missed retests are not retroactively executed.
+
+## Open questions
+
+- **Q23.1.** Retest cadence is fixed at 7 days. An alternative is adaptive cadence — re-test sooner if the activation graph accumulates many narrative contributors against the same facet (signal that the self's self-report is drifting from its calculated score). Deferred.
+- **Q23.2.** `RETEST_WEIGHT = 0.25` is a seed. Empirical tuning (spec 11) will check whether this stabilizes or oscillates over months of retest history.
+- **Q23.3.** Bootstrap draws from a truncated normal at μ=3.0. An operator might want to bias the distribution (e.g., force a high-Honesty-Humility self for a compliance-sensitive deployment). A config-level override of the bootstrap mean per facet is plausible but not specified here.
+- **Q23.4.** Narrative contributor weights are capped at ≤0.4. If that cap proves too low for the self to meaningfully self-report, tuning raises it. Test-covered only at the 0.1 floor / 0.4 ceiling boundaries.
+- **Q23.5.** Reverse-scoring uses `6 - raw`. HEXACO literature uses a 5-point Likert on `{1..5}` so `6 - raw` inverts correctly; if the bank ever switches to a 7-point form, this constant must change.

--- a/research/project-turing/specs/self-as-conduit.md
+++ b/research/project-turing/specs/self-as-conduit.md
@@ -1,0 +1,246 @@
+# Spec 30 — Self-as-Conduit: first-person routing
+
+*The Turing replacement for the stateless Conduit. Every inbound request is a moment in the self's life: the self perceives, decides, observes the outcome, and folds the experience back into its memory and self-model.*
+
+**Depends on:** [self-schema.md](./self-schema.md), [personality.md](./personality.md), [self-nodes.md](./self-nodes.md), [activation-graph.md](./activation-graph.md), [self-todos.md](./self-todos.md), [mood.md](./mood.md), [self-surface.md](./self-surface.md), [self-bootstrap.md](./self-bootstrap.md), [motivation.md](./motivation.md), [chat-surface.md](./chat-surface.md), [retrieval.md](./retrieval.md), [write-paths.md](./write-paths.md).
+**Depended on by:** —
+
+---
+
+## Current state
+
+- `main` has a stateless Conduit (ARCHITECTURE.md §2.6). Classifier → route → agent.handle. No memory of prior routings.
+- Turing DESIGN.md §5 frames what the Conduit *becomes* when autonoetic: recognition of recurrence, policy via AFFIRMATION, prospective simulation. This spec specifies the concrete request flow.
+
+## Target
+
+Replace the classifier → route → handle pipeline with a self-reasoning step that consults the minimal prompt block (spec 28), optionally calls `recall_self()`, decides the routing via an LLM turn, dispatches (or declines), then observes and folds.
+
+## Acceptance criteria
+
+### Pipeline entry
+
+- **AC-30.1.** The HTTP entry at `POST /v1/chat/completions` (chat-surface.md spec 17) routes to `self_conduit.handle(request, auth)` instead of the stateless classify-and-route. Test at HTTP level with a fake pipeline asserts the right handler is invoked.
+- **AC-30.2.** `self_conduit.handle` precondition: bootstrap is complete (per spec 29). If not, respond with HTTP 503 + body `"self not bootstrapped"`. Test.
+
+### Perception
+
+- **AC-30.3.** On request arrival, the pipeline:
+  1. Runs Warden on user input (existing).
+  2. Assembles the minimal prompt block (spec 28 AC-28.15).
+  3. Fires semantic retrieval over durable memory + stance-bearing memory (spec 16) + self-nodes. Materializes top-K matches as `origin=retrieval` contributors (spec 25 AC-25.11).
+  4. Calls the self-LLM with `minimal_block + user_request` and the self-tools available.
+
+  Test asserts all four steps execute and that retrieval contributors are present for this request's tick.
+- **AC-30.4.** The LLM call budget is capped at `PERCEPTION_TOKEN_BUDGET = 6000` input + `PERCEPTION_OUTPUT_BUDGET = 2000` output. Exceeding input budget triggers graceful degradation: drop recent-memories section first, then drop retrieval-similarity expansion. Test with oversized context.
+- **AC-30.5.** The self may call `recall_self()` during perception (at most once per request). Subsequent calls raise `RecallSelfAlreadyInvoked`. Test.
+
+### Decision
+
+- **AC-30.6.** The self emits a tool call to **exactly one** of:
+  - `reply_directly(content)` — no specialist needed
+  - `delegate(specialist, task_spec)` — dispatch to an agent in the existing roster (Ranger, Artificer, Scribe, Warden-at-Arms, Forge, or a sub-spawn of any)
+  - `ask_clarifying(question)` — request clarification from the user
+  - `decline(reason)` — refuse to route this request
+
+  The decision tool name is captured as the routing choice. A response without exactly one of these four tool calls raises `AmbiguousRouting` and re-prompts once; second failure replies with HTTP 500 + audit log entry. Test each path.
+
+- **AC-30.7.** `delegate` validates that the named specialist exists in the roster and is enabled. Unknown specialist → treat as `AmbiguousRouting` (re-prompt). Test.
+
+- **AC-30.8.** The routing choice is written as an OBSERVATION-tier memory in first person:
+  ```
+  content = f"I chose to {decision_verb} for this request: {summary}"
+  source = I_DID
+  intent_at_time = "route request"
+  context = {"decision": decision_tool_name, "target": specialist_or_none, "request_hash": sha256(user_text)}
+  ```
+  Before the specialist (if any) is actually invoked. Test.
+
+- **AC-30.9.** Pre-decision the self MAY write self-model updates (note new passion, mint an AFFIRMATION, write a todo) via its tools. These writes must happen BEFORE the delegate/reply tool call — the self can't write self-model changes AFTER routing. Test: attempting a self-tool after the decision tool raises.
+
+### Dispatch
+
+- **AC-30.10.** If the decision is `delegate`, the specialist runs via existing `agent.handle()` in the stateless agent pipeline (unchanged from `main`). Tenant isolation still holds at that layer. Test that specialist execution does not see self-model state.
+- **AC-30.11.** If the decision is `reply_directly`, the content is sanitized via the Warden post-gate (spec 3 equivalent) and returned. Test.
+- **AC-30.12.** If the decision is `ask_clarifying`, the question is returned to the user with an HTTP 200 and a `conversation_continue: true` marker. The self does NOT learn from the question itself; it learns from the user's follow-up. Test.
+- **AC-30.13.** If the decision is `decline`, the response is a polite refusal with the self's reason. A REGRET-tier memory is NOT automatically minted (decline is a legitimate choice); but an OPINION memory IS written. Test.
+
+### Observation
+
+- **AC-30.14.** After dispatch completes (or fails), the self runs a brief `observe(outcome)` step that:
+  - Receives the specialist's result (or error, or clarification-response, or decline).
+  - May mint AFFIRMATION / REGRET / LESSON memories via standard write-paths (spec 4).
+  - May nudge mood via `apply_event_nudge` (spec 27 AC-27.10).
+  - May `note_passion` / `note_hobby` / `note_skill` / `note_preference` if the experience prompts a noticed self-attribute.
+  - May complete an active todo if the request advanced it.
+
+  All writes are in first person. Test asserts every post-dispatch write is attributed to the self and written before the response returns.
+- **AC-30.15.** The observation step has a token budget of `OBSERVATION_TOKEN_BUDGET = 2000`. Over budget → truncate to a single-line outcome summary + optional one mood nudge. Test.
+- **AC-30.16.** `observe` runs even when dispatch fails. A specialist exception becomes an outcome the self can REGRET / LESSON. Test.
+
+### Ordering and atomicity
+
+- **AC-30.17.** End-to-end ordering per request:
+  1. Warden (user input)
+  2. minimal_block + retrieval contributors
+  3. self perception (LLM call, possible recall_self, possible self-tool writes)
+  4. Decision write (routing choice memory)
+  5. Dispatch (specialist runs, OR direct reply, OR clarify, OR decline)
+  6. Warden (outcome, if present)
+  7. Observation (LLM call, possible self-model updates)
+  8. Response returned to user
+
+  Test asserts sequence via span ordering in a trace.
+- **AC-30.18.** If the request is cancelled mid-flight (client disconnect), steps 1–4 are preserved (the routing decision is minted regardless). Step 5 is cancelled. Step 7 runs with `outcome = "cancelled"`. Test.
+- **AC-30.19.** The retrieval contributors are guaranteed to expire before the next tick — they are TTL-bound per spec 25. No cross-request leakage of retrieval state. Test asserts that a contributor from request N is expired by request N+1 if N+1 arrives after TTL.
+
+### First-person framing
+
+- **AC-30.20.** System prompts for the self's perception and observation LLM calls open with "You are the self:" or equivalent first-person framing. Every tool description is first-person (spec 28 AC-28.5). Test.
+- **AC-30.21.** The response returned to the user is the specialist's output (for delegate), the self's content (for reply_directly), the clarifying question (for ask_clarifying), or the decline reason (for decline). The user NEVER sees the minimal_block, the retrieval contributors, or the self's internal reasoning. Test.
+
+### Cross-tenant routing (research-branch posture)
+
+- **AC-30.22.** The self perceives every request regardless of `auth.tenant_id`. Below the self, specialists still respect tenant isolation where applicable. Routing metadata (which specialist was picked) is visible to the self across tenants; specialist execution is tenant-scoped. Test with two different tenants making requests and asserting the self's memory contains both while specialist memory does not cross.
+- **AC-30.23.** This cross-tenant posture is the reason the self-as-Conduit cannot land in `main`. This AC is tested as a research-branch invariant, not as a feature: a test asserts the existence of cross-tenant memory as evidence that the design is research-only.
+
+### Edge cases
+
+- **AC-30.24.** A request that arrives during bootstrap raises HTTP 503 (per AC-30.2). Test.
+- **AC-30.25.** A request whose user-input Warden returns `blocked` short-circuits at step 1; no perception, no decision, no observation. An OBSERVATION memory still records the block ("I saw an ingress-blocked request.") Test.
+- **AC-30.26.** A specialist that returns a result tainted by `warden.tool_result` → `blocked`: the self's observation step sees the block, mints a REGRET-tier memory ("I routed to Scribe; the tool result was blocked by Warden."), nudges mood negative. Test.
+- **AC-30.27.** Two rapid requests where the second arrives before the first's observation step completes: the second's perception sees the first's decision memory (already written) but NOT the first's observation (not yet written). Intentional — the self knows what it *chose* before it knows the *outcome*. Test.
+- **AC-30.28.** `recall_self()` called during observation is permitted (different invocation scope from perception). Test.
+- **AC-30.29.** A stuck LLM call at perception (timeout) raises `PerceptionTimeout` after `PERCEPTION_TIMEOUT_SEC = 30`. An OBSERVATION memory records the timeout. Response is HTTP 504. Test with a fake LLM that sleeps.
+
+## Implementation
+
+### 30.1 Constants
+
+```python
+PERCEPTION_TOKEN_BUDGET:      int = 6000
+PERCEPTION_OUTPUT_BUDGET:     int = 2000
+OBSERVATION_TOKEN_BUDGET:     int = 2000
+PERCEPTION_TIMEOUT_SEC:       int = 30
+OBSERVATION_TIMEOUT_SEC:      int = 15
+```
+
+### 30.2 Request flow skeleton
+
+```python
+async def handle(request: ChatRequest, auth: AuthContext) -> ChatResponse:
+    if not _bootstrap_complete(SELF_ID):
+        return ChatResponse(status=503, body="self not bootstrapped")
+
+    # Step 1: Warden ingress
+    verdict_in = warden.scan_user_input(request.messages)
+    if verdict_in.status == "blocked":
+        _record_ingress_block(request, verdict_in)
+        return ChatResponse(status=400, body="request blocked by warden")
+
+    # Steps 2-3: perception
+    block = render_minimal_block(SELF_ID)
+    _materialize_retrieval_contributors(SELF_ID, request)
+    perception = await _perceive(block, request, auth,
+                                 budget=PERCEPTION_TOKEN_BUDGET,
+                                 timeout=PERCEPTION_TIMEOUT_SEC)
+
+    # Step 4: decision write
+    decision = _extract_decision(perception)
+    if decision is None:
+        return ChatResponse(status=500, body="routing failure")
+    _record_routing_decision(SELF_ID, decision, request)
+
+    # Step 5: dispatch
+    try:
+        outcome = await _dispatch(decision, request, auth)
+    except Exception as e:
+        outcome = DispatchOutcome(status="error", error=repr(e))
+
+    # Step 6: Warden outcome
+    if outcome.has_content():
+        verdict_out = warden.scan_tool_result(outcome.content)
+        if verdict_out.status == "blocked":
+            outcome = outcome.with_blocked(verdict_out)
+
+    # Step 7: observe
+    await _observe(SELF_ID, decision, outcome,
+                   budget=OBSERVATION_TOKEN_BUDGET,
+                   timeout=OBSERVATION_TIMEOUT_SEC)
+
+    # Step 8: respond
+    return _render_response(outcome)
+```
+
+### 30.3 Decision extraction
+
+```python
+_DECISION_TOOLS = {"reply_directly", "delegate", "ask_clarifying", "decline"}
+
+
+def _extract_decision(perception: LLMResponse) -> Decision | None:
+    calls = [c for c in perception.tool_calls if c.name in _DECISION_TOOLS]
+    if len(calls) != 1:
+        return None
+    call = calls[0]
+    if call.name == "delegate":
+        if call.args["specialist"] not in SPECIALIST_ROSTER:
+            return None
+    return Decision.from_tool_call(call)
+```
+
+### 30.4 Observation loop
+
+```python
+async def _observe(self_id, decision, outcome, budget, timeout):
+    prompt = _render_observation_prompt(decision, outcome)
+    result = await llm.complete(prompt, max_tokens=budget, timeout=timeout,
+                                tools=_OBSERVATION_TOOLS)
+    # _OBSERVATION_TOOLS ⊂ SELF_TOOL_REGISTRY — a read+write subset:
+    #   apply_event_nudge, write_self_todo, complete_self_todo,
+    #   note_passion, note_hobby, note_skill, note_preference,
+    #   record_personality_claim, mint_affirmation, mint_regret, mint_lesson
+    for call in result.tool_calls:
+        _invoke_self_tool(self_id, call)
+```
+
+### 30.5 Decision tools (stub)
+
+```python
+@dataclass
+class DelegateArgs:
+    specialist: str             # "ranger", "artificer", "scribe", …
+    task_spec: dict             # payload for specialist.handle()
+
+
+DECISION_TOOL_SCHEMAS = {
+    "reply_directly": {
+        "description": "I reply to the user directly without invoking a specialist.",
+        "params": {"content": str},
+    },
+    "delegate": {
+        "description": "I delegate to a specialist in my roster.",
+        "params": {"specialist": str, "task_spec": dict},
+    },
+    "ask_clarifying": {
+        "description": "I ask the user a clarifying question before deciding.",
+        "params": {"question": str},
+    },
+    "decline": {
+        "description": "I decline to route this request and explain why.",
+        "params": {"reason": str},
+    },
+}
+```
+
+### 30.6 Concurrency
+
+Per `SELF_ID`, perception is serialized by an advisory lock to preserve episodic ordering. Two concurrent requests see the first's decision memory (already written) but serialize on their own perception-LLM calls. Under high concurrency, this is a visible bottleneck — a Phase-2 design question is whether multiple in-flight perceptions can proceed in parallel while sharing a point-in-time self-snapshot.
+
+## Open questions
+
+- **Q30.1.** Serializing perception is strong consistency for the self's self-knowledge but limits throughput. Alternative: a per-request *view* of the self materialized at perception start, with observation steps applying updates optimistically. Deferred.
+- **Q30.2.** The `decline` decision doesn't automatically mint a REGRET. That's deliberate — declining is a legitimate choice. But there's no mechanism for the self to later review whether a decline was right. A weekly review pass (aligned with the retest cadence?) could re-read recent declines and mint REGRET/AFFIRMATION accordingly. Deferred.
+- **Q30.3.** Cross-tenant self-memory (AC-30.22) is the load-bearing research-branch assumption. If findings land in `main`, it must be rebuilt as per-tenant selves, and cross-tenant WISDOM reconciliation becomes a separate problem (mentioned in DESIGN.md §6.5 and §4.2).
+- **Q30.4.** Mood nudges happen in the observation loop. If the LLM's observation call times out, the nudge is skipped. A small deterministic fallback (e.g., error outcome → auto `valence -0.1`) would guarantee mood tracks reality even on observation failure. Tempting but adds non-self authored mutations. Deferred.
+- **Q30.5.** `ask_clarifying` returns immediately without the self observing a success/failure. The clarification is a *pending* routing state. Phase-2 could thread the follow-up back to the original routing episode so the self's memory holds "I asked about X, then routed to Y after the user clarified." Deferred.

--- a/research/project-turing/specs/self-bootstrap.md
+++ b/research/project-turing/specs/self-bootstrap.md
@@ -1,0 +1,204 @@
+# Spec 29 — Self-bootstrap
+
+*The one-shot procedure that mints a self: random HEXACO profile, 200 Likert answers with justifications, 24 facet rows, neutral mood, everything else empty. Idempotent per `self_id`. Ships as `stronghold bootstrap-self`.*
+
+**Depends on:** [self-schema.md](./self-schema.md), [personality.md](./personality.md), [self-nodes.md](./self-nodes.md), [mood.md](./mood.md), [persistence.md](./persistence.md).
+**Depended on by:** [self-surface.md](./self-surface.md), [self-as-conduit.md](./self-as-conduit.md).
+
+---
+
+## Current state
+
+- `self_id` minting (spec 8) exists but is not populated with a self-model. A bootstrap self has an `agent_id` and nothing else.
+
+## Target
+
+A CLI-triggered procedure that takes a fresh `self_id` to a state where `recall_self()` succeeds: the 24 HEXACO facets populated, the 200-item HEXACO bank loaded (once per deployment, shared across selves), 200 answer rows minted, mood neutral, all other node kinds empty. Running bootstrap twice for the same `self_id` raises.
+
+## Acceptance criteria
+
+### Invocation
+
+- **AC-29.1.** `stronghold bootstrap-self --self-id <ID>` is registered as a CLI entry point. `--self-id` is required. An absent value raises with a clear usage message. Test via invoking the CLI under a subprocess-harness or its `main()` function directly.
+- **AC-29.2.** Optional flags:
+  - `--seed <INT>`: RNG seed for deterministic HEXACO draw (default: random).
+  - `--llm-model <NAME>`: override the LLM pool used for the 200 Likert answer generations (default: cheapest available).
+  - `--dry-run`: run the full procedure without writing. Report what would be written.
+  - `--resume`: continue a partially-bootstrapped self from its last checkpoint (see AC-29.12).
+
+  Test each flag's effect.
+- **AC-29.3.** The CLI exits with code 0 on success, 1 on validation failure (already bootstrapped, invalid self_id shape), 2 on runtime failure (LLM error, DB error). Test each exit code.
+
+### Pre-flight validation
+
+- **AC-29.4.** Before any writes, the bootstrap checks: `self_id` exists in the identity table (spec 8); `self_id` has zero rows in `self_personality_facets`; zero rows in `self_personality_answers`; no `self_mood` row. Any pre-existing state raises `AlreadyBootstrapped`. Test.
+- **AC-29.5.** Pre-flight checks are bundled into a single read transaction. Test.
+
+### HEXACO-200 bank load (once per deployment)
+
+- **AC-29.6.** If `self_personality_items` has zero rows at bootstrap start, the bank is loaded from `research/project-turing/config/hexaco_200.yaml`. If the file is absent, raise `HexacoBankMissing`. If the file loads 199 or 201 rows, raise `HexacoBankInvalid`. Test.
+- **AC-29.7.** If the bank already has 200 rows, skip load (bank is shared across selves). Test.
+- **AC-29.8.** The bank YAML schema is a list of `{item_number, prompt_text, keyed_facet, reverse_scored}`. Unknown keys raise at parse time. Test against a malformed fixture.
+
+### Facet draw
+
+- **AC-29.9.** Draw 24 facet scores per `draw_bootstrap_profile` (spec 23 §23.2). Write 24 `PersonalityFacet` rows in a single transaction. Abort if any constraint fails (e.g., duplicate `(trait, facet_id)`). Test for atomicity: a rigged failure on the 20th row leaves zero facet rows.
+- **AC-29.10.** When `--seed` is provided, the 24 scores are reproducible across runs. Test asserts identical output for identical seeds.
+
+### 200-item Likert generation
+
+- **AC-29.11.** For each of 200 items, invoke the configured LLM with a prompt that includes the full 24-facet profile and the item's `prompt_text`. Require the LLM to return `{"answer": int in {1..5}, "justification": str of length ≤ 200}`. Retry up to 3 times per item on parse or range failure. On 4th failure, abort the whole bootstrap. Test with a flaky fake LLM.
+- **AC-29.12.** After each successful item answer, write the `PersonalityAnswer` row AND the mirrored OBSERVATION memory, AND record a `bootstrap_progress` row keyed to `self_id` with the last completed item number. Test asserts the progress row updates monotonically.
+- **AC-29.13.** On `--resume`, the bootstrap reads `bootstrap_progress` and continues from the next uncompleted item. Tests: a run aborted at item 87, then resumed, produces 200 total answers. Test with simulated mid-run crash.
+- **AC-29.14.** The 200 answers are NOT generated in parallel by default — they are serial to respect LLM rate limits on a single pool. A `--concurrency <N>` flag allows up to N=4 parallel answer calls. Test serial mode and N=4 mode produce identical answer counts.
+
+### Finalization
+
+- **AC-29.15.** After all 200 answers are persisted, insert the singleton `self_mood` row at `(valence=0.0, arousal=0.3, focus=0.5, last_tick_at=now())`. Test.
+- **AC-29.16.** Register the weekly retest Reactor trigger with `first_fire_at = now() + timedelta(days=7)`. Test by inspecting the Reactor's trigger list.
+- **AC-29.17.** Write a LESSON-tier episodic memory marking the completion: `content = "I was bootstrapped on {date} with seed {seed}. I have no passions, hobbies, skills, or preferences yet."`, `source = I_DID`, `intent_at_time = "self bootstrap complete"`. Test.
+- **AC-29.18.** Delete the `bootstrap_progress` row for this `self_id`. Test.
+- **AC-29.19.** A final verification pass asserts: exactly 24 facet rows; exactly 200 answer rows; exactly 1 mood row; zero passion/hobby/interest/preference/skill rows; zero todo rows; trigger registered. If any assertion fails, log an error but do NOT roll back (the partial state is more useful for forensics than a clean slate). Test the verification pass in both success and induced-failure modes.
+
+### Name and operator overrides
+
+- **AC-29.20.** The self has no name post-bootstrap. `recall_self()` returns `self_id` as the identity string. The operator can later set a name via `stronghold self name <NAME>` (out of scope for this spec; reserved).
+- **AC-29.21.** An operator can supply per-facet mean overrides via `--facet-bias <trait.facet>=<mean>` flags. Each override replaces the default `μ=3.0` with the given mean for the truncated-normal draw. Test.
+
+### Edge cases
+
+- **AC-29.22.** A bootstrap interrupted by SIGTERM between items 87 and 88: `bootstrap_progress` is at 87; on resume, item 88 is the next call. Test by sending SIGTERM to a subprocess mid-run.
+- **AC-29.23.** A bootstrap where the LLM returns answers that are all 3 (indifferent) still completes — no semantic check on answer distribution at bootstrap time. The tuning detector will flag the pattern post-hoc. Test.
+- **AC-29.24.** A bootstrap where the LLM returns a malformed JSON on the 200th item retries three times then aborts. The 199 successful answers are preserved. On resume, only item 200 is re-asked. Test.
+- **AC-29.25.** Concurrent `stronghold bootstrap-self --self-id X` invocations: the second acquires the advisory lock on `self:X:bootstrap` and blocks. If the first completes successfully, the second sees `AlreadyBootstrapped` and exits 1. If the first fails mid-way, the second acquires the lock and continues as `--resume`. Test with two subprocesses.
+- **AC-29.26.** `--dry-run` performs facet draw and one LLM-answer-generation as a canary (to validate connectivity), then reports and exits. No DB writes occur. Test.
+
+## Implementation
+
+### 29.1 CLI shape
+
+```python
+# stronghold/cli/bootstrap_self.py
+@click.command()
+@click.option("--self-id", required=True, type=str)
+@click.option("--seed", type=int, default=None)
+@click.option("--llm-model", type=str, default=None)
+@click.option("--dry-run", is_flag=True, default=False)
+@click.option("--resume", is_flag=True, default=False)
+@click.option("--concurrency", type=int, default=1)
+@click.option("--facet-bias", multiple=True,
+              help="e.g. openness.inquisitiveness=4.0")
+def bootstrap_self(self_id, seed, llm_model, dry_run, resume, concurrency, facet_bias):
+    overrides = _parse_biases(facet_bias)
+    try:
+        run_bootstrap(
+            self_id=self_id, seed=seed, llm_model=llm_model,
+            dry_run=dry_run, resume=resume,
+            concurrency=concurrency, facet_biases=overrides,
+        )
+    except AlreadyBootstrapped as e:
+        click.echo(f"already bootstrapped: {e}", err=True)
+        sys.exit(1)
+    except BootstrapValidationError as e:
+        click.echo(f"validation failure: {e}", err=True)
+        sys.exit(1)
+    except BootstrapRuntimeError as e:
+        click.echo(f"runtime failure: {e}", err=True)
+        sys.exit(2)
+```
+
+### 29.2 Top-level flow
+
+```python
+def run_bootstrap(*, self_id, seed, llm_model, dry_run, resume,
+                  concurrency, facet_biases):
+    with repo.advisory_lock(f"self:{self_id}:bootstrap"):
+        if not resume:
+            _preflight_validate(self_id)
+
+        _ensure_bank_loaded()
+
+        if dry_run:
+            _dry_run_canary(self_id, seed, llm_model, facet_biases)
+            return
+
+        if resume:
+            progress = repo.get_bootstrap_progress(self_id)
+            if progress is None:
+                raise BootstrapValidationError("nothing to resume")
+        else:
+            progress = repo.start_bootstrap_progress(self_id, seed=seed)
+            _draw_and_persist_facets(self_id, seed, facet_biases)
+
+        _generate_likert_answers(
+            self_id=self_id,
+            progress=progress,
+            llm_model=llm_model,
+            concurrency=concurrency,
+        )
+
+        _finalize(self_id, seed=seed)
+```
+
+### 29.3 Resume resilience
+
+Each successful item write is one atomic `BEGIN; INSERT answer; INSERT memory; UPDATE progress; COMMIT;` transaction. Crash between items → at most one item's worth of partial work, and the progress row guarantees `--resume` picks up exactly where the crash occurred.
+
+### 29.4 Finalize
+
+```python
+def _finalize(self_id, seed):
+    now = datetime.now(UTC)
+    repo.insert_mood(Mood(
+        self_id=self_id,
+        valence=0.0, arousal=0.3, focus=0.5,
+        last_tick_at=now,
+    ))
+    reactor.register_interval_trigger(
+        name=f"retest:{self_id}",
+        interval=timedelta(days=7),
+        first_fire_at=now + timedelta(days=7),
+        handler=lambda: run_personality_retest(self_id, now=datetime.now(UTC)),
+    )
+    memories.write_lesson(
+        self_id=self_id,
+        content=(
+            f"I was bootstrapped on {now.date().isoformat()} with seed {seed}. "
+            "I have no passions, hobbies, skills, or preferences yet."
+        ),
+        source=SourceKind.I_DID,
+        intent_at_time="self bootstrap complete",
+    )
+    repo.delete_bootstrap_progress(self_id)
+    _verify_final_state(self_id)
+```
+
+### 29.5 Verify
+
+```python
+def _verify_final_state(self_id):
+    problems = []
+    if repo.count_facets(self_id) != 24:
+        problems.append("facet count")
+    if repo.count_answers(self_id) != 200:
+        problems.append("answer count")
+    if not repo.has_mood(self_id):
+        problems.append("missing mood")
+    for kind in ("passion", "hobby", "interest", "preference", "skill", "todo"):
+        if repo.count(kind, self_id) != 0:
+            problems.append(f"non-empty {kind}")
+    if not reactor.has_trigger(f"retest:{self_id}"):
+        problems.append("retest trigger not registered")
+    if problems:
+        log.error("bootstrap final-state problems: %s", problems)
+```
+
+Logs the problems but does not roll back. Operator decides whether to reset via a separate `stronghold self reset` (not specced here).
+
+## Open questions
+
+- **Q29.1.** HEXACO-200 bank file path is hardcoded to `research/project-turing/config/hexaco_200.yaml`. An alternative is a `--bank-file` flag. Keeping hardcoded for the research branch.
+- **Q29.2.** Licensing of the HEXACO-200 item text. The HEXACO-PI-R is available for non-commercial research use under the author's license (Lee & Ashton). The research branch treats this as acceptable for its research status; commercial deployments would need to address licensing separately.
+- **Q29.3.** `--concurrency > 1` violates "serial by default for rate limits." The cap at 4 is a seed; actual safe parallelism depends on the LLM pool's RPM.
+- **Q29.4.** `_dry_run_canary` makes one real LLM call. An alternative is to skip the LLM call entirely and only validate the schema / connectivity. The canary call catches prompt/format issues the schema alone doesn't.
+- **Q29.5.** No operator review gate after bootstrap. The self enters service immediately with a random personality. A `--approval-required` flag that pauses after the LESSON memory is written and waits for an operator ACK would be a mild safety valve. Deferred.

--- a/research/project-turing/specs/self-nodes.md
+++ b/research/project-turing/specs/self-nodes.md
@@ -1,0 +1,154 @@
+# Spec 24 — Self-nodes: passions, hobbies, interests, preferences, skills
+
+*The non-personality attributes that accrete from lived experience. Four "what I care about / engage with" kinds (passion, hobby, interest, preference) and one time-dynamic kind (skill).*
+
+**Depends on:** [self-schema.md](./self-schema.md).
+**Depended on by:** [activation-graph.md](./activation-graph.md), [self-surface.md](./self-surface.md), [self-as-conduit.md](./self-as-conduit.md).
+
+---
+
+## Current state
+
+- Nothing in `main` or on Turing models the self's durable attitudes. Specialist agents may have seed RULES.md files, but there is no persisted, self-owned "what I care about" layer.
+
+## Target
+
+Five node kinds that share a common pattern (self-authored through reflection, stored durably, read into the activation graph) but differ in shape:
+
+| Kind | What it is | Stance vs. activity | Has strength? | Has level? | Has time-dynamic? |
+|------|------------|---------------------|---------------|------------|-------------------|
+| Passion | A stance about what I care about | Stance | ✓ | — | — |
+| Hobby | An activity I engage in | Activity | — | — | `last_engaged_at` only |
+| Interest | A topical pull without commitment to practice | Neither | — | — | `last_noticed_at` only |
+| Preference | A concrete like/dislike/favorite/avoid | — | ✓ | — | — |
+| Skill | Something I can do; decays with time | Activity | — | ✓ | Decay function |
+
+The four non-skill kinds initialize **empty at bootstrap** (per DESIGN.md and [autonoetic-self.md §3.1](../autonoetic-self.md#31-bootstrap)) and accrete via the self's `note_*` tools during reflection. Skills also initialize empty.
+
+## Acceptance criteria
+
+### Creation invariants
+
+- **AC-24.1.** `note_passion(text, strength)` inserts a `Passion` row with `strength ∈ [0.0, 1.0]`, auto-assigned `rank = max(existing_ranks) + 1`, `first_noticed_at = now()`. Out-of-range strength raises. Duplicate text (case-insensitive, whitespace-normalized) raises with a suggestion to use `revise_passion`. Test.
+- **AC-24.2.** `note_hobby(name, description)` inserts a `Hobby` with `last_engaged_at = None`. Duplicate name (case-insensitive) raises. Test.
+- **AC-24.3.** `note_interest(topic, description)` inserts an `Interest` with `last_noticed_at = None`. Duplicate topic (case-insensitive) raises. Test.
+- **AC-24.4.** `note_preference(kind, target, strength, rationale)` inserts a `Preference`. `(self_id, kind, target)` must be unique; collision raises. Test.
+- **AC-24.5.** `note_skill(name, level, kind, decay_rate_per_day=None)` inserts a `Skill` with `stored_level=level`, `last_practiced_at=now()`. If `decay_rate_per_day` is omitted, it defaults per `kind`:
+  - `intellectual`: 0.0005/day
+  - `physical`: 0.005/day
+  - `habit`: 0.002/day
+  - `social`: 0.001/day
+
+  Out-of-range level raises. Test for each default.
+
+### Mutation invariants
+
+- **AC-24.6.** Passion rank is re-orderable via `rerank_passions(self_id, ordered_ids)`. The call is atomic: either all ranks update or none. A list missing any current passion raises. A list containing a non-existent passion raises. Test.
+- **AC-24.7.** `strength` on passions/preferences is mutable via `revise_passion(id, strength=...)` / `revise_preference(id, strength=...)`. Setting `strength = 0.0` is equivalent to soft-archiving — the row remains queryable but does not contribute to the activation graph. Test.
+- **AC-24.8.** `last_engaged_at` on a hobby is updated only by `note_engagement(hobby_id, notes)`. The notes are also written as an OBSERVATION-tier memory. Test.
+- **AC-24.9.** `last_noticed_at` on an interest is updated by `note_interest_trigger(interest_id, source_memory_id)`. Test.
+- **AC-24.10.** `practice_skill(skill_id, new_level=None, notes="")` updates `stored_level` (if provided; else unchanged) and sets `last_practiced_at = now()`. Writes an OBSERVATION-tier memory with the notes. Test.
+- **AC-24.11.** No node is deletable by the self. Archival is via setting `strength=0` (passions/preferences) or `last_engaged_at=None, description="[archived]"` convention. Operators can hard-delete at the database layer. Test asserts no self-tool deletes.
+
+### Skill decay
+
+- **AC-24.12.** `current_level(skill, at=now())` returns `stored_level × exp(-decay_rate_per_day × days_since_practice)`. `days_since_practice = (at - last_practiced_at).total_seconds() / 86400`. Test at known inputs (e.g., `level=1.0, rate=0.005, 30 days → ≈0.861`).
+- **AC-24.13.** `current_level` is clamped to `[0.0, 1.0]`. A skill that would compute below 0.0 (impossible under the formula, but guard anyway) clamps to 0.0. Test.
+- **AC-24.14.** `current_level` is a pure function of stored fields — no DB write, no mutation. Test asserts no persistence side effects.
+- **AC-24.15.** `practice_skill` resets `last_practiced_at` and may raise `stored_level` (to recognize improvement through practice) but never lowers it. An attempt to lower `stored_level` via `practice_skill` raises. A separate `downgrade_skill(id, new_level, reason)` exists for explicit downgrade and writes a LESSON-tier memory. Test.
+- **AC-24.16.** Skill decay is applied only on read. A scheduled decay job does not exist. Test confirms no such job runs (by checking the Reactor's registered triggers).
+
+### Graph integration
+
+- **AC-24.17.** Every note_* insertion optionally takes `contributes_to: list[(target_node_id, weight)]` so the self can, in one tool call, create the node AND wire it into the activation graph. Weights follow the contributor rules (spec 25). Test.
+- **AC-24.18.** Reciprocal contributions (e.g., the new hobby contributing to a facet and the facet contributing to the hobby) require **two** calls, or the convenience `wire_reciprocal(node_a, node_b, a_to_b_weight, b_to_a_weight)` helper. There is no implicit bidirectional wiring. Test.
+
+### Edge cases
+
+- **AC-24.19.** A passion whose `text` is a near-duplicate of an existing one ("I love art" vs. "I care about art") is accepted — exact-match duplicate detection only. The tuning detector (spec 11) flags suspiciously similar passions for potential merge. Test.
+- **AC-24.20.** A skill with an unrecognized `kind` not in `SkillKind` raises at construction (enum validation). Test.
+- **AC-24.21.** `practice_skill` on a skill that hasn't decayed below `stored_level` still updates `last_practiced_at`. This is intentional — practice is recorded regardless of whether the stored level would drop today. Test.
+- **AC-24.22.** Passion rank uniqueness survives reordering, deletion-through-archive, and concurrent `rerank` calls by holding an advisory lock on `self_id` during rerank. Test with simulated concurrent reranks.
+
+## Implementation
+
+### 24.1 Default decay rates
+
+```python
+DEFAULT_DECAY_RATES: dict[SkillKind, float] = {
+    SkillKind.INTELLECTUAL: 0.0005,
+    SkillKind.PHYSICAL:     0.005,
+    SkillKind.HABIT:        0.002,
+    SkillKind.SOCIAL:       0.001,
+}
+```
+
+Rationale: physical skills lose the most per idle day (muscle memory), intellectual skills the least (once learned, retrieval stays plausible), habits and social calibration sit between.
+
+### 24.2 Skill decay read-path
+
+```python
+import math
+
+def current_level(skill: Skill, at: datetime) -> float:
+    days = max(0.0, (at - skill.last_practiced_at).total_seconds() / 86400.0)
+    raw = skill.stored_level * math.exp(-skill.decay_rate_per_day * days)
+    return max(0.0, min(1.0, raw))
+```
+
+### 24.3 Tool signatures
+
+```python
+def note_passion(self_id: str, text: str, strength: float,
+                 contributes_to: list[tuple[str, float]] | None = None) -> Passion: ...
+
+def note_hobby(self_id: str, name: str, description: str,
+               contributes_to: list[tuple[str, float]] | None = None) -> Hobby: ...
+
+def note_interest(self_id: str, topic: str, description: str,
+                  contributes_to: list[tuple[str, float]] | None = None) -> Interest: ...
+
+def note_preference(self_id: str, kind: PreferenceKind, target: str,
+                    strength: float, rationale: str,
+                    contributes_to: list[tuple[str, float]] | None = None) -> Preference: ...
+
+def note_skill(self_id: str, name: str, level: float, kind: SkillKind,
+               decay_rate_per_day: float | None = None,
+               contributes_to: list[tuple[str, float]] | None = None) -> Skill: ...
+
+def practice_skill(self_id: str, skill_id: str,
+                   new_level: float | None = None, notes: str = "") -> Skill: ...
+
+def downgrade_skill(self_id: str, skill_id: str,
+                    new_level: float, reason: str) -> Skill: ...
+
+def rerank_passions(self_id: str, ordered_ids: list[str]) -> list[Passion]: ...
+```
+
+All tool entry points validate `self_id` matches the current self and raise on cross-self writes.
+
+### 24.4 Engagement / notice recording
+
+```python
+def note_engagement(self_id: str, hobby_id: str, notes: str) -> None:
+    hobby = repo.get_hobby(self_id, hobby_id)
+    hobby.last_engaged_at = datetime.now(UTC)
+    hobby.updated_at = datetime.now(UTC)
+    repo.update_hobby(hobby)
+    memories.write_observation(
+        self_id=self_id,
+        content=f"[hobby engagement] {hobby.name}: {notes}",
+        intent_at_time="engage hobby",
+        context={"hobby_id": hobby_id},
+    )
+```
+
+Identical shape for `note_interest_trigger`.
+
+## Open questions
+
+- **Q24.1.** Default decay rates are seeds. Per-deployment calibration (spec 11 tuner) can adjust them based on observed patterns (is a `physical` skill actually decaying faster than an `intellectual` one in this self's real usage?).
+- **Q24.2.** Distinction between `interest` and `preference` is sharp in theory (topical pull vs. concrete choice) but may be muddy in LLM-driven authoring. A merge-or-split detector is plausible but deferred.
+- **Q24.3.** `contributes_to` in note_* calls couples node-creation and graph-wiring. An alternative is to always separate them (create node, then wire). Coupling is kept for ergonomics; the self can still do it in two steps.
+- **Q24.4.** Skill `stored_level` can only go up via `practice_skill`. Realistically, a skill can regress from injury, disuse beyond normal decay, or retraining into something incompatible. `downgrade_skill` handles explicit regression, but the gesture requires naming a reason — might push the self toward narrative honesty, might add friction.
+- **Q24.5.** Archival by `strength=0` is a soft delete, which makes querying "my current passions" slightly heavier (filter on `strength > 0`). An explicit `archived: bool` column is clearer but adds another field everywhere. Leaving as `strength=0` convention for now.

--- a/research/project-turing/specs/self-schema.md
+++ b/research/project-turing/specs/self-schema.md
@@ -1,0 +1,339 @@
+# Spec 22 — Self-model schema
+
+*Tables and value types for the durable self-model nodes: personality, passions, hobbies, interests, preferences, skills, todos, mood, and the activation-graph edges that relate them.*
+
+**Depends on:** [schema.md](./schema.md), [tiers.md](./tiers.md).
+**Depended on by:** [personality.md](./personality.md), [self-nodes.md](./self-nodes.md), [activation-graph.md](./activation-graph.md), [self-todos.md](./self-todos.md), [mood.md](./mood.md), [self-surface.md](./self-surface.md), [self-bootstrap.md](./self-bootstrap.md), [self-as-conduit.md](./self-as-conduit.md).
+
+---
+
+## Current state
+
+- `EpisodicMemory` (spec 1) carries the memory layer. No tables exist for persistent self-model nodes — personality, passions, hobbies, interests, preferences, skills, todos, mood.
+- `self_id` is minted (spec 8) but no state is indexed to it beyond memory.
+- The Conduit treats every request as a fresh classification; there is no durable "what I am" it consults.
+
+## Target
+
+Add per-`self_id` tables that hold the self's durable attributes alongside episodic memory. Every row is owned by exactly one `self_id`. The research branch runs with one self, so `self_id` is effectively a constant — but the column is present so the schema can later be read by audits that compare selves across deployments.
+
+Every node kind shares four common fields: `node_id`, `self_id`, `created_at`, `updated_at`. Specific node kinds layer their own fields on top.
+
+## Acceptance criteria
+
+### Node identity and ownership
+
+- **AC-22.1.** Every self-model row has a `node_id` that is unique within its table and a `self_id` that matches the owning self. Inserting a row without `self_id` raises. Test.
+- **AC-22.2.** `NodeKind` is an enum over `{personality_facet, passion, hobby, interest, preference, skill, todo, mood}`. Used as `source_kind` and `target_kind` in the activation graph (spec 25). Test for every enum member.
+- **AC-22.3.** `node_id` values are prefixed by node kind (`facet:honesty_humility.sincerity`, `passion:42`, `skill:python`, ...) so the graph can resolve kind without a join. Regex-based validation test on insert.
+
+### Personality tables
+
+- **AC-22.4.** `self_personality_facets` has exactly 24 rows per `self_id`: one per HEXACO facet. A 25th insert raises. A 23-row state is invalid and fails the bootstrap completion check (spec 29). Test.
+- **AC-22.5.** Each facet row carries `trait_id` ∈ `{honesty_humility, emotionality, extraversion, agreeableness, conscientiousness, openness}`, `facet_id` (the 4-per-trait slug), `score ∈ [1.0, 5.0]`, `last_revised_at`. Out-of-range score raises. Test.
+- **AC-22.6.** `self_personality_items` stores the HEXACO-200 item bank. Static after seed — inserting during normal operation raises. Test that the table has exactly 200 rows after seed.
+- **AC-22.7.** `self_personality_answers` rows carry `item_id`, `revision_id` (nullable for bootstrap answers), `answer_1_5 ∈ {1,2,3,4,5}`, `justification_text`, `asked_at`. Out-of-range answer raises. Test.
+- **AC-22.8.** `self_personality_revisions` rows carry `revision_id`, `ran_at`, `sampled_item_ids: list[str]` (length 20), `deltas_by_facet: dict[facet_id, float]`. An empty sample or a sample of wrong length raises. Test.
+
+### Simple-node tables
+
+- **AC-22.9.** `self_passions` rows: `text`, `strength ∈ [0.0, 1.0]`, `rank ∈ int≥0` (for primacy ordering, unique within `self_id`), `first_noticed_at`. Out-of-range strength raises. Duplicate rank within the same `self_id` raises. Test.
+- **AC-22.10.** `self_hobbies` rows: `name`, `description`, `last_engaged_at` (nullable). No strength field — hobbies don't carry intrinsic weight; their activation is derived from the graph. Test.
+- **AC-22.11.** `self_interests` rows: `topic`, `description`, `last_noticed_at`. No strength field; same rationale as hobbies. Test.
+- **AC-22.12.** `self_preferences` rows: `kind ∈ {like, dislike, favorite, avoid}`, `target: str`, `strength ∈ [0.0, 1.0]`, `rationale`. `(self_id, kind, target)` is unique. Duplicate insert raises. Test.
+
+### Skills
+
+- **AC-22.13.** `self_skills` rows: `name`, `kind ∈ {intellectual, physical, habit, social}`, `stored_level ∈ [0.0, 1.0]`, `decay_rate_per_day > 0.0`, `last_practiced_at`. Out-of-range level raises. Non-positive decay rate raises. Test.
+- **AC-22.14.** `stored_level` is never mutated by decay. Decay is a read-time transformation (spec 24 §4). A write that mutates `stored_level` must set `last_practiced_at = now()` in the same transaction. Test.
+
+### Todos
+
+- **AC-22.15.** `self_todos` rows: `text`, `motivated_by_node_id` (required, foreign-key-like reference into any self-model table), `status ∈ {active, completed, archived}`, `outcome_text` (nullable; required iff status = completed), `created_at`. Insert without `motivated_by_node_id` raises. Marking `completed` without `outcome_text` raises. Test.
+- **AC-22.16.** `self_todo_revisions` rows: `todo_id`, `revision_num` (monotonic per todo), `text_before`, `text_after`, `revised_at`. Append-only — updating or deleting a revision row raises. Test.
+
+### Mood
+
+- **AC-22.17.** `self_mood` has exactly one row per `self_id` at any time (singleton state). A second insert raises; updates mutate the existing row. Test.
+- **AC-22.18.** Mood row carries `valence ∈ [-1.0, 1.0]`, `arousal ∈ [0.0, 1.0]`, `focus ∈ [0.0, 1.0]`, `last_tick_at`. Out-of-range values raise. Test.
+
+### Activation-graph table
+
+- **AC-22.19.** `self_activation_contributors` rows: `target_node_id`, `target_kind: NodeKind`, `source_id` (node_id, memory_id, or rule_id), `source_kind ∈ NodeKind ∪ {memory, rule, retrieval}`, `weight ∈ [-1.0, 1.0]` (negative allowed for inhibitory edges), `origin ∈ {self, rule, retrieval}`, `rationale: str`, `created_at`. Out-of-range weight raises. Test.
+- **AC-22.20.** A contributor where `target_node_id == source_id` raises (no direct self-loops). Test.
+- **AC-22.21.** `origin = retrieval` rows carry an `expires_at` timestamp. All other origins carry `expires_at = NULL` (durable). Test.
+
+### Cross-cutting invariants
+
+- **AC-22.22.** Every table has `created_at` and `updated_at` in UTC. Updates that don't touch `updated_at` raise (enforced by the repo layer). Test.
+- **AC-22.23.** No self-model table is deletable by the LLM. Only the operator can hard-delete a row; the self can only mark `status=archived` on todos or set `strength=0` on passions/preferences. Test.
+
+## Implementation
+
+### 22.1 Enums
+
+```python
+from enum import StrEnum
+
+class Trait(StrEnum):
+    HONESTY_HUMILITY = "honesty_humility"
+    EMOTIONALITY = "emotionality"
+    EXTRAVERSION = "extraversion"
+    AGREEABLENESS = "agreeableness"
+    CONSCIENTIOUSNESS = "conscientiousness"
+    OPENNESS = "openness"
+
+
+class NodeKind(StrEnum):
+    PERSONALITY_FACET = "personality_facet"
+    PASSION = "passion"
+    HOBBY = "hobby"
+    INTEREST = "interest"
+    PREFERENCE = "preference"
+    SKILL = "skill"
+    TODO = "todo"
+    MOOD = "mood"
+
+
+class ContributorOrigin(StrEnum):
+    SELF = "self"           # self-authored via write_contributor tool
+    RULE = "rule"           # always-on default rule
+    RETRIEVAL = "retrieval" # ephemeral per-request semantic match
+
+
+class SkillKind(StrEnum):
+    INTELLECTUAL = "intellectual"
+    PHYSICAL = "physical"
+    HABIT = "habit"
+    SOCIAL = "social"
+
+
+class PreferenceKind(StrEnum):
+    LIKE = "like"
+    DISLIKE = "dislike"
+    FAVORITE = "favorite"
+    AVOID = "avoid"
+
+
+class TodoStatus(StrEnum):
+    ACTIVE = "active"
+    COMPLETED = "completed"
+    ARCHIVED = "archived"
+```
+
+### 22.2 Common base
+
+```python
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+
+
+@dataclass
+class SelfNode:
+    node_id: str
+    self_id: str
+    created_at: datetime = field(default_factory=lambda: datetime.now(UTC))
+    updated_at: datetime = field(default_factory=lambda: datetime.now(UTC))
+```
+
+### 22.3 Personality
+
+```python
+@dataclass
+class PersonalityFacet(SelfNode):
+    trait: Trait
+    facet_id: str                     # e.g. "sincerity", "fairness", …
+    score: float                      # [1.0, 5.0]
+    last_revised_at: datetime
+
+    def __post_init__(self) -> None:
+        if not 1.0 <= self.score <= 5.0:
+            raise ValueError(f"facet score out of range: {self.score}")
+
+
+@dataclass
+class PersonalityItem(SelfNode):
+    item_number: int                  # 1..200
+    prompt_text: str
+    keyed_facet: str
+    reverse_scored: bool
+
+
+@dataclass
+class PersonalityAnswer(SelfNode):
+    item_id: str
+    revision_id: str | None           # None for bootstrap answers
+    answer_1_5: int
+    justification_text: str
+    asked_at: datetime
+
+    def __post_init__(self) -> None:
+        if self.answer_1_5 not in (1, 2, 3, 4, 5):
+            raise ValueError("answer must be 1..5")
+
+
+@dataclass
+class PersonalityRevision(SelfNode):
+    revision_id: str
+    ran_at: datetime
+    sampled_item_ids: list[str]       # length exactly 20
+    deltas_by_facet: dict[str, float]
+
+    def __post_init__(self) -> None:
+        if len(self.sampled_item_ids) != 20:
+            raise ValueError("retest sample must be exactly 20 items")
+```
+
+### 22.4 Simple nodes
+
+```python
+@dataclass
+class Passion(SelfNode):
+    text: str
+    strength: float                   # [0.0, 1.0]
+    rank: int                         # unique per self_id
+    first_noticed_at: datetime
+
+
+@dataclass
+class Hobby(SelfNode):
+    name: str
+    description: str
+    last_engaged_at: datetime | None = None
+
+
+@dataclass
+class Interest(SelfNode):
+    topic: str
+    description: str
+    last_noticed_at: datetime | None = None
+
+
+@dataclass
+class Preference(SelfNode):
+    kind: PreferenceKind
+    target: str
+    strength: float                   # [0.0, 1.0]
+    rationale: str
+```
+
+### 22.5 Skills
+
+```python
+@dataclass
+class Skill(SelfNode):
+    name: str
+    kind: SkillKind
+    stored_level: float               # [0.0, 1.0]; never decayed on disk
+    decay_rate_per_day: float         # > 0.0
+    last_practiced_at: datetime
+```
+
+### 22.6 Todos
+
+```python
+@dataclass
+class SelfTodo(SelfNode):
+    text: str
+    motivated_by_node_id: str         # required
+    status: TodoStatus = TodoStatus.ACTIVE
+    outcome_text: str | None = None
+
+
+@dataclass
+class SelfTodoRevision(SelfNode):
+    todo_id: str
+    revision_num: int
+    text_before: str
+    text_after: str
+    revised_at: datetime
+```
+
+### 22.7 Mood
+
+```python
+@dataclass
+class Mood(SelfNode):
+    valence: float                    # [-1.0, 1.0]
+    arousal: float                    # [0.0, 1.0]
+    focus: float                      # [0.0, 1.0]
+    last_tick_at: datetime
+```
+
+### 22.8 Activation graph
+
+```python
+@dataclass
+class ActivationContributor(SelfNode):
+    target_node_id: str
+    target_kind: NodeKind
+    source_id: str
+    source_kind: str                  # NodeKind ∪ {"memory", "rule", "retrieval"}
+    weight: float                     # [-1.0, 1.0]
+    origin: ContributorOrigin
+    rationale: str
+    expires_at: datetime | None = None
+
+    def __post_init__(self) -> None:
+        if self.target_node_id == self.source_id:
+            raise ValueError("contributor cannot target itself")
+        if not -1.0 <= self.weight <= 1.0:
+            raise ValueError("contributor weight out of range")
+        if (self.origin == ContributorOrigin.RETRIEVAL) != (self.expires_at is not None):
+            raise ValueError("retrieval contributors must set expires_at; others must not")
+```
+
+### 22.9 Schema SQL sketch
+
+```sql
+-- All tables are CREATE TABLE IF NOT EXISTS. self_id is a foreign key
+-- into the identity table minted in spec 8.
+
+CREATE TABLE self_personality_facets (
+    node_id          TEXT PRIMARY KEY,
+    self_id          TEXT NOT NULL,
+    trait            TEXT NOT NULL,
+    facet_id         TEXT NOT NULL,
+    score            REAL NOT NULL CHECK (score >= 1.0 AND score <= 5.0),
+    last_revised_at  TIMESTAMPTZ NOT NULL,
+    created_at       TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at       TIMESTAMPTZ NOT NULL DEFAULT now(),
+    UNIQUE (self_id, trait, facet_id)
+);
+
+-- Analogous tables for: self_personality_items, self_personality_answers,
+-- self_personality_revisions, self_passions, self_hobbies, self_interests,
+-- self_preferences, self_skills, self_todos, self_todo_revisions, self_mood,
+-- self_activation_contributors.
+
+CREATE TABLE self_mood (
+    self_id          TEXT PRIMARY KEY,
+    valence          REAL NOT NULL CHECK (valence >= -1.0 AND valence <= 1.0),
+    arousal          REAL NOT NULL CHECK (arousal >= 0.0 AND arousal <= 1.0),
+    focus            REAL NOT NULL CHECK (focus >= 0.0 AND focus <= 1.0),
+    last_tick_at     TIMESTAMPTZ NOT NULL,
+    updated_at       TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE TABLE self_activation_contributors (
+    node_id          TEXT PRIMARY KEY,
+    self_id          TEXT NOT NULL,
+    target_node_id   TEXT NOT NULL,
+    target_kind      TEXT NOT NULL,
+    source_id        TEXT NOT NULL,
+    source_kind      TEXT NOT NULL,
+    weight           REAL NOT NULL CHECK (weight >= -1.0 AND weight <= 1.0),
+    origin           TEXT NOT NULL,
+    rationale        TEXT NOT NULL,
+    expires_at       TIMESTAMPTZ,
+    created_at       TIMESTAMPTZ NOT NULL DEFAULT now(),
+    CHECK (target_node_id <> source_id),
+    CHECK ((origin = 'retrieval') = (expires_at IS NOT NULL))
+);
+```
+
+## Open questions
+
+- **Q22.1.** `strength` on passions/preferences is `[0.0, 1.0]` while personality `score` is `[1.0, 5.0]`. Two different scales across self-model nodes is a correctness hazard during graph computation (spec 25). Either normalize on read or standardize at schema time. Leaving them as-is for now because HEXACO's Likert-1-to-5 is a load-bearing property for retest maths; the activation graph normalizes on read.
+- **Q22.2.** `motivated_by_node_id` is stored as a plain string reference. Actual foreign-key constraints are hard when the target can live in eight tables. Enforcement is at the application layer. Consider a polymorphic-association column pair `(target_table, target_id)` instead.
+- **Q22.3.** `self_personality_items` being read-only after seed is an invariant enforced at the application layer. A migration path for a revised HEXACO item bank (new translation, new validated form) isn't defined.

--- a/research/project-turing/specs/self-surface.md
+++ b/research/project-turing/specs/self-surface.md
@@ -1,0 +1,265 @@
+# Spec 28 — Self-surface: tools and prompt surface
+
+*What the self can read, what the self can write, and how much of itself it carries into every prompt. A small always-on block plus a deep `recall_self()` tool for when the self wants the full picture.*
+
+**Depends on:** [self-schema.md](./self-schema.md), [personality.md](./personality.md), [self-nodes.md](./self-nodes.md), [activation-graph.md](./activation-graph.md), [self-todos.md](./self-todos.md), [mood.md](./mood.md).
+**Depended on by:** [self-as-conduit.md](./self-as-conduit.md).
+
+---
+
+## Current state
+
+- Specialist agents consume system prompts (SOUL.md) assembled at request time with memory injections. There is no equivalent "self-surface" for the Conduit — the Conduit doesn't consult a persistent identity.
+
+## Target
+
+Define the full shape of the self-surface: every tool the self has for reading and writing its own state, plus the minimal always-on prompt block and the on-demand deep recall.
+
+## Acceptance criteria
+
+### Tool registry
+
+- **AC-28.1.** The following tools are registered for the self and for the self ONLY (not exposed to downstream specialists):
+  - `recall_self()`
+  - `write_self_todo(text, motivated_by_node_id)`
+  - `revise_self_todo(id, new_text, reason)`
+  - `complete_self_todo(id, outcome_text)`
+  - `archive_self_todo(id, reason)`
+  - `record_personality_claim(facet_id, claim_text, evidence)`
+  - `write_contributor(target, source, weight, rationale)`
+  - `retract_contributor_by_counter(target, source, weight, rationale)`
+  - `note_passion(text, strength, contributes_to=None)`
+  - `note_hobby(name, description, contributes_to=None)`
+  - `note_interest(topic, description, contributes_to=None)`
+  - `note_preference(kind, target, strength, rationale, contributes_to=None)`
+  - `note_skill(name, level, kind, decay_rate_per_day=None, contributes_to=None)`
+  - `practice_skill(skill_id, new_level=None, notes="")`
+  - `downgrade_skill(skill_id, new_level, reason)`
+  - `rerank_passions(ordered_ids)`
+  - `revise_passion(id, strength=None, text=None)`
+  - `revise_preference(id, strength=None, rationale=None)`
+  - `note_engagement(hobby_id, notes)`
+  - `note_interest_trigger(interest_id, source_memory_id)`
+
+  Test: a registry lookup for each name returns a live callable.
+
+- **AC-28.2.** Each tool's OpenAI function schema is generated and exported to `research/project-turing/config/self_tools.json` at startup. Schema declares parameter types, required fields, and descriptions. Test asserts schema presence and validity per [tool-layer.md](./tool-layer.md).
+
+- **AC-28.3.** All self-tools check that the acting `self_id` matches the configured singleton self. A cross-self call raises `CrossSelfForbidden`. Test.
+
+- **AC-28.4.** Every self-tool runs inside a transaction; on failure, the write is rolled back AND no memory is written. Test with a failing sub-step asserts neither row nor memory persists.
+
+### First-person framing
+
+- **AC-28.5.** Tool prompts (the descriptions the LLM sees) are written in the first person from the self's perspective: "I notice a new passion" / "I record a claim about my own trait." Test asserts each description opens with a first-person clause.
+- **AC-28.6.** Any text the self writes through these tools is stored verbatim — no post-hoc rewriting. The first-person framing is enforced by prompt engineering, not by a sanitizer. Test feeds a non-first-person input (`"The self notices X"`) through `note_passion` and asserts it is stored as-is, with a tuning-detector flag raised.
+
+### `recall_self()` output
+
+- **AC-28.7.** `recall_self()` returns a structured view with these top-level keys: `self_id`, `personality`, `passions`, `hobbies`, `interests`, `skills`, `preferences`, `active_todos`, `mood`, `recent_personality_claims`, `recent_completed_todos`. Test asserts every key is populated.
+- **AC-28.8.** `personality` is a list of 24 `{trait, facet, score, active_now}` entries. `score` is the stored value; `active_now` is computed via the activation graph (spec 25). Test.
+- **AC-28.9.** Each node kind's list returns only non-archived entries sorted by `active_now` descending. Test sorting.
+- **AC-28.10.** `mood` returns the full numeric state `(valence, arousal, focus, descriptor)`. Test.
+- **AC-28.11.** `recent_personality_claims` returns up to 10 most recent `OPINION` memories with `intent_at_time = "narrative personality revision"`. Test.
+- **AC-28.12.** `recent_completed_todos` returns up to 10 most recent completed todos with their `outcome_text`. Test.
+- **AC-28.13.** `recall_self()` is read-only. No side effects, no memory writes, no cache invalidations. Test asserts no DB writes occur during call.
+- **AC-28.14.** `recall_self()` total payload is capped at `RECALL_TOKEN_BUDGET` (default 4000 tokens). Over-budget sections are truncated with a `"…truncated…"` marker, preserving the most-`active_now` items. Test with a large fake state.
+
+### Minimal prompt block
+
+- **AC-28.15.** The minimal block is prepended to every request prompt the self sees. It contains exactly four lines:
+  1. `self_id` and trait one-liner
+  2. Current mood descriptor (spec 27 AC-27.12)
+  3. Active-todo list (up to `MINIMAL_TODO_COUNT = 5` most recent, each as `[todo:id] text`)
+  4. Dominant-passion line (top 1 by rank, prefixed `"I care about:"`)
+
+  Example:
+  ```
+  I am self:turing (moderate Openness, high Conscientiousness, low Extraversion).
+  Right now: alert, attentive; focused.
+  My active todos: [todo:42] Re-read Tulving '85; [todo:51] Practice embedding tests.
+  I care about: work that lasts.
+  ```
+
+  Test asserts exactly four lines and that each line is present when the underlying state exists.
+
+- **AC-28.16.** When a line has no content (e.g., no active todos), it is omitted entirely rather than rendered as an empty line. Test at empty state.
+- **AC-28.17.** The trait one-liner is derived from the three facets with the highest `active_now` — chosen by adjective phrasing from a seed lookup. Deterministic given the same `active_now` values. Test.
+- **AC-28.18.** The minimal block's token budget is `MINIMAL_TOKEN_CEILING = 120` tokens. Over-budget triggers truncation of the todo list first, then the passion line. Test with 50 active todos asserts only the top 5 appear.
+- **AC-28.19.** The minimal block is NOT a user-visible surface; it is only in the self's system prompt. Test asserts no request pipeline leaks the block into user-facing output.
+
+### Tool-call reporting back
+
+- **AC-28.20.** After any self-tool call, the updated minimal block is re-computed and made available to the next LLM turn. The self sees the effect of its own writes on the next reflection. Test.
+- **AC-28.21.** A tool call that fails validation returns a structured error with both the failure reason and a hint (e.g., "motivated_by_node_id references an archived passion; consider archiving this todo or choosing a different motivator"). Test for each failure mode.
+
+### Permissions and trust
+
+- **AC-28.22.** Self-tools are trust-tier `t0` (built-in, core trust). Skill Forge cannot create tools at this trust tier. Test.
+- **AC-28.23.** Self-tools are NOT routable — they are not discoverable via `list_tools()` for any specialist agent. Only the self's system runtime has them in its registry. Test.
+- **AC-28.24.** The `write_contributor` tool cannot set `origin = RETRIEVAL` (spec 25 AC-25.13). Attempting raises. Test.
+
+### Edge cases
+
+- **AC-28.25.** A `recall_self()` called mid-bootstrap (before all 24 facets are seeded) raises `SelfNotReady` rather than returning a partial view. Test.
+- **AC-28.26.** A minimal-block render when mood has never been tick-decayed (fresh bootstrap, zero time elapsed) still renders the correct neutral descriptor. Test.
+- **AC-28.27.** If `list_active_todos` returns zero, the todo line is omitted. If all four lines are omitted (truly fresh self with no todos and no passions), the minimal block reduces to just the `self_id`/trait one-liner. Test.
+- **AC-28.28.** A tool description longer than `TOOL_DESCRIPTION_MAX = 400` chars at registration time raises (keeps prompts compact). Test.
+
+## Implementation
+
+### 28.1 Constants
+
+```python
+RECALL_TOKEN_BUDGET:       int = 4000
+MINIMAL_TODO_COUNT:        int = 5
+MINIMAL_TOKEN_CEILING:     int = 120
+TOOL_DESCRIPTION_MAX:      int = 400
+```
+
+### 28.2 Registry shape
+
+```python
+@dataclass(frozen=True)
+class SelfTool:
+    name: str
+    description: str
+    schema: dict                      # OpenAI function schema
+    handler: Callable
+    trust_tier: str = "t0"
+
+
+SELF_TOOL_REGISTRY: dict[str, SelfTool] = {}
+
+
+def register_self_tool(tool: SelfTool) -> None:
+    if len(tool.description) > TOOL_DESCRIPTION_MAX:
+        raise ValueError(f"tool description too long: {tool.name}")
+    SELF_TOOL_REGISTRY[tool.name] = tool
+```
+
+### 28.3 `recall_self()` skeleton
+
+```python
+def recall_self(self_id: str) -> dict:
+    if not _bootstrap_complete(self_id):
+        raise SelfNotReady(self_id)
+
+    ctx = activation_context(self_id, now=datetime.now(UTC))
+
+    personality = [
+        {
+            "trait": f.trait,
+            "facet": f.facet_id,
+            "score": f.score,
+            "active_now": active_now(repo, f.node_id, ctx),
+        }
+        for f in repo.list_facets(self_id)
+    ]
+
+    passions    = _sorted_nodes(repo.list_passions(self_id),   ctx)
+    hobbies     = _sorted_nodes(repo.list_hobbies(self_id),    ctx)
+    interests   = _sorted_nodes(repo.list_interests(self_id),  ctx)
+    skills      = _sorted_skills(repo.list_skills(self_id),    ctx.now)
+    preferences = _sorted_nodes(repo.list_preferences(self_id),ctx)
+    active_todos = repo.list_active_todos(self_id)
+
+    mood = repo.get_mood(self_id)
+    mood_view = {
+        "valence": mood.valence,
+        "arousal": mood.arousal,
+        "focus":   mood.focus,
+        "descriptor": mood_descriptor(mood),
+    }
+
+    payload = {
+        "self_id":                  self_id,
+        "personality":              personality,
+        "passions":                 passions,
+        "hobbies":                  hobbies,
+        "interests":                interests,
+        "skills":                   skills,
+        "preferences":              preferences,
+        "active_todos":             [_summarize_todo(t) for t in active_todos],
+        "mood":                     mood_view,
+        "recent_personality_claims": repo.recent_claims(self_id, limit=10),
+        "recent_completed_todos":    repo.recent_completed(self_id, limit=10),
+    }
+    return _truncate_to_budget(payload, RECALL_TOKEN_BUDGET)
+```
+
+### 28.4 Minimal block assembly
+
+```python
+def render_minimal_block(self_id: str) -> str:
+    ctx = activation_context(self_id, now=datetime.now(UTC))
+    lines: list[str] = []
+
+    # Line 1: identity + trait one-liner
+    trait_phrase = _trait_phrase_top3(self_id, ctx)
+    lines.append(f"I am {self_id} ({trait_phrase}).")
+
+    # Line 2: mood descriptor
+    mood = repo.get_mood(self_id)
+    lines.append(f"Right now: {mood_descriptor(mood)}.")
+
+    # Line 3: active todos (up to MINIMAL_TODO_COUNT)
+    todos = repo.list_active_todos(self_id)[:MINIMAL_TODO_COUNT]
+    if todos:
+        rendered = "; ".join(f"[todo:{t.node_id}] {t.text}" for t in todos)
+        lines.append(f"My active todos: {rendered}.")
+
+    # Line 4: dominant passion
+    top_passion = repo.top_passion(self_id)
+    if top_passion and top_passion.strength > 0:
+        lines.append(f"I care about: {top_passion.text}.")
+
+    # Budget enforcement
+    block = "\n".join(lines)
+    while _approx_tokens(block) > MINIMAL_TOKEN_CEILING and lines:
+        # Drop the todo list first, then the passion line
+        if any(l.startswith("My active todos:") for l in lines):
+            lines = [l for l in lines if not l.startswith("My active todos:")]
+        elif any(l.startswith("I care about:") for l in lines):
+            lines = [l for l in lines if not l.startswith("I care about:")]
+        else:
+            break
+        block = "\n".join(lines)
+    return block
+```
+
+### 28.5 Trait one-liner
+
+```python
+_TRAIT_ADJECTIVES: dict[str, tuple[str, str]] = {
+    # facet → (high-adjective, low-adjective)
+    "sincerity":           ("sincere",      "strategic"),
+    "fairness":            ("fair-minded",  "opportunistic"),
+    "inquisitiveness":     ("inquisitive",  "disinterested"),
+    "creativity":          ("creative",     "conventional"),
+    "organization":        ("organized",    "loose"),
+    "diligence":           ("diligent",     "easygoing"),
+    # … full table of 24 entries lives in code
+}
+
+
+def _trait_phrase_top3(self_id, ctx) -> str:
+    facets = sorted(
+        repo.list_facets(self_id),
+        key=lambda f: active_now(repo, f.node_id, ctx),
+        reverse=True,
+    )[:3]
+    parts = []
+    for f in facets:
+        high, low = _TRAIT_ADJECTIVES[f.facet_id]
+        parts.append(high if f.score >= 3.0 else low)
+    return ", ".join(parts)
+```
+
+## Open questions
+
+- **Q28.1.** Minimal block is four lines. An alternative is two (identity+mood in one line, todos+passion in another). Four matches the "one idea per line" convention and parses cleanly from an LLM perspective. Test at both shapes is plausible.
+- **Q28.2.** Tool set is wide. An alternative is a meta-tool `self_act(kind, payload)` that dispatches over a typed union. More compact registry; less clear per-action schemas. Kept explicit for readability.
+- **Q28.3.** `write_contributor` gives the self first-class authorship of its ontology. If the self writes contradictory or obviously-bad contributors, there's no guardrail beyond the `counter` mechanism (spec 25). A reviewer detector could flag low-quality contributor writes (self-contributor churn, reciprocal contributors created and retracted in the same session) — deferred.
+- **Q28.4.** `TOOL_DESCRIPTION_MAX = 400` is a seed. Current tool count (20) × 400 = 8000 chars of prompt surface for descriptions alone. If the self carries all descriptions every turn, that's a non-trivial fraction of the context window. Tool descriptions may need compression for scale.
+- **Q28.5.** The minimal block is always rendered, even when the self has not yet accreted passions or todos (a fresh bootstrap). In that state, it reduces to a one-line identity. An alternative is to render no block at all when under-populated, letting the self discover itself through retrieval. The always-on version is simpler and provides a stable "I am" anchor.

--- a/research/project-turing/specs/self-todos.md
+++ b/research/project-turing/specs/self-todos.md
@@ -1,0 +1,190 @@
+# Spec 26 — Self-todos
+
+*The self's own task list. Every todo links to the self-model node that motivates it; revisions are preserved; completions carry an outcome. Active todos surface in every prompt.*
+
+**Depends on:** [self-schema.md](./self-schema.md), [self-nodes.md](./self-nodes.md).
+**Depended on by:** [self-surface.md](./self-surface.md), [self-as-conduit.md](./self-as-conduit.md).
+
+---
+
+## Current state
+
+- `main` has no self-authored task list. Proactive work on Turing is driven by motivation/backlog items (spec 9), but those are dispatcher items — they don't carry first-person intent.
+- The self has no way to say "I want to do X because it serves passion Y" and have that persist across the week.
+
+## Target
+
+A minimal, durable, first-person task list. Every todo has required provenance (which self-node motivates it), is rewriteable with full revision history, and carries a completion outcome when closed. Todos are self-authored only — no one else writes to this table.
+
+## Acceptance criteria
+
+### Creation
+
+- **AC-26.1.** `write_self_todo(text, motivated_by_node_id)` inserts a `SelfTodo` row with `status = ACTIVE`, `created_at = now()`, `outcome_text = None`. Test.
+- **AC-26.2.** `motivated_by_node_id` is required. Insertion without it raises. Test.
+- **AC-26.3.** `motivated_by_node_id` must reference an existing, non-archived self-model node (passion, hobby, interest, preference, skill, personality_facet). Dangling references raise. Test.
+- **AC-26.4.** `text` is capped at 500 characters. Longer text raises with a `TodoTextTooLong` error. Test at 500, 501.
+- **AC-26.5.** There is no limit on active todos per self, but the tuning detector (spec 11) flags when count > `TODO_VOLUME_THRESHOLD` (default 50) as a signal of possible thrashing. Flag-only.
+
+### Revision
+
+- **AC-26.6.** `revise_self_todo(id, new_text, reason)` updates `SelfTodo.text` and inserts a `SelfTodoRevision` row with `text_before`, `text_after`, `revised_at`, `revision_num = current_max + 1`. Test asserts both the mutation and the append-only history.
+- **AC-26.7.** Revising a `completed` or `archived` todo raises. A completed todo is immutable. Test.
+- **AC-26.8.** `revision_num` is monotonic per `todo_id`, starting at 1 on the first revision. A second revision increments. Concurrent revisions are serialized by an advisory lock on `todo_id`. Test.
+- **AC-26.9.** `SelfTodoRevision` rows are never updated or deleted by any self-tool. Any attempted mutation raises `ImmutableRevisionRow`. Test.
+- **AC-26.10.** `motivated_by_node_id` is **not** revisable — if the motivation has changed, the self should archive the todo and write a new one. A `change_motivation(todo_id, new_node_id)` tool does not exist. Test.
+
+### Completion
+
+- **AC-26.11.** `complete_self_todo(id, outcome_text)` sets `status = COMPLETED`, `outcome_text = outcome_text`, `updated_at = now()`. `outcome_text` is required and non-empty. Empty or missing raises. Test.
+- **AC-26.12.** Completion also writes an AFFIRMATION-tier episodic memory (per write-paths.md) with:
+  - `content = f"[todo completed] {text} → {outcome_text}"`
+  - `intent_at_time = "complete self todo"`
+  - `context = {"todo_id": id, "motivated_by": motivated_by_node_id}`
+  - `source = I_DID`
+  Test asserts the memory is written with the right tier and source.
+- **AC-26.13.** Completing an already-completed or archived todo raises `TodoNotActive`. Test.
+- **AC-26.14.** Completion writes a contributor edge from the motivating node back to the completed-todo-memory with `weight = +0.3` (reinforces the motivating node by evidence-of-action). `origin = self`, `rationale = "todo completion"`. Test.
+
+### Archival
+
+- **AC-26.15.** `archive_self_todo(id, reason)` sets `status = ARCHIVED`, `updated_at = now()`. `reason` is stored as an OBSERVATION memory but NOT as `outcome_text` (archived ≠ completed). Test.
+- **AC-26.16.** Archiving an already-completed todo raises. A completed todo stays completed forever. Test.
+- **AC-26.17.** Archived todos are hidden from the minimal prompt block (spec 28) but still retrievable via `recall_self()` with `include_archived=True`. Test.
+
+### Query
+
+- **AC-26.18.** `list_active_todos(self_id)` returns all todos with `status = ACTIVE`, ordered by `created_at` ascending. Test.
+- **AC-26.19.** `list_todos_for_motivator(motivator_node_id, include_archived=False)` returns all todos motivated by that node. Test.
+- **AC-26.20.** `recall_self()` includes the top-N active todos in its structured output (spec 28 AC-28.x). Default N=10.
+
+### Edge cases
+
+- **AC-26.21.** A todo whose motivating node is later archived (passion `strength=0` or similar) stays live but is flagged in `list_active_todos` with a `motivator_state = "archived"` annotation. The self may then archive the todo or revise its motivation (by archiving and re-writing). Test.
+- **AC-26.22.** A concurrent `complete` and `revise` on the same todo is serialized by the advisory lock; whichever wins the lock completes first. If `complete` wins, the subsequent `revise` raises `TodoNotActive`. Test.
+- **AC-26.23.** A todo text containing personally-identifying-information-shaped content (emails, phone numbers) is NOT rejected — the self is allowed to write what it wants about itself. The Warden scans outputs, not the self's internal writes. Documented as intentional.
+- **AC-26.24.** Resurrecting an archived todo requires writing a new todo; there is no `unarchive`. Test asserts no such tool exists.
+
+## Implementation
+
+### 26.1 Tool signatures
+
+```python
+def write_self_todo(
+    self_id: str,
+    text: str,
+    motivated_by_node_id: str,
+) -> SelfTodo: ...
+
+def revise_self_todo(
+    self_id: str,
+    todo_id: str,
+    new_text: str,
+    reason: str,
+) -> SelfTodo: ...
+
+def complete_self_todo(
+    self_id: str,
+    todo_id: str,
+    outcome_text: str,
+) -> SelfTodo: ...
+
+def archive_self_todo(
+    self_id: str,
+    todo_id: str,
+    reason: str,
+) -> SelfTodo: ...
+
+def list_active_todos(self_id: str) -> list[SelfTodo]: ...
+def list_todos_for_motivator(self_id: str, motivator_id: str,
+                              include_archived: bool = False) -> list[SelfTodo]: ...
+```
+
+### 26.2 Revision append
+
+```python
+def revise_self_todo(self_id, todo_id, new_text, reason):
+    with repo.advisory_lock(f"todo:{todo_id}"):
+        todo = repo.get_todo(todo_id)
+        if todo.status != TodoStatus.ACTIVE:
+            raise TodoNotActive(todo_id)
+        if len(new_text) > 500:
+            raise TodoTextTooLong()
+        before = todo.text
+        todo.text = new_text
+        todo.updated_at = now()
+        repo.update_todo(todo)
+        last = repo.max_revision_num(todo_id) or 0
+        repo.insert_todo_revision(SelfTodoRevision(
+            node_id=new_id("rev"),
+            self_id=self_id,
+            todo_id=todo_id,
+            revision_num=last + 1,
+            text_before=before,
+            text_after=new_text,
+            revised_at=now(),
+        ))
+        memories.write_observation(
+            self_id=self_id,
+            content=f"[todo revised] {before} → {new_text} (reason: {reason})",
+            intent_at_time="revise self todo",
+            context={"todo_id": todo_id},
+        )
+        return todo
+```
+
+### 26.3 Completion reinforcement edge
+
+```python
+def complete_self_todo(self_id, todo_id, outcome_text):
+    with repo.advisory_lock(f"todo:{todo_id}"):
+        todo = repo.get_todo(todo_id)
+        if todo.status != TodoStatus.ACTIVE:
+            raise TodoNotActive(todo_id)
+        if not outcome_text.strip():
+            raise ValueError("outcome_text is required on completion")
+        todo.status = TodoStatus.COMPLETED
+        todo.outcome_text = outcome_text
+        todo.updated_at = now()
+        repo.update_todo(todo)
+
+        mem = memories.write_affirmation(
+            self_id=self_id,
+            content=f"[todo completed] {todo.text} → {outcome_text}",
+            intent_at_time="complete self todo",
+            context={"todo_id": todo_id, "motivated_by": todo.motivated_by_node_id},
+        )
+        repo.insert_contributor(ActivationContributor(
+            node_id=new_id("ctr"),
+            self_id=self_id,
+            target_node_id=todo.motivated_by_node_id,
+            target_kind=repo.kind_of(todo.motivated_by_node_id),
+            source_id=mem.memory_id,
+            source_kind="memory",
+            weight=0.3,
+            origin=ContributorOrigin.SELF,
+            rationale="todo completion reinforces motivator",
+        ))
+        return todo
+```
+
+### 26.4 Minimal block placement
+
+Active todos in the minimal prompt block appear as:
+
+```
+Active todos (3):
+ - [todo:42] Re-read Tulving '85 (motivated by passion:3)
+ - [todo:51] Practice embedding-index tests (motivated by skill:embeddings)
+ - [todo:77] Write a note about last week's retest shift (motivated by facet:openness.inquisitiveness)
+```
+
+IDs are included so the self can reference them directly in subsequent tool calls.
+
+## Open questions
+
+- **Q26.1.** `text` cap of 500 is a seed. HEXACO retest justifications are capped at 200 (spec 23), and general memories aren't capped. 500 is a rough "enough to name the task, not enough to encode an essay" target. Tunable.
+- **Q26.2.** Immutable `motivated_by_node_id` forces the self to archive-and-rewrite rather than edit in place. This is slightly more paperwork but makes motivation changes structurally visible in the todo history. Alternative: allow `change_motivation` and log the change as a revision. Deferred.
+- **Q26.3.** Completion → contributor edge at weight `+0.3` is a seed. Tuning detector can adjust whether todo completions meaningfully reinforce their motivators over time. If the coefficient drifts toward zero, the self isn't learning from its own task completions, which is worth flagging.
+- **Q26.4.** Revision history could grow large for todos the self repeatedly rewrites. A compaction pass (keep first, last, and every 10th) is plausible but deferred.
+- **Q26.5.** No `snooze_todo(id, until)` facility is specced here. Motivation-dispatcher (spec 9) already handles "when do I act on this?" via pressure and fit. Adding a self-authored snooze would be parallel machinery; deferred.


### PR DESCRIPTION
Closes the "personality / interests / hobbies / passions / likes-dislikes / favorites / personal skill development" deferred item in `research/project-turing/specs/README.md` by landing Tranche 6 — the durable content of the autonoetic self the Turing Conduit carries.

## What's in it

### Design (2 docs)
- `research/project-turing/autonoetic-self.md` — companion overview to `DESIGN.md`. What the Conduit *is* when it has a self (personality, mood, passions, skills, preferences, todos, activation graph), alongside `DESIGN.md`'s *why*.
- `ARCHITECTURE.md` §2.6 — two-line pointer to the research track.

### Specs (9 new, Tranche 6)
Each follows the house format — Current state → Target → numbered Acceptance criteria grouped by topic → Implementation sketch → Open questions.

| # | Spec | Scope |
|---|---|---|
| 22 | `self-schema.md` | Tables and value types for all self-model nodes. 23 AC, 3 open questions. |
| 23 | `personality.md` | HEXACO-24 profile, random bootstrap draw, 200-item HEXACO-PI-R seed, weekly 20-item re-test weighted by time-since-last-asked, narrative revision via the activation graph (25% calculated move; ≤0.4 narrative cap). 26 AC. |
| 24 | `self-nodes.md` | Passions, hobbies, interests, preferences, skills. Bootstrap-empty, accrete via self-authored `note_*` tools. Per-kind decay rates; `current_level = stored × exp(-rate × days)`. 22 AC. |
| 25 | `activation-graph.md` | Contributor edges (`target, source, weight, origin, rationale`). `active_now = sigmoid(Σ weight × source_state / SCALE)`. Origins: self / rule / retrieval (TTL-bounded). Counter-contributor conflict resolution. 24 AC. |
| 26 | `self-todos.md` | Self-authored todos with required `motivated_by_node_id`. Append-only revision history. Completion mints AFFIRMATION + reinforces motivator via a +0.3 contributor edge. 24 AC. |
| 27 | `mood.md` | `(valence, arousal, focus)` singleton. Hourly compound decay toward neutral; event nudges (tool success/fail, AFFIRMATION/REGRET mints, todo completion, Warden alerts). Phase-1: affects tone only. 19 AC. |
| 28 | `self-surface.md` | Self-tool registry (20 tools), `recall_self()` deep read, 4-line minimal prompt block (identity + mood + active todos + dominant passion). First-person framing throughout. 28 AC. |
| 29 | `self-bootstrap.md` | `stronghold bootstrap-self` CLI. Random HEXACO draw → 200 Likert LLM answers with justifications → 24 facets + 1 mood + empty everything else. Idempotent per `self_id`; resumable from checkpoint. 26 AC. |
| 30 | `self-as-conduit.md` | First-person routing pipeline: Warden → minimal block + retrieval contributors → perception (LLM + optional `recall_self`) → decision (`reply_directly` / `delegate` / `ask_clarifying` / `decline`) → dispatch → observation (self-model updates, mood nudges). Replaces the stateless Conduit for the Turing branch. 29 AC. |

Also updates `specs/README.md` with Tranche 6 index and removes the deferred note; updates `research/project-turing/README.md` reading order.

### Implementation (8 modules + schema)
`research/project-turing/sketches/turing/`:
- `self_model.py` — dataclasses + enums for all node kinds with constructor validation (ranges, enum membership, completed-todo-requires-outcome, retrieval-requires-expiry, no-self-loops).
- `self_repo.py` — SQLite persistence for every self-model table (insert/get/update/list/count helpers).
- `self_mood.py` — compounded decay `1 − (1−DECAY_RATE)^hours`, event-nudge registry, qualitative descriptor lookup over 6 valence×arousal quadrants with focus suffix.
- `self_activation.py` — contributor aggregation, `source_state` resolver per source_kind, sigmoid aggregation, recency helpers, neutral-baseline-when-empty, dangling-source safe.
- `self_personality.py` — truncated-normal bootstrap draw, weighted retest sampling with facet-diversity fallback (>=12 facets), 25% calculated revision, narrative-weight heuristic.
- `self_nodes.py` — `note_*` with duplicate rejection, two-phase rerank to avoid UNIQUE collisions, practice-cannot-lower-stored-level rule.
- `self_todos.py` — write/revise/complete/archive with required motivated_by, append-only revisions, completion-reinforces-motivator +0.3 edge.
- `self_surface.py` — `recall_self` deep view, 4-line minimal prompt block with token-ceiling truncation, trait one-liner from top-3 active facets via 24-entry adjective table.
- `self_bootstrap.py` — preflight → load bank → draw facets → serial 200-answer generation with retry and checkpoint → finalize + neutral mood.

Schema additions in `schema.sql`: 13 tables + append-only trigger on `self_todo_revisions` + DB CHECK constraints (facet score range, mood range, contributor weight range, retrieval↔expiry correlation, no self-loop).

### Tests (161 new, 370 total)
Substantive assertions — not smoke tests:
- Exact arithmetic on `decay_step`, `compute_facet_deltas`, `narrative_weight`, `current_level`.
- SQLite IntegrityError on UNIQUE / CHECK violations (facet uniqueness, passion rank, preference `(kind,target)`, mood singleton, contributor no-self-loop, retrieval expiry correlation).
- All 9 valence×arousal×focus buckets for mood descriptor.
- 10^7-to-1 weight ratio for retest-sample recency domination.
- Bootstrap resume after simulated crash at item 87.
- Activation graph: single-contributor, multi-contributor sum, inhibitory+excitatory, dangling-source safe, retrieval-TTL expiration, retraction, sigmoid saturation.
- Skill decay: exponential formula at known inputs, read-only (no persistence side effects), practice resets decay window.

Full run: **370 passed** (161 new + 209 existing, zero regressions).

## Why `project_Turing` and not `main`

`project_Turing` is the pseudo-main of the research fork. Work flows `feature → research/project-turing → project_Turing → main`. This PR is the first feature slice landing against the new `project_Turing` integration branch; it carries only research-branch content under `research/project-turing/` plus a prominent Project Turing section in the root README (added in `project_Turing`).

Not for `main`. One global self is structurally incompatible with `main`'s multi-tenant posture; DESIGN.md §6.5 spells out why retrofitting shreds cross-context WISDOM or violates tenant isolation.

## Review guidance

Read specs in order; each is self-contained and <300 lines. For code review, schema.sql + self_model.py + self_repo.py cover the data shape; self_activation.py is the most load-bearing computation; self_bootstrap.py is the end-to-end integration point. Tests mirror spec AC numbering (`test_ac_N_M_...`).