### PR TITLE
fix(helm): vault-deployment guard survives .Values.vault = nil

### DIFF
--- a/deploy/helm/stronghold/templates/vault-deployment.yaml
+++ b/deploy/helm/stronghold/templates/vault-deployment.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.vault.enabled }}
+{{- if (and .Values.vault .Values.vault.enabled) }}
 # OpenBao / HashiCorp Vault deployment in stronghold-system namespace.
 # ADR-K8S-018: per-user credential vault with K8s auth.
 #

--- a/tests/deploy/test_vault_helm.py
+++ b/tests/deploy/test_vault_helm.py
@@ -2,7 +2,11 @@
 
 from __future__ import annotations
 
+import shutil
+import subprocess
 from pathlib import Path
+
+import pytest
 
 
 def test_vault_template_exists() -> None:
@@ -11,9 +15,16 @@ def test_vault_template_exists() -> None:
 
 
 def test_vault_template_conditional() -> None:
-    """Vault template only renders when vault.enabled is true."""
+    """Vault template only renders when vault.enabled is true and guards against
+    a nil `.Values.vault` map (regression: #1033).
+
+    The original guard `{{- if .Values.vault.enabled }}` panicked with
+    'nil pointer evaluating interface {}.enabled' whenever `vault` was missing
+    or set to null in a values file. The `and` guard forces short-circuit on
+    the outer presence check.
+    """
     content = Path("deploy/helm/stronghold/templates/vault-deployment.yaml").read_text()
-    assert "{{- if .Values.vault.enabled }}" in content
+    assert "{{- if (and .Values.vault .Values.vault.enabled) }}" in content
     assert "{{- end }}" in content
 
 
@@ -53,3 +64,44 @@ def test_vault_template_health_probes() -> None:
     assert "readinessProbe" in content
     assert "livenessProbe" in content
     assert "/v1/sys/health" in content
+
+
+# ---------------------------------------------------------------------------
+# Regression: helm template must not panic when .Values.vault is missing /
+# null. Before #1033's fix, `--set vault=null` produced:
+#   nil pointer evaluating interface {}.enabled
+# ---------------------------------------------------------------------------
+
+
+def _helm_template(*extra_args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(  # noqa: S603 — controlled args, not user input
+        ["helm", "template", "deploy/helm/stronghold/", *extra_args],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+@pytest.mark.skipif(shutil.which("helm") is None, reason="helm binary not installed")
+def test_helm_template_default_values_renders() -> None:
+    """Default values.yaml (vault.enabled=false) renders cleanly."""
+    result = _helm_template()
+    assert result.returncode == 0, f"stderr:\n{result.stderr}"
+
+
+@pytest.mark.skipif(shutil.which("helm") is None, reason="helm binary not installed")
+def test_helm_template_vault_null_does_not_panic() -> None:
+    """Regression #1033: passing `--set vault=null` must NOT trigger a nil
+    pointer dereference inside the vault-deployment.yaml guard."""
+    result = _helm_template("--set", "vault=null")
+    assert result.returncode == 0, f"stderr:\n{result.stderr}"
+    assert "nil pointer" not in result.stderr
+
+
+@pytest.mark.skipif(shutil.which("helm") is None, reason="helm binary not installed")
+def test_helm_template_vault_disabled_produces_no_vault_deployment() -> None:
+    """When vault is disabled, no Vault Deployment manifest is rendered."""
+    result = _helm_template()
+    assert result.returncode == 0
+    # The Vault StatefulSet/Deployment name is `vault` in its namespace.
+    assert "name: vault\n  namespace: stronghold-system" not in result.stdout


### PR DESCRIPTION
Closes #1033.

## Bug
`helm template --set vault=null deploy/helm/stronghold/` panicked:
```
Error: template: stronghold/templates/vault-deployment.yaml:1:14: executing "stronghold/templates/vault-deployment.yaml" at <.Values.vault.enabled>: nil pointer evaluating interface {}.enabled
```

The guard `{{- if .Values.vault.enabled }}` dereferences `.vault.enabled` even when `.vault` itself is nil. (`values.yaml` provides a default `vault: enabled: false`, which is why `helm lint` passed with no flags — but the nil-pointer surfaces whenever a values override or `--set` wipes the `vault` map.)

## Fix
```diff
- {{- if .Values.vault.enabled }}
+ {{- if (and .Values.vault .Values.vault.enabled) }}
```
Go template `and` short-circuits on the first falsy argument, so if `.Values.vault` is nil the enabled check never evaluates.

## Tests
- Updated `test_vault_template_conditional` to pin the new guard string.
- Three new subprocess-based tests that actually shell out to `helm template`:
  - default values renders cleanly
  - `--set vault=null` doesn't panic (regression)
  - vault-disabled produces no Vault Deployment manifest
- All gated on `shutil.which('helm')` so they no-op on machines without helm.

## Verified
- `helm lint` clean
- `helm template` with default / null-vault / disabled-vault all exit 0
- 11/11 tests pass
- `ruff` / `ruff format` / `mypy --strict` clean

## Out of scope
`--set vault.enabled=true` surfaces a separate bug (`.Values.vault.image.repository` also dereferences a nil map when the vault image block isn't configured). Leaving that to a follow-up since it's orthogonal to the nil-on-missing-vault fix this ticket tracks.