### PR TITLE
Potential fix for code scanning alert no. 34: Clear-text logging of sensitive information

### DIFF
--- a/src/stronghold/api/routes/webhooks.py
+++ b/src/stronghold/api/routes/webhooks.py
@@ -115,9 +115,7 @@ def _validate_webhook_auth(request: Request, config_secret: str) -> str:
     if expected_org:
         if org_id != expected_org:
             logger.warning(
-                "Webhook org mismatch: header=%r expected=%r (rejecting)",
-                org_id,
-                expected_org,
+                "Webhook org mismatch: header=<redacted> expected=<redacted> (rejecting)"
             )
             raise HTTPException(
                 status_code=403,
@@ -126,9 +124,8 @@ def _validate_webhook_auth(request: Request, config_secret: str) -> str:
     else:
         # No pinned org configured -- log for audit visibility
         logger.warning(
-            "No webhook_org_id configured; accepting X-Webhook-Org=%r at face value. "
-            "Set STRONGHOLD_WEBHOOK_ORG_ID to pin the expected org.",
-            org_id,
+            "No webhook_org_id configured; accepting X-Webhook-Org=<redacted> at face value. "
+            "Set STRONGHOLD_WEBHOOK_ORG_ID to pin the expected org."
         )
 
     return org_id


### PR DESCRIPTION
Potential fix for [https://github.com/Agent-StrongHold/stronghold/security/code-scanning/34](https://github.com/Agent-StrongHold/stronghold/security/code-scanning/34)

To fix this safely without changing behavior, stop logging raw `org_id` and `expected_org` values in webhook auth warnings. Keep the warning event and rejection logic intact, but redact values in logs (or replace with non-sensitive metadata like presence/length). This preserves operational visibility (mismatch happened) without leaking tenant identifiers.

Best targeted change:
- **File**: `src/stronghold/api/routes/webhooks.py`
- **Region**: `_validate_webhook_auth`, warning logs around org mismatch and unpinned org acceptance.
- Replace formatted arguments that print `%r` values with fixed redacted placeholders in the message text.
- No new imports/dependencies needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
