### PR TITLE
fix(ci): drift-check — remove error-count tail that flipped step outcome

### DIFF
--- a/.github/workflows/drift-check.yml
+++ b/.github/workflows/drift-check.yml
@@ -37,33 +37,32 @@ jobs:
       - name: Install dependencies
         run: pip install -e ".[dev]"
 
+      # NOTE: each check uses `set -o pipefail` via the default bash runner,
+      # so the pipe to `tee` preserves the tool's exit code. The summary step
+      # reads steps.X.outcome (NOT outputs) to decide drift, so no per-step
+      # error-count output is needed — earlier revisions had a `grep -c ... ||
+      # echo 0` tail that flipped outcome to failure under `set -e` and opened
+      # a spurious drift issue (#1125).
+
       - name: Ruff check (full)
         id: ruff_check
         continue-on-error: true
-        run: |
-          ruff check src/stronghold/ 2>&1 | tee /tmp/ruff-check.txt
-          echo "errors=$(grep -c 'Found [0-9]' /tmp/ruff-check.txt || echo 0)" >> "$GITHUB_OUTPUT"
+        run: ruff check src/stronghold/ 2>&1 | tee /tmp/ruff-check.txt
 
       - name: Ruff format (full)
         id: ruff_format
         continue-on-error: true
-        run: |
-          ruff format --check src/stronghold/ 2>&1 | tee /tmp/ruff-format.txt
-          echo "errors=$(grep -c 'would be reformatted' /tmp/ruff-format.txt || echo 0)" >> "$GITHUB_OUTPUT"
+        run: ruff format --check src/stronghold/ 2>&1 | tee /tmp/ruff-format.txt
 
       - name: Mypy strict (full)
         id: mypy
         continue-on-error: true
-        run: |
-          mypy src/stronghold/ --strict 2>&1 | tee /tmp/mypy.txt
-          echo "errors=$(grep -c 'error:' /tmp/mypy.txt || echo 0)" >> "$GITHUB_OUTPUT"
+        run: mypy src/stronghold/ --strict 2>&1 | tee /tmp/mypy.txt
 
       - name: Bandit (full)
         id: bandit
         continue-on-error: true
-        run: |
-          bandit -r src/stronghold/ -ll --skip B608 2>&1 | tee /tmp/bandit.txt
-          echo "errors=$(grep -c 'Issue:' /tmp/bandit.txt || echo 0)" >> "$GITHUB_OUTPUT"
+        run: bandit -r src/stronghold/ -ll --skip B608 2>&1 | tee /tmp/bandit.txt
 
       - name: Check for drift
         id: summary


### PR DESCRIPTION
The Quality Drift Check opened issue #1125 when the codebase was actually clean — body showed `ruff clean` / `mypy 0 errors` but the workflow flagged drift anyway.

## Root cause

```yaml
run: |
  ruff check src/stronghold/ 2>&1 | tee /tmp/ruff-check.txt
  echo "errors=$(grep -c 'Found [0-9]' /tmp/ruff-check.txt || echo 0)" >> "$GITHUB_OUTPUT"
```

Under the default bash runner's `set -eo pipefail`:
- `grep -c` exits 1 when no matches (i.e. clean output)
- `|| echo 0` fires inside the `$(...)`, but `set -e` still propagates the inner non-zero to the outer script
- result: step `conclusion=success` (thanks to `continue-on-error`), but step **`outcome=failure`**
- the summary step reads `steps.X.outcome`, so it composes a drift-issue body as if every check had failed

## Fix

Error-count outputs aren't consumed anywhere — the summary step only checks outcomes. Drop the tail lines. Each step is now a single-line pipe whose exit code is the tool's.

Closes #1125.