### PR TITLE
fix(ci): Dockerfile — targeted hadolint DL3008 ignore for git install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,10 @@ RUN pip install --no-cache-dir --prefix=/install ".[dev]"
 
 FROM python:3.12-slim
 
-# Mason needs git to create branches, worktrees, commit, push
+# Mason needs git to create branches, worktrees, commit, push.
+# Pinning the Debian-slim git package version would break every time the
+# base image refreshes, so accept the Debian stable floor instead.
+# hadolint ignore=DL3008
 RUN apt-get update && apt-get install -y --no-install-recommends git && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app


### PR DESCRIPTION
Closes #1032.

## Plan
Silence Hadolint DL3008 on the one `apt-get install git` line in `Dockerfile`.

## Spec
**Acceptance:** `hadolint Dockerfile` exits 0 with zero warnings while still installing git in the runtime image.

## Why targeted ignore over the other two options
- **Strict pin** (`git=2.39.x`): noisy — breaks on every `python:3.12-slim` base-image refresh.
- **Global `--ignore DL3008`**: suppresses DL3008 everywhere, including places where pinning IS reasonable (e.g. a future postgresql-client line in ci.yml).
- **Targeted `# hadolint ignore=DL3008`** on this one line, plus a comment that justifies why pinning isn't viable here.

## Test plan
- [x] Before: `hadolint Dockerfile` → exit 1, DL3008 warning on line 16
- [x] After: `hadolint Dockerfile` → exit 0, zero warnings
- [x] Confirmed `Dockerfile` is the only Dockerfile in the repo (`Dockerfile.worker` was retired in #1124)

## Edge cases
- No other Dockerfiles exist → no other places the ignore needs to go.
- CI has no hadolint step yet; this fix makes future CI integration clean out of the gate.
- The comment preceding the ignore documents the rationale so a future reviewer can see why the suppression is safe (and reverse it if we move off Debian slim).