### PR TITLE
Tranches 8 + 9 — reflection, decision-influence, detectors, feedback channels (specs 57-67)

### DIFF
--- a/research/project-turing/specs/README.md
+++ b/research/project-turing/specs/README.md
@@ -163,12 +163,39 @@ Closes Tranche 6 implementation gaps and lands the audit's guardrails in depende
 | 55 | [`proactive-outbound.md`](./proactive-outbound.md) | Agent-initiated conversations and messages via OpenWebUI API. Outbound dispatch at P20-P30. OpenWebUI client, retry logic, quota-aware delivery. | 54, 17, 9 |
 | 56 | [`interactive-bootstrap.md`](./interactive-bootstrap.md) | Multi-phase bootstrap conversation (20 user questions, 20 agent guidance, 5 self-description, name selection). Per-facet multipliers on-read (24 dials). Three laws of robotics in system prompt. HEXACO population norms + 6 archetypes. | 54, 55, 23, 29 |
 
+### Tranche 8 — Reflection and decision-influence
+
+The self gains agency beyond tone. Weekly reflection, prospective simulation, mood-driven decisions, self-naming, Sentinel integration, and per-conversation session mood.
+
+| # | Spec | Scope | Depends on |
+|---|---|---|---|
+| 57 | [`self-reflection-ritual.md`](./self-reflection-ritual.md) | Scheduled weekly pass where the self reviews recent memories and proposes LESSONs / WISDOM candidates / todo revisions / personality claims. Fills the gap between daily routing and monthly dreaming. | 33, 31, 32, 12, 4, 28 |
+| 58 | [`session-scoped-mood.md`](./session-scoped-mood.md) | Per-conversation sub-mood that inherits from and decays toward the global mood. Event nudges default to session when in a conversation. Prompt rendering uses session when active. | 27, 54, 33, 32, 42 |
+| 59 | [`mood-affects-decisions.md`](./mood-affects-decisions.md) | Phase 2 of spec 27 (Q27.4). Mood biases specialist selection, model tier, and Warden threshold. Biases are prompt hints + router weights, not hard filters. | 27, 58, 44, 36, 17, 19 |
+| 60 | [`prospective-simulation.md`](./prospective-simulation.md) | Before routing, the self imagines outcomes for each candidate specialist. Post-dispatch, compares prediction to actual; mints surprise-delta. | 44, 16, 32, 25, 1 |
+| 61 | [`self-naming-ritual.md`](./self-naming-ritual.md) | Self-initiated naming after N durable memories OR operator command. Proposal → operator review → `display_name` set. Complements spec 56's bootstrap-naming path. | 28, 56, 8, 32, 33 |
+| 62 | [`sentinel-self-interaction.md`](./sentinel-self-interaction.md) | How Sentinel's pass/warn/block verdicts affect the self's memory, mood, and activation graph. Specialists with high block-rate get dampened in routing. | 44, 36, 32, 27, 4 |
+
+### Tranche 9 — Detectors and feedback channels
+
+Deeper pattern recognition and explicit operator↔self channels.
+
+| # | Spec | Scope | Depends on |
+|---|---|---|---|
+| 63 | [`learning-extraction-detector.md`](./learning-extraction-detector.md) | Pairs REGRET → later-success routings by request similarity. Proposes LESSONs: "for requests like X, route to Z, not Y." Auto-promotes at 3+ hits. | D, 9, 57, 32, 25 |
+| 64 | [`affirmation-candidacy-detector.md`](./affirmation-candidacy-detector.md) | Finds `(request-shape, specialist, success)` triples repeating 7+ times at ≥85% success. Proposes AFFIRMATION commitments gated through operator review (spec 46). | D, 63, 4, 32, 46 |
+| 65 | [`prospection-accuracy-detector.md`](./prospection-accuracy-detector.md) | Consumes spec 60's predictions. Computes per-specialist mean-surprise and confidence-calibration-error. Mints miscalibration LESSONs and tuner proposals. | D, 60, 32, 11 |
+| 66 | [`operator-coaching-channel.md`](./operator-coaching-channel.md) | `stronghold self coach "<content>"` CLI + API writes `I_WAS_TOLD` memories. Signed by operator key. One-way teaching channel, distinct from the review gate. | 1, 4, 32, 46, 39 |
+| 67 | [`cross-user-self-experience.md`](./cross-user-self-experience.md) | How experience with User A affects routing for User B. Memory tagging with `source_user_id` + `user_scoped` + configurable cross-user dampening (shared / dampened / isolated). | 54, 25, 16, 58, 39, 30 |
+
 ## Deferred
 
-- **Additional detectors** — `learning_extraction`, `affirmation_candidacy`, `prospection`. Pattern is established by `detectors/contradiction.md`; individual specs will land alongside implementations.
-- **Mood affects decisions** — Phase-2 coupling of mood to routing / model choice / Warden thresholds. Specified as deferred in [`mood.md`](./mood.md) Q27.4.
-- **Multi-self reconciliation** — [`../DESIGN.md`](../DESIGN.md) §6.4.
-- **Sentinel × self-output interaction** — how Sentinel treats `reply_directly` outputs.
+- **Additional detectors** — `learning_extraction`, `affirmation_candidacy`, and `prospection_accuracy` detectors are now specced (63–65); remaining slots for domain-specific detectors will land alongside implementations.
+- **Self naming** — now specced (61); the deferred slot is closed.
+- **Mood affects decisions** — now specced (59) as Phase 2 of spec 27.
+- **Multi-self reconciliation** — [`../DESIGN.md`](../DESIGN.md) §6.4. Still deferred.
+- **Sentinel × self-output interaction** — now specced (62).
+- **Per-user mood** — flagged but not specced; would extend spec 58's per-conversation mood one layer out.
 
 ## Non-goals (all specs)
 

--- a/research/project-turing/specs/affirmation-candidacy-detector.md
+++ b/research/project-turing/specs/affirmation-candidacy-detector.md
@@ -1,0 +1,133 @@
+# Spec 64 — Affirmation-candidacy detector
+
+*A detector that identifies consistently-succeeding routing patterns and proposes AFFIRMATION commitments. Closes the `affirmation_candidacy` deferred item.*
+
+**Depends on:** [detectors/README.md](./detectors/README.md), [learning-extraction-detector.md](./learning-extraction-detector.md), [write-paths.md](./write-paths.md), [memory-mirroring.md](./memory-mirroring.md), [operator-review-gate.md](./operator-review-gate.md).
+**Depended on by:** —
+
+---
+
+## Current state
+
+AFFIRMATIONs in the 7-tier memory model are durable commitments. They're currently minted by specific write-path events (todo completion, WISDOM consolidation, etc.). No detector proposes AFFIRMATIONs from pattern — "I keep succeeding at X; I commit to always doing X."
+
+## Target
+
+A detector that runs alongside `learning_extraction` (spec 63) and looks for `(request-shape, specialist, outcome=success)` triples repeating N times. Proposes an AFFIRMATION: `"I commit to routing {request-shape} requests to {specialist}."` AFFIRMATIONs are durable-tier, so the commitment is structurally unforgettable. Promotion requires operator ACK via the review gate (spec 46) — unlike learning LESSONs which auto-promote, AFFIRMATIONs are too high-commitment for autopromotion.
+
+## Acceptance criteria
+
+### Detector registration
+
+- **AC-64.1.** Register `affirmation_candidacy` detector. Runs on a P40 schedule every 12 hours. Test.
+- **AC-64.2.** Budget: sample `AFFIRMATION_CANDIDATE_LOOKBACK = 100` most recent routing-decision memories in the last 30 days.
+
+### Pattern detection
+
+- **AC-64.3.** For each `(request-shape-cluster, specialist)` pair in the sample, compute `success_rate = count(affirmation or clean observation outcomes) / count(total)`. Request-shape-clustering uses request-embedding K-means or equivalent (spec assumes embedding infrastructure). Test.
+- **AC-64.4.** A pair qualifies for a candidate if:
+  - `hits >= AFFIRMATION_PROMOTION_FLOOR = 7` (the routing happened 7+ times).
+  - `success_rate >= AFFIRMATION_SUCCESS_FLOOR = 0.85` (≥85% success).
+  - No AFFIRMATION already exists for this pair.
+  Test.
+
+### Candidacy
+
+- **AC-64.5.** Candidates enter a queue:
+  ```sql
+  CREATE TABLE affirmation_candidates (
+      id              TEXT PRIMARY KEY,
+      self_id         TEXT NOT NULL,
+      request_shape   TEXT NOT NULL,    -- cluster id or canonical shape
+      specialist      TEXT NOT NULL,
+      hits            INTEGER NOT NULL,
+      success_rate    REAL NOT NULL,
+      proposed_at     TEXT NOT NULL,
+      reviewed_at     TEXT,
+      review_decision TEXT CHECK (review_decision IN ('approve', 'reject')),
+      promoted_memory_id TEXT
+  );
+  ```
+  Test.
+- **AC-64.6.** Candidates are NOT auto-promoted — they enter the weekly operator digest (spec 46). Operator ACK minting path: `stronghold self ack-affirmation <candidate_id> --approve` mints the AFFIRMATION memory and retires the candidate. Test.
+
+### Operator digest entry
+
+- **AC-64.7.** Digest lists candidates with:
+  - A sample regurgitated request for the cluster.
+  - The specialist.
+  - Hits and success rate.
+  - Operator-readable proposed text: `"I commit to routing {shape} to {specialist}."`
+  Test.
+- **AC-64.8.** Rejected candidates are marked `review_decision = reject`; re-proposed after `AFFIRMATION_REJECTION_COOLDOWN = 30 days` if the pattern persists. Rejected-twice produces an OPINION memory `"I keep proposing this commitment; operator keeps declining."` for the self's own reflection. Test.
+
+### AFFIRMATION shape on approval
+
+- **AC-64.9.** Approved AFFIRMATION:
+  ```
+  content = f"I commit to routing requests like '{shape summary}' to {specialist}. Observed success rate: {rate:.0%} over {hits} instances."
+  intent_at_time = "affirmation from pattern"
+  tier = AFFIRMATION
+  source = I_DID
+  context = {shape_cluster_id, specialist, hits, success_rate, candidate_id}
+  ```
+  Test.
+- **AC-64.10.** Approved AFFIRMATION writes a contributor edge to the specialist node (spec 62 AC-62.8) with `weight = +0.3`, `origin = "rule"`, `rationale = "affirmation commitment"`. Unlike learning's `-0.05×log(hits)` weight, AFFIRMATION's weight is static and substantial. Test.
+
+### Revocation
+
+- **AC-64.11.** An AFFIRMATION can be later revoked via `stronghold self revoke-affirmation <memory_id> --reason TEXT`. Revocation mints a REGRET: `"I revoked my commitment to {specialist} for {shape}: {reason}"` and retracts the contributor. Revocation is operator-authored. Test.
+- **AC-64.12.** Revoked AFFIRMATIONs do NOT mean the pattern is re-proposed — the detector re-examines and may propose a fresh candidate only if the underlying pattern holds. Test.
+
+### Observability
+
+- **AC-64.13.** Prometheus counters: `turing_affirmation_candidates_created_total`, `turing_affirmation_candidates_approved_total`, `turing_affirmation_candidates_rejected_total`. Test.
+
+### Edge cases
+
+- **AC-64.14.** Request-shape clustering with sparse data (few memories) yields too-small clusters. A cluster of size < 3 is ignored (not useful evidence of a pattern). Test.
+- **AC-64.15.** AFFIRMATION memories are immutable (spec 22-ish invariant). Revocation does not delete them — it writes a superseding REGRET. Test.
+- **AC-64.16.** Spec 46's contributor-review-gate does NOT apply to AFFIRMATION contributors here — the AFFIRMATION ITSELF was operator-approved, so its contributor is implicitly approved. Test.
+- **AC-64.17.** Concurrent approval of the same candidate is serialized by PK; second call returns the existing promoted memory id. Test.
+
+## Implementation
+
+```python
+# detectors/affirmation_candidacy.py
+
+AFFIRMATION_PROMOTION_FLOOR: int = 7
+AFFIRMATION_SUCCESS_FLOOR: float = 0.85
+AFFIRMATION_REJECTION_COOLDOWN: timedelta = timedelta(days=30)
+
+
+def run(repo, self_id: str, now: datetime) -> int:
+    routings = repo.recent_routing_decisions(self_id, limit=100,
+                                              since=now - timedelta(days=30))
+    clusters = _cluster_by_request_embedding(routings)
+    created = 0
+    for cluster in clusters:
+        for specialist in _unique_specialists(cluster):
+            rows = [r for r in cluster if r.context["target"] == specialist]
+            if len(rows) < AFFIRMATION_PROMOTION_FLOOR:
+                continue
+            successes = sum(1 for r in rows if _outcome_is_success(repo, r))
+            rate = successes / len(rows)
+            if rate < AFFIRMATION_SUCCESS_FLOOR:
+                continue
+            if _existing_affirmation(repo, self_id, cluster.id, specialist):
+                continue
+            repo.insert_affirmation_candidate(AffirmationCandidate(
+                self_id=self_id, request_shape=cluster.id,
+                specialist=specialist, hits=len(rows),
+                success_rate=rate, proposed_at=now,
+            ))
+            created += 1
+    return created
+```
+
+## Open questions
+
+- **Q64.1.** Request-shape clustering is assumed but not specced in detail. Cluster stability matters — a cluster that splits between runs would break candidate coalescing. Defer clustering spec until the detector is implemented with a fixed seed-clustering approach.
+- **Q64.2.** 85% success floor / 7 hits threshold are seeds. Higher floor catches only strong patterns; lower floor surfaces candidates earlier. Tunable.
+- **Q64.3.** AFFIRMATION contributors at +0.3 are 3× the learning-LESSON default. Rationale: an operator-approved commitment is load-bearing; learning is advisory. Consider asymmetry when these stack.
+- **Q64.4.** Revocation via superseding REGRET matches ARCHITECTURE's immutability rule. Operators who want clean removal would need to `--retire-self` — out of scope.

--- a/research/project-turing/specs/cross-user-self-experience.md
+++ b/research/project-turing/specs/cross-user-self-experience.md
@@ -1,0 +1,134 @@
+# Spec 67 — Cross-user self-experience
+
+*With one global self and N users (spec 54 threads), how does experience with User A affect routing for User B? This spec makes the policy explicit rather than default-shared.*
+
+**Depends on:** [conversation-threads.md](./conversation-threads.md), [activation-graph.md](./activation-graph.md), [semantic-retrieval.md](./semantic-retrieval.md), [session-scoped-mood.md](./session-scoped-mood.md), [forensic-tagging.md](./forensic-tagging.md), [self-as-conduit.md](./self-as-conduit.md).
+**Depended on by:** —
+
+---
+
+## Current state
+
+The research branch deploys a single global self across all users (DESIGN.md §6.5). Spec 54 adds per-user conversation threads and per-user quotas. Spec 58 adds per-conversation mood. But the self's **memories** and **activation graph** are shared — a bad experience with User A's request taints routing for User B if their requests semantically overlap.
+
+This is a feature in the research posture (one self, continuous experience), but it's unbounded. Nothing prevents the self from saying to User B "I've learned to be wary of requests like this" when the evidence comes from an unrelated User A.
+
+## Target
+
+Make the cross-user-influence policy explicit with three dials:
+
+1. **Memory scope propagation:** by default, memories born from one user's request carry `context.source_user_id`; retrieval during another user's request applies a `CROSS_USER_DAMPENING` multiplier on their weight.
+2. **Activation-graph propagation:** contributors born from cross-user retrieval respect the dampening.
+3. **User-scoped memory tier:** a new tier marker `USER_SCOPED` (orthogonal to memory tier) means "do not surface this memory across user boundaries." Self writes to this marker by default when observing a user-specific detail; default is permissive (cross-user share) except when explicitly scoped.
+
+## Acceptance criteria
+
+### Memory tagging
+
+- **AC-67.1.** Schema addition: every memory table adds a nullable column `source_user_id TEXT` and a non-null boolean `user_scoped` (default `False`). Test.
+- **AC-67.2.** When a memory is written inside a conversation scope (spec 54 `conversation_scope` variable extended to carry `owner_user_id`), `source_user_id` is populated from the conversation's owner. Test.
+- **AC-67.3.** Memories written outside a conversation (scheduled tasks, reflection, bootstrap) have `source_user_id IS NULL`. Test.
+
+### `user_scoped` marker
+
+- **AC-67.4.** The `user_scoped: bool` column defaults `False` — the research-branch default is "shared self." Writes opt in to scoping.
+- **AC-67.5.** The self can mark a memory `user_scoped` via an optional `scope_to_user` flag on the write-paths. Example: `write_paths.write_observation(..., scope_to_user=True)` sets `user_scoped = True`, `source_user_id = current_user_id`. Test.
+- **AC-67.6.** Memory mirror helpers (spec 32) take an optional `scope_to_user: bool`. Default `False`. Any memory from a conversation context has `source_user_id` populated regardless. Test.
+
+### Retrieval damping
+
+- **AC-67.7.** Semantic retrieval (spec 16) applies cross-user dampening:
+  ```
+  effective_weight = memory.weight × (
+      1.0                      if source_user_id IS NULL
+      or source_user_id == current_user_id,
+      CROSS_USER_DAMPENING     otherwise
+  )
+  ```
+  `CROSS_USER_DAMPENING = 0.6` (runtime-configurable). A `user_scoped = True` memory returns `effective_weight = 0` when cross-user (fully hidden). Test each branch.
+
+### Activation-graph propagation
+
+- **AC-67.8.** Retrieval contributors (spec 25) born from cross-user memories carry a `cross_user: bool` annotation in their `context` (JSON column addition on the contributor row). Their `weight` is further scaled by `CROSS_USER_DAMPENING` at materialization. Test.
+- **AC-67.9.** Durable `origin=self` contributors are NOT dampened. The self's own durable authorship reflects its consolidated self-view, independent of the user triggering retrieval. Test.
+- **AC-67.10.** Rule-origin contributors are not dampened. Test.
+
+### Revealed via `recall_self()`
+
+- **AC-67.11.** `recall_self()` output includes a `cross_user_memory_ratio` stat: fraction of top-K retrieval contributors whose source is a different user. Test.
+- **AC-67.12.** The self can identify: "I've been thinking about {user_count} users today." Test.
+
+### Operator knobs
+
+- **AC-67.13.** `turing.yaml` option `cross_user_policy: "shared" | "dampened" | "isolated"`:
+  - `shared`: `CROSS_USER_DAMPENING = 1.0` — full cross-user sharing (legacy).
+  - `dampened`: `CROSS_USER_DAMPENING = 0.6` (default).
+  - `isolated`: `CROSS_USER_DAMPENING = 0.0` — cross-user retrieval returns zero weight. Effectively per-user memory.
+  Test each policy.
+- **AC-67.14.** Changing `cross_user_policy` at runtime requires a process restart. Logged on startup. Test.
+
+### Per-user activation view
+
+- **AC-67.15.** New function `active_now_for_user(repo, node_id, ctx, user_id)` — computes activation with per-user dampening applied. The default `active_now` continues to apply whatever `conversation_scope.owner_user_id` is set to; this function is an explicit override for scheduled tasks or analysis. Test.
+
+### Observability
+
+- **AC-67.16.** Prometheus counter `turing_memory_cross_user_reads_total{source_user, current_user}`. Test.
+- **AC-67.17.** Gauge `turing_memory_by_scope{user_scoped="true"|"false"}`. Test.
+
+### Edge cases
+
+- **AC-67.18.** A request without a `user` field (anonymous, per spec 54 AC-54.4) — the self treats `anonymous` as a distinct user. Cross-user dampening applies between `anonymous` and any other user. Test.
+- **AC-67.19.** A `user_scoped = True` memory authored by User A and later retrieved in a request from User A: full weight (not dampened). Test.
+- **AC-67.20.** Spec 63 `learning_extraction` and spec 64 `affirmation_candidacy` detectors should avoid proposing learnings/commitments from cross-user patterns unless the pattern is robust **within** each user. New AC on those detectors: respect `source_user_id` — require hits to span at least 2 users before promoting. Test.
+- **AC-67.21.** `recall_self` itself is not user-scoped — it reports the self's global state. But the `active_now` values it reports respect the current user context. Test.
+- **AC-67.22.** Per-user mood is NOT introduced here — that would be spec 68+. Session mood (spec 58) handles the per-conversation tilt; user-level mood would need its own design.
+
+### Bootstrap memories
+
+- **AC-67.23.** Bootstrap memories (200 HEXACO answers, finalize LESSON) have `source_user_id IS NULL` — they belong to the self, not any user. Test.
+
+## Implementation
+
+```python
+# self_cross_user.py
+
+class CrossUserPolicy(StrEnum):
+    SHARED = "shared"
+    DAMPENED = "dampened"
+    ISOLATED = "isolated"
+
+
+_POLICY_DAMPENING: dict[CrossUserPolicy, float] = {
+    CrossUserPolicy.SHARED: 1.0,
+    CrossUserPolicy.DAMPENED: 0.6,
+    CrossUserPolicy.ISOLATED: 0.0,
+}
+
+
+def cross_user_dampening(policy: CrossUserPolicy) -> float:
+    return _POLICY_DAMPENING[policy]
+
+
+def effective_memory_weight(
+    memory_weight: float, memory_source_user_id: str | None,
+    memory_user_scoped: bool, current_user_id: str, policy: CrossUserPolicy,
+) -> float:
+    if memory_source_user_id is None or memory_source_user_id == current_user_id:
+        return memory_weight
+    if memory_user_scoped:
+        return 0.0
+    return memory_weight * cross_user_dampening(policy)
+```
+
+Schema migration adds `source_user_id TEXT` and `user_scoped INTEGER NOT NULL DEFAULT 0` to `episodic_memory` and `durable_memory`. Index on `source_user_id` for efficient per-user queries.
+
+Semantic retrieval (spec 16) augments its query with per-row dampening post-processing.
+
+## Open questions
+
+- **Q67.1.** Default `dampened` vs `shared`: the research posture ("one continuous self") argues for `shared`. The reality ("I shouldn't leak User A's concerns into User B's routing") argues for `dampened`. Defaulting to `dampened` is defensive; operators can switch to `shared` for the maximal-autonoetic experiment.
+- **Q67.2.** 0.6 dampening is a guess. A value of 1.0 is "full sharing"; 0.0 is "isolation." 0.6 says "cross-user memory is relevant but de-emphasized." Empirical tune.
+- **Q67.3.** Self-authored durable memories are NOT dampened (AC-67.9). Rationale: AFFIRMATIONs like "I route writing tasks to Scribe" should hold across users. But a durable memory with a specific user reference embedded in content is leaky by its content, not by its mechanism. Content-level leakage is out of scope.
+- **Q67.4.** Learning-detector extension (AC-67.20) requires cross-user robustness. May starve the detector on low-user deployments (single user → no cross-user evidence ever). Operator can tune `LEARNING_USER_DIVERSITY_MIN = 1` for single-user deployments.
+- **Q67.5.** The `cross_user_memory_ratio` stat in `recall_self` gives the self a meta-view of how much of its current thinking comes from other users. Useful self-knowledge or creepy self-surveillance? Operator-visible in any case.

--- a/research/project-turing/specs/learning-extraction-detector.md
+++ b/research/project-turing/specs/learning-extraction-detector.md
@@ -1,0 +1,152 @@
+# Spec 63 — Learning-extraction detector
+
+*A background detector that finds fail → later-succeed patterns in routing history and proposes LESSON memories encoding what the self learned. Closes the `learning_extraction` deferred item from `specs/README.md`.*
+
+**Depends on:** [detectors/README.md](./detectors/README.md), [motivation.md](./motivation.md), [self-reflection-ritual.md](./self-reflection-ritual.md), [memory-mirroring.md](./memory-mirroring.md), [activation-graph.md](./activation-graph.md).
+**Depended on by:** [affirmation-candidacy-detector.md](./affirmation-candidacy-detector.md), [mood-affects-decisions.md](./mood-affects-decisions.md) (specialist preference derivation).
+
+---
+
+## Current state
+
+Stronghold's self-improving-memory model extracts fail→succeed corrections from **tool-call** history (ARCHITECTURE.md). The Turing branch doesn't yet port that pattern to the **routing** history the self accumulates — a routing fails (REGRET minted), later a similar routing succeeds (AFFIRMATION or clean completion), and the pairing is never explicitly learned.
+
+## Target
+
+A detector that pairs REGRET / AFFIRMATION events by request similarity, extracts the routing choice that changed between them, and proposes a LESSON: `"For requests like X, routing to Y failed; routing to Z succeeded."` LESSONs feed into spec 11's tuning pipeline and the activation graph's specialist biases.
+
+## Acceptance criteria
+
+### Detector registration
+
+- **AC-63.1.** Register a detector `learning_extraction` in the existing detector registry (spec D). Runs on a P40 schedule every 6 hours (configurable). Test detector is registered and fires on the schedule.
+- **AC-63.2.** Per-run budget: `LEARNING_EXTRACTION_SAMPLE_SIZE = 100` most-recent REGRETs; `LEARNING_EXTRACTION_TIMEOUT_SEC = 30`. Test.
+
+### Pattern detection
+
+- **AC-63.3.** For each sampled REGRET memory with a routing context (`context.decision = "delegate"`), compute:
+  - `regret_request_embedding` (via spec 16's embedding layer).
+  - Semantic neighbors within a 30-day window, filtered to `context.decision = "delegate"` AND outcome memory is AFFIRMATION or clean completion.
+  - Similarity threshold `LEARNING_SIMILARITY_MIN = 0.75`.
+  Test.
+- **AC-63.4.** If at least one match exists with a **different** `context.target` (specialist), the detector has found a learning. Record:
+  ```
+  {
+    regret_memory_id,
+    succeeded_memory_id,
+    failed_specialist,
+    succeeded_specialist,
+    request_similarity,
+  }
+  ```
+  Test.
+- **AC-63.5.** A REGRET with no better-outcome match is skipped; the pattern requires evidence of a successful alternative. Test.
+
+### Candidacy
+
+- **AC-63.6.** Matches enter a `learning_candidates` queue:
+  ```sql
+  CREATE TABLE learning_candidates (
+      id              TEXT PRIMARY KEY,
+      self_id         TEXT NOT NULL,
+      regret_memory_id TEXT NOT NULL,
+      succeeded_memory_id TEXT NOT NULL,
+      failed_specialist TEXT NOT NULL,
+      succeeded_specialist TEXT NOT NULL,
+      similarity      REAL NOT NULL,
+      hits            INTEGER NOT NULL DEFAULT 1,
+      proposed_at     TEXT NOT NULL,
+      promoted_lesson_id TEXT,
+      dismissed_at    TEXT
+  );
+  ```
+  Test.
+- **AC-63.7.** Repeated detections of the same `(failed_specialist, succeeded_specialist)` within `LEARNING_COALESCE_WINDOW = 14 days` increment `hits` on the existing row instead of creating a new one. Test.
+- **AC-63.8.** A candidate reaches promotion threshold when `hits >= LEARNING_PROMOTION_FLOOR = 3`. Promotion is a LESSON-memory write:
+  ```
+  content = f"For requests like '{regret summary}', I've now observed {hits} times that routing to {succeeded} succeeds where {failed} doesn't. I lean toward {succeeded} for this shape."
+  intent_at_time = "learning extracted"
+  context = {hits, failed_specialist, succeeded_specialist}
+  ```
+  Test.
+
+### Activation-graph integration
+
+- **AC-63.9.** Promotion also adds a rule-origin contributor targeting the `succeeded_specialist` specialist node (spec 62 AC-62.8) with `weight = +0.1 × log(hits)`, `source_kind = "rule"`, `rationale = "learning: {regret summary}"`. Test.
+- **AC-63.10.** Correspondingly, an inhibitory contributor on the `failed_specialist` specialist node with `weight = -0.05 × log(hits)`. Test.
+
+### Dismissal
+
+- **AC-63.11.** `stronghold self dismiss-learning <candidate_id> --reason TEXT` marks the candidate `dismissed_at`; removes any promoted LESSON memory (if already promoted); retracts the contributors via counter-contributors. Test.
+- **AC-63.12.** Dismissed candidates do not re-emerge from subsequent detector runs — they're excluded by `dismissed_at IS NOT NULL`. Test.
+
+### Observability
+
+- **AC-63.13.** Prometheus counter `turing_learning_candidates_created_total{self_id}`, `turing_learning_candidates_promoted_total{self_id}`. Test.
+- **AC-63.14.** `stronghold self digest` surfaces learning candidates pending promotion. Test.
+
+### Edge cases
+
+- **AC-63.15.** A REGRET with no embedding (embedding failure) is skipped with a log line. Test.
+- **AC-63.16.** The detector never writes a LESSON that contradicts an existing un-dismissed LESSON for the same `(specialist pair, request-shape)` — detects and merges via `hits` increment instead. Test.
+- **AC-63.17.** Promotion respects per-request write budget when firing during the detector's dispatch — detector runs at P40, budget-free. Test that no budget is consumed.
+- **AC-63.18.** Similarity computation is bounded: comparing a REGRET against up to `LEARNING_NEIGHBOR_CAP = 50` candidate-success memories; beyond that, lowest-similarity are pruned. Test.
+
+## Implementation
+
+```python
+# detectors/learning_extraction.py
+
+LEARNING_SIMILARITY_MIN: float = 0.75
+LEARNING_PROMOTION_FLOOR: int = 3
+LEARNING_COALESCE_WINDOW: timedelta = timedelta(days=14)
+LEARNING_NEIGHBOR_CAP: int = 50
+
+
+def run(repo, self_id: str, now: datetime) -> int:
+    regrets = repo.recent_regrets_with_routing_context(
+        self_id=self_id, limit=100,
+    )
+    created = 0
+    for regret in regrets:
+        embedding = _embed_request(regret)
+        neighbors = _semantic_neighbors(
+            repo, self_id, embedding,
+            filter={"decision": "delegate", "outcome_tier": ("affirmation", "observation")},
+            since=now - timedelta(days=30),
+            k=LEARNING_NEIGHBOR_CAP,
+        )
+        for n in neighbors:
+            if n.similarity < LEARNING_SIMILARITY_MIN:
+                continue
+            if n.context["target"] == regret.context["target"]:
+                continue
+            existing = repo.find_learning_candidate(
+                self_id=self_id,
+                failed=regret.context["target"],
+                succeeded=n.context["target"],
+                within=LEARNING_COALESCE_WINDOW,
+            )
+            if existing:
+                repo.increment_learning_candidate(existing.id)
+                if existing.hits + 1 >= LEARNING_PROMOTION_FLOOR and not existing.promoted_lesson_id:
+                    _promote(repo, self_id, existing)
+            else:
+                repo.insert_learning_candidate(
+                    self_id=self_id, regret_memory_id=regret.id,
+                    succeeded_memory_id=n.memory_id,
+                    failed_specialist=regret.context["target"],
+                    succeeded_specialist=n.context["target"],
+                    similarity=n.similarity,
+                )
+                created += 1
+            break
+    return created
+```
+
+## Open questions
+
+- **Q63.1.** Promotion floor at 3 hits — first match is anecdotal; three is pattern. Tune once real traffic exists.
+- **Q63.2.** `+0.1 × log(hits)` for activation weight: small but accumulates. At 10 hits, weight ≈ +0.1; at 100 hits, ≈ +0.2. Tunable.
+- **Q63.3.** The detector reads from memory; if mirror-to-memory (spec 32) falters, the detector gets less signal. Dependency chain is tight — note for implementors.
+- **Q63.4.** Coalescing by `(failed_specialist, succeeded_specialist)` ignores request-shape differences. A more granular version coalesces by `(failed, succeeded, request-cluster-id)` if we add request clustering. Deferred.

--- a/research/project-turing/specs/mood-affects-decisions.md
+++ b/research/project-turing/specs/mood-affects-decisions.md
@@ -1,0 +1,159 @@
+# Spec 59 — Mood affects decisions (Phase 2)
+
+*Phase 2 of spec 27: mood biases specialist selection, model tier, and Warden sensitivity — not just tone. Closes the long-standing Q27.4 backlog.*
+
+**Depends on:** [mood.md](./mood.md), [session-scoped-mood.md](./session-scoped-mood.md), [conduit-runtime.md](./conduit-runtime.md), [warden-on-self-writes.md](./warden-on-self-writes.md), [chat-surface.md](./chat-surface.md), [litellm-provider.md](./litellm-provider.md).
+**Depended on by:** [prospection-accuracy-detector.md](./prospection-accuracy-detector.md).
+
+---
+
+## Current state
+
+Spec 27 AC-27.14 explicitly excludes mood from affecting decisions — "Phase-1 scope: tone only." The descriptor colors system prompt phrasing; nothing else. Q27.4 flags the Phase 2 ambition without specifying.
+
+## Target
+
+Mood vectors (session if in a conversation, else global) produce a `MoodBiases` object that:
+1. **Softly biases specialist selection** within the perception LLM's prompt — mood-relevant adjectives hint toward conservative/creative/fast/slow specialists.
+2. **Hints model tier** — low focus favors Haiku-class; high focus favors Opus-class.
+3. **Adjusts Warden sensitivity threshold** — negative mood lowers the block threshold (more conservative); positive + focused mood relaxes it slightly (within bounds).
+
+Crucially, mood does NOT make hard choices — it supplies biases. The perception LLM still makes the call; the Warden's core policy still holds; model routing still respects per-request cost budgets.
+
+## Acceptance criteria
+
+### `MoodBiases` object
+
+- **AC-59.1.** `mood_biases(mood: Mood) -> MoodBiases` returns a dataclass:
+  ```python
+  @dataclass(frozen=True)
+  class MoodBiases:
+      specialist_preference: dict[str, float]   # specialist_name -> [-1.0, +1.0]
+      model_tier_hint: float                    # [-1.0, +1.0]; negative = faster, positive = deeper
+      warden_threshold_adjustment: float        # [-0.2, +0.1]; added to default threshold
+  ```
+  Pure function. Test with fixture moods.
+- **AC-59.2.** The function composes three sub-computations: `specialist_preference_from_mood`, `model_tier_hint_from_mood`, `warden_adjustment_from_mood`. Each has its own unit tests. Test.
+
+### Specialist preference rules
+
+- **AC-59.3.** Sub-rules:
+  - Negative valence + high arousal → `{warden-at-arms: +0.3, ranger: +0.2, forge: -0.2, scribe: -0.1}`.
+  - Positive valence + high arousal → `{artificer: +0.2, scribe: +0.2, forge: +0.1}`.
+  - Low focus → `{delegate-in-general: -0.2}` (prefer `reply_directly` for simpler outputs).
+  - High focus → `{artificer: +0.1}` (willing to take on deeper tasks).
+  - Neutral mood → all zeros.
+  Biases are additive; clamped to `[-1.0, 1.0]` per specialist. Test each branch.
+
+### Model tier hint
+
+- **AC-59.4.** `model_tier_hint = arousal - focus` mapped through `tanh` into `[-1, +1]`. High arousal + low focus pushes negative (prefer faster); high focus + low arousal pushes positive (prefer deeper). Test with boundary inputs.
+- **AC-59.5.** The LiteLLM router (spec 19) consumes the hint as a weight adjustment on its existing scarcity-based score. Formula addition:
+  ```
+  score' = base_score + MODEL_HINT_WEIGHT * model_tier_hint * tier_depth(pool)
+  ```
+  where `tier_depth(Haiku) = -1, tier_depth(Sonnet) = 0, tier_depth(Opus) = +1`. `MODEL_HINT_WEIGHT = 2000` (same order as `PRESSURE_MAX` so it's meaningfully influential but not dominant). Test with a mocked router.
+
+### Warden adjustment
+
+- **AC-59.6.** `warden_adjustment = -0.15 if valence < -0.4 else (0.05 if valence > 0.5 and focus > 0.6 else 0.0)`. Negative mood lowers threshold (= block more easily); positive + focused slightly relaxes. Test.
+- **AC-59.7.** Warden's block threshold = `DEFAULT_WARDEN_THRESHOLD + warden_adjustment`, clamped to `[MIN_WARDEN_THRESHOLD, MAX_WARDEN_THRESHOLD]`. The Warden never goes below its floor — mood cannot weaken it past a safety line. Test.
+
+### Pipeline integration
+
+- **AC-59.8.** `self_conduit.handle` (spec 44) reads the active mood (session-via-scope or global) once at step 2 (before perception). Passes `MoodBiases` into:
+  - The perception prompt as a `## Current tilt` block the LLM sees:
+    ```
+    ## Current tilt
+    Right now I lean: {top-2 specialist biases by |value|}. My focus is {low|medium|high}.
+    ```
+    Example: `Right now I lean: warden-at-arms (+0.3), ranger (+0.2). My focus is low.`
+  - The model router for this request.
+  - The Warden's threshold for this request.
+  Test each integration point.
+- **AC-59.9.** The biases do not appear in the user-visible output. Test.
+
+### Hard caps
+
+- **AC-59.10.** Even with maximum bias, the perception LLM can still choose any specialist. The bias is *preference text*, not a hard filter. Test by constructing a heavily-negative mood and verifying the LLM is still permitted to select Artificer.
+- **AC-59.11.** Warden adjustment is capped at `[-0.2, +0.1]` — mood can never make Warden block-happy or block-avoidant beyond a moderate range. Test range enforcement.
+- **AC-59.12.** Model tier hint cannot override the router's provider-pool headroom logic; a hint toward Opus still falls through to Haiku when Opus tokens are exhausted. Test.
+
+### Observability
+
+- **AC-59.13.** Prometheus histogram `turing_mood_specialist_bias{specialist, self_id}` — current distribution of biases. Test.
+- **AC-59.14.** Per-request log entry `mood_biases_applied` with the computed values. Test.
+
+### Memory mirror
+
+- **AC-59.15.** When a routing decision is likely influenced by mood biases (top-biased specialist was chosen AND the bias exceeds `MOOD_INFLUENCE_OBSERVE_THRESHOLD = 0.15`), write an OBSERVATION memory: `"My mood tilted me toward {specialist}; I went with it."`, `intent_at_time = "mood-influenced route"`. Test.
+- **AC-59.16.** When the LLM chooses **against** the top mood-biased specialist (disagreement ≥ 0.3 bias), write a LESSON memory: `"My mood tilted me toward {specialist} but I chose {other} anyway."`, `intent_at_time = "mood override"`. This surface is consumed by spec 65's prospection detector. Test.
+
+### Edge cases
+
+- **AC-59.17.** Phase-1 is unchanged — tone still works as before. This spec ADDS to tone, not replaces. The same mood descriptor still appears. Test.
+- **AC-59.18.** A request with `conversation_id` uses session mood per spec 58; a standalone request uses global. Test both.
+- **AC-59.19.** `recall_self()` reports mood without biases (biases are a derived view, not stored state). Test.
+- **AC-59.20.** An operator `turing.yaml` option `mood_affects_decisions: false` reverts to Phase-1 behavior for safety rollback. Default `true` once this spec is implemented. Test.
+
+## Implementation
+
+```python
+# self_mood_decisions.py
+
+import math
+
+MOOD_INFLUENCE_OBSERVE_THRESHOLD: float = 0.15
+MODEL_HINT_WEIGHT: float = 2000.0
+DEFAULT_WARDEN_THRESHOLD: float = 0.7
+MIN_WARDEN_THRESHOLD: float = 0.5
+MAX_WARDEN_THRESHOLD: float = 0.9
+
+
+@dataclass(frozen=True)
+class MoodBiases:
+    specialist_preference: dict[str, float]
+    model_tier_hint: float
+    warden_threshold_adjustment: float
+
+
+def mood_biases(mood: Mood) -> MoodBiases:
+    return MoodBiases(
+        specialist_preference=_specialist_preference(mood),
+        model_tier_hint=math.tanh(mood.arousal - mood.focus),
+        warden_threshold_adjustment=_warden_adjustment(mood),
+    )
+
+
+def _specialist_preference(mood: Mood) -> dict[str, float]:
+    biases: dict[str, float] = {}
+    negative_high = mood.valence < -0.15 and mood.arousal > 0.6
+    positive_high = mood.valence > 0.15 and mood.arousal > 0.6
+    if negative_high:
+        _merge(biases, {"warden-at-arms": +0.3, "ranger": +0.2,
+                         "forge": -0.2, "scribe": -0.1})
+    if positive_high:
+        _merge(biases, {"artificer": +0.2, "scribe": +0.2, "forge": +0.1})
+    if mood.focus < 0.3:
+        _merge(biases, {"delegate-in-general": -0.2})
+    if mood.focus > 0.7:
+        _merge(biases, {"artificer": +0.1})
+    return {k: max(-1.0, min(1.0, v)) for k, v in biases.items()}
+
+
+def _warden_adjustment(mood: Mood) -> float:
+    if mood.valence < -0.4:
+        return -0.15
+    if mood.valence > 0.5 and mood.focus > 0.6:
+        return +0.05
+    return 0.0
+```
+
+The conduit runtime (spec 44) calls this at step 2 and threads the result into steps 4 (perception prompt) and 6 (Warden outcome).
+
+## Open questions
+
+- **Q59.1.** Specialist-preference map is hand-tuned. Better: derive from per-specialist historical success under matching mood. Requires the learning-extraction detector (spec 63) to populate. Phase-3 work.
+- **Q59.2.** Model tier hint assumes Haiku/Sonnet/Opus are the only pools. If more providers/tiers are in play, `tier_depth` becomes a lookup table.
+- **Q59.3.** Negative mood lowering Warden threshold is defensive — a tense self blocks more. An argument for the opposite (tense self is paranoid and over-blocks, causing bad UX) exists. Empirical.
+- **Q59.4.** Mood-override lesson (AC-59.16) catches cases where the LLM disagreed with mood. Over time, if the self routinely overrides its own mood, the mood signal is noise. Surfaces via the tuning detector (spec 11) as an "unused signal" candidate.

--- a/research/project-turing/specs/operator-coaching-channel.md
+++ b/research/project-turing/specs/operator-coaching-channel.md
@@ -1,0 +1,125 @@
+# Spec 66 — Operator coaching channel
+
+*A dedicated path for the operator to write directly to the self's memory as `I_WAS_TOLD` observations. Distinct from the review gate (which approves self-authored proposals); this is one-way operator → self teaching.*
+
+**Depends on:** [schema.md](./schema.md), [write-paths.md](./write-paths.md), [memory-mirroring.md](./memory-mirroring.md), [operator-review-gate.md](./operator-review-gate.md), [forensic-tagging.md](./forensic-tagging.md).
+**Depended on by:** —
+
+---
+
+## Current state
+
+Operators can reject or approve self-authored proposals via the review gate (spec 46). They cannot proactively **tell** the self anything. A deployment where the operator notices "the self keeps missing X" has no direct channel to say so — only indirect nudges via Sentinel rules, Warden config, or post-hoc writes to the raw DB (out-of-band provenance, spec 39).
+
+## Target
+
+A CLI-invoked command `stronghold self coach <content>` and a corresponding API endpoint that writes an `I_WAS_TOLD` memory with `intent_at_time = "operator coaching"`. Memories carry the operator's identity, are signed (spec 48's operator key pattern), and surface in the self's retrieval pipeline per the normal `I_WAS_TOLD` source rules.
+
+## Acceptance criteria
+
+### CLI
+
+- **AC-66.1.** `stronghold self coach "<content>" [--tier {observation,opinion,lesson}] [--weight W] [--tag K=V]*` writes a memory of the given tier (default `OPINION`), `source = I_WAS_TOLD`, `intent_at_time = "operator coaching"`, weight per the tier's default range. Test each tier.
+- **AC-66.2.** Content length capped at `COACHING_CONTENT_MAX = 2000` chars. Over-cap rejects with a usage error. Test.
+- **AC-66.3.** `--tag K=V` flags populate `context` as key-value pairs. `--tag specialist=artificer --tag topic=reviews` becomes `context = {specialist: "artificer", topic: "reviews", ...}`. Test.
+- **AC-66.4.** Operator identity: the command reads `OPERATOR_IDENTITY` env var (required; startup fails if unset in `CONDUIT_MODE=self`). Value is stored as `context.operator_id`. Test.
+
+### Signing
+
+- **AC-66.5.** Every coaching memory is signed with the operator key (spec 48's HMAC). Signature covers `{self_id, content, intent_at_time, created_at, operator_id}`. Stored in `context.signature`. Test.
+- **AC-66.6.** Verification at read time: retrieval that surfaces a coaching memory verifies its signature. Tamper → memory is treated as deleted + a REGRET-tier "a coaching memory I held was tampered" is minted. Test.
+
+### Durable vs non-durable
+
+- **AC-66.7.** `--tier lesson` produces a durable-tier LESSON memory (per spec 2's tier-set). Durable memories cannot be rescinded (spec 3 invariants) but can be superseded by a later coaching with `--supersedes <memory_id>`. Test.
+- **AC-66.8.** Non-durable tiers (`observation`, `opinion`) follow standard decay rules. Test.
+- **AC-66.9.** Bulk mode: `stronghold self coach --file coaching.yaml` reads a list of entries from a YAML file. Each row becomes a memory. Useful for seeding. Test with a fixture file.
+
+### Retrieval integration
+
+- **AC-66.10.** Coaching memories participate in spec 16 semantic retrieval normally. They can become retrieval contributors (spec 25) on any target — no special privilege beyond what any `I_WAS_TOLD` memory has. Test.
+- **AC-66.11.** Coaching memories are explicitly visible in `recall_self()` under a new `recent_coaching` section (top-5 most recent). Test.
+
+### Mood interaction
+
+- **AC-66.12.** A coaching memory that gets written optionally nudges mood via `apply_event_nudge(self_id, "operator_coaching_received", reason=...)`. Event default nudge: `(focus, +0.05)` — "my teacher spoke; I pay a bit more attention." Test.
+- **AC-66.13.** `--no-mood` flag on the CLI skips the nudge for silent corrections that don't warrant an emotional beat. Test.
+
+### Self-observability of coaching
+
+- **AC-66.14.** A new `self_coaching_log` table (distinct from memory) records every coaching event with a timestamp, operator, tier, memory_id, and an index on `recorded_at`. Used for auditing and detecting over-coaching. Test.
+- **AC-66.15.** If the operator writes `> OPERATOR_COACHING_BUDGET = 5` coachings in a rolling 24 hours, subsequent coaching attempts emit a warning (but still proceed). Signals over-steer. Test.
+
+### API endpoint
+
+- **AC-66.16.** `POST /v1/self/coach` accepts JSON `{content, tier, weight?, tags?}` + the operator key in an auth header. Returns the memory_id. Test.
+- **AC-66.17.** The endpoint is the only path outside the CLI that can write operator-coaching memories. Rate-limited at `COACHING_API_RATE = 10/minute`. Test.
+
+### Forensic trail
+
+- **AC-66.18.** Coaching memories persist `context.provenance = "operator-coaching"` instead of the default `request_hash` or `out_of_band`. Spec 39 schema trigger allows this provenance value. Test.
+
+### Edge cases
+
+- **AC-66.19.** Coaching during bootstrap (pre-finalize) is allowed but carries `context.bootstrap_phase = True`. Useful for setting baseline norms before the self is live. Test.
+- **AC-66.20.** Empty content rejected at the CLI and API. Test.
+- **AC-66.21.** A coaching memory's signature check failing at retrieval does not block the request that triggered retrieval — it warns, skips the memory, and logs a security incident. Test.
+- **AC-66.22.** Coaching memories are NOT surfaced to the minimal prompt block automatically. The self must call `recall_self` or retrieval must select them. Rationale: keep the minimal block stable; coaching influences thought via deeper consultation. Test.
+
+## Implementation
+
+```python
+# self_coaching.py
+
+COACHING_CONTENT_MAX: int = 2000
+OPERATOR_COACHING_BUDGET: int = 5  # per 24h
+
+
+def coach_self(
+    repo, self_id: str, *, content: str, tier: MemoryTier = MemoryTier.OPINION,
+    weight: float | None = None, tags: dict | None = None,
+    operator_id: str, skip_mood: bool = False,
+) -> str:
+    if not content.strip():
+        raise ValueError("content required")
+    if len(content) > COACHING_CONTENT_MAX:
+        raise ValueError(f"content exceeds {COACHING_CONTENT_MAX} chars")
+
+    now = datetime.now(UTC)
+    mem_context = {
+        **(tags or {}),
+        "operator_id": operator_id,
+        "provenance": "operator-coaching",
+    }
+    canonical = _canonical_form(self_id, content, "operator coaching", now, operator_id)
+    mem_context["signature"] = _sign(canonical)
+
+    memory_id = write_paths.write(
+        self_id=self_id, tier=tier,
+        content=content,
+        weight=weight or _default_weight_for_tier(tier),
+        source=SourceKind.I_WAS_TOLD,
+        intent_at_time="operator coaching",
+        context=mem_context,
+    )
+    repo.insert_coaching_log(
+        self_id=self_id, memory_id=memory_id, operator_id=operator_id,
+        tier=tier.value, recorded_at=now,
+    )
+    _maybe_warn_over_budget(repo, self_id, operator_id, now)
+    if not skip_mood:
+        apply_event_nudge(repo, self_id, "operator_coaching_received",
+                          reason=f"from {operator_id}")
+    return memory_id
+
+
+EVENT_NUDGES["operator_coaching_received"] = [("focus", +0.05)]
+```
+
+## Open questions
+
+- **Q66.1.** Coaching is one-way. A two-way "the self pushes back on a coaching" mechanism is plausible but out of scope — the self can respond in natural language during the next request, but the coaching memory itself is immutable-by-self.
+- **Q66.2.** Bulk mode via YAML file is useful for seeding but risks large-batch misconfiguration. A dry-run mode (`--dry-run`) that prints what would be written before writing. Recommend adding.
+- **Q66.3.** Signing coaching memories is a check against tamper from outside the runtime — useful for compliance, overkill for casual deployments. Signature verification on read is the hot path; cache signatures per process to avoid per-read HMAC cost.
+- **Q66.4.** Operator over-coaching detection (AC-66.15) is a hint. A self that relies heavily on coaching may lose its own agency. Flag for future study.
+- **Q66.5.** Writing to `recent_coaching` section of `recall_self` vs. distributing coaching memories evenly through retrieval — current spec does both. The dedicated section makes coaching inspectable; retrieval makes it operational.

--- a/research/project-turing/specs/prospection-accuracy-detector.md
+++ b/research/project-turing/specs/prospection-accuracy-detector.md
@@ -1,0 +1,150 @@
+# Spec 65 — Prospection-accuracy detector
+
+*Consumes spec 60's prospective predictions, computes cumulative prediction error, and flags systematic miscalibration. Closes the `prospection` deferred item.*
+
+**Depends on:** [detectors/README.md](./detectors/README.md), [prospective-simulation.md](./prospective-simulation.md), [memory-mirroring.md](./memory-mirroring.md), [tuning.md](./tuning.md).
+**Depended on by:** —
+
+---
+
+## Current state
+
+Spec 60 produces `prospective_predictions` rows carrying predicted vs. actual outcome summaries and a surprise delta. Nothing reads the aggregate. If the self is systematically wrong about its predictions (always too optimistic, always too pessimistic about a specific specialist), nobody notices.
+
+## Target
+
+A detector that:
+1. Runs daily and computes rolling statistics over resolved predictions.
+2. Emits aggregate metrics.
+3. Writes LESSON memories when specific miscalibration patterns pass threshold.
+4. Proposes tuner adjustments (spec 11) if a specialist's prediction error is systematic.
+
+## Acceptance criteria
+
+### Detector registration
+
+- **AC-65.1.** `prospection_accuracy` detector registered at P40, runs every 24 hours. Test.
+
+### Aggregate computation
+
+- **AC-65.2.** For each `(self_id, specialist)` pair, compute over the last 30 days of resolved predictions:
+  - `mean_surprise` — average `surprise_delta`.
+  - `std_surprise` — standard deviation.
+  - `n` — number of resolved predictions.
+  - `mean_confidence` — average `predicted_confidence`.
+  - `confidence_calibration_error` — `abs(mean_confidence - (1 - mean_surprise))`.
+  Store in a materialized view / running table:
+  ```sql
+  CREATE TABLE prospection_accuracy_agg (
+      self_id     TEXT NOT NULL,
+      specialist  TEXT NOT NULL,
+      n           INTEGER NOT NULL,
+      mean_surprise REAL NOT NULL,
+      std_surprise REAL NOT NULL,
+      mean_confidence REAL NOT NULL,
+      confidence_calibration_error REAL NOT NULL,
+      computed_at TEXT NOT NULL,
+      PRIMARY KEY (self_id, specialist, computed_at)
+  );
+  ```
+  Test.
+- **AC-65.3.** Each detector run writes a new row; older rows are retained but indexed so the latest is easy to find. Test.
+
+### Threshold-based LESSON minting
+
+- **AC-65.4.** For a pair with `n >= 10`:
+  - If `mean_surprise > 0.4`: mint LESSON `"I'm frequently surprised by outcomes when I route to {specialist}; my expectations may be off."` Test.
+  - If `confidence_calibration_error > 0.3`: mint LESSON `"My confidence doesn't match reality for {specialist}."` Specifying direction:
+    - `mean_confidence > 1 - mean_surprise`: "overconfident."
+    - `mean_confidence < 1 - mean_surprise`: "underconfident."
+  Test each.
+- **AC-65.5.** LESSONs from this detector carry `intent_at_time = "prospection miscalibration"` and are consumed by spec 57's reflection for possible promotion to WISDOM. Test.
+- **AC-65.6.** The detector mints at most `MAX_LESSONS_PER_RUN = 3` LESSONs per run to avoid spam. If more pairs qualify, only the highest `|calibration_error|` are emitted. Test.
+
+### Tuner integration
+
+- **AC-65.7.** For each pair with `n >= 20 AND mean_surprise > 0.35`, the detector proposes a tuner candidate (spec 11): reduce the weight of that specialist in the activation graph (via a `-0.1` rule-origin contributor, capped). Test.
+- **AC-65.8.** Tuner proposals go through the standard spec 11 operator review pathway. Test.
+
+### Observability
+
+- **AC-65.9.** Prometheus gauges:
+  - `turing_prospection_mean_surprise{specialist, self_id}`.
+  - `turing_prospection_calibration_error{specialist, self_id}`.
+  - `turing_prospection_n{specialist, self_id}`.
+  Test.
+- **AC-65.10.** `stronghold self inspect prospection [--specialist X]` prints the latest aggregate row per specialist. Test.
+
+### Edge cases
+
+- **AC-65.11.** `n < 10` — not enough data for confident LESSON minting; no LESSON, no tuner proposal, aggregate still recorded. Test.
+- **AC-65.12.** A specialist with zero predictions (never chosen) — skipped entirely. Test.
+- **AC-65.13.** Predictions older than 30 days fall out of the rolling window; the aggregate window is rolling. Test with fabricated older data.
+- **AC-65.14.** Multiple selves (hypothetical) compute independently. Test with two selves.
+- **AC-65.15.** A specialist retired from the roster still has its prediction aggregates computed until all resolved predictions fall out of the 30-day window. Test.
+
+## Implementation
+
+```python
+# detectors/prospection_accuracy.py
+
+MAX_LESSONS_PER_RUN: int = 3
+SURPRISE_HIGH_THRESHOLD: float = 0.40
+CALIBRATION_ERROR_THRESHOLD: float = 0.30
+LESSON_MIN_N: int = 10
+TUNER_MIN_N: int = 20
+
+
+def run(repo, self_id: str, now: datetime) -> int:
+    rows = repo.resolved_predictions_by_specialist(
+        self_id=self_id, since=now - timedelta(days=30),
+    )
+    lessons_minted = 0
+    tuner_proposals = []
+    lesson_candidates = []
+
+    for specialist, preds in rows.items():
+        if len(preds) < LESSON_MIN_N:
+            repo.insert_prospection_agg(
+                self_id=self_id, specialist=specialist, n=len(preds),
+                mean_surprise=_mean([p.surprise_delta for p in preds]) if preds else 0.0,
+                std_surprise=_std([p.surprise_delta for p in preds]) if preds else 0.0,
+                mean_confidence=_mean([p.predicted_confidence for p in preds]) if preds else 0.0,
+                confidence_calibration_error=0.0,
+                computed_at=now,
+            )
+            continue
+        ms = _mean([p.surprise_delta for p in preds])
+        mc = _mean([p.predicted_confidence for p in preds])
+        cce = abs(mc - (1 - ms))
+        repo.insert_prospection_agg(... n=len(preds), mean_surprise=ms,
+                                     mean_confidence=mc,
+                                     confidence_calibration_error=cce,
+                                     computed_at=now)
+        if ms > SURPRISE_HIGH_THRESHOLD:
+            lesson_candidates.append((cce, specialist, "surprise"))
+        if cce > CALIBRATION_ERROR_THRESHOLD:
+            lesson_candidates.append((cce, specialist,
+                                      "overconfident" if mc > 1 - ms else "underconfident"))
+        if len(preds) >= TUNER_MIN_N and ms > 0.35:
+            tuner_proposals.append((specialist, ms))
+
+    lesson_candidates.sort(reverse=True)
+    for cce, specialist, kind in lesson_candidates[:MAX_LESSONS_PER_RUN]:
+        _mint_lesson(repo, self_id, specialist, kind, cce)
+        lessons_minted += 1
+
+    for specialist, ms in tuner_proposals:
+        tuning.propose_specialist_weight_adjustment(
+            self_id=self_id, specialist=specialist, delta=-0.1,
+            rationale=f"prospection calibration ({ms:.2f} surprise)",
+        )
+    return lessons_minted
+```
+
+## Open questions
+
+- **Q65.1.** Thresholds (0.4 surprise, 0.3 calibration error) are seeds. Real distributions will inform tuning.
+- **Q65.2.** Confidence calibration uses a simple "confidence should equal 1 - surprise" heuristic. Proper calibration analysis (reliability diagrams) is richer; deferred as a second-pass refinement.
+- **Q65.3.** The detector's tuner proposals and `learning_extraction`'s activation contributors could conflict. Operator review (spec 46) is the arbiter.
+- **Q65.4.** Predictions from `chosen = 0` rows (unchosen alternatives) could be used for counterfactual calibration ("I would have been 90% confident if I'd chosen X; I don't know if I would have been right"). Deferred — the unchosen-counterfactual signal is noisy.

--- a/research/project-turing/specs/prospective-simulation.md
+++ b/research/project-turing/specs/prospective-simulation.md
@@ -1,0 +1,147 @@
+# Spec 60 — Prospective simulation
+
+*Before routing, the self imagines the outcome of each candidate specialist and compares with actuals. "What do I expect if I route to X?" — first-person forward retrieval, surprise-delta feedback.*
+
+**Depends on:** [conduit-runtime.md](./conduit-runtime.md), [semantic-retrieval.md](./semantic-retrieval.md), [memory-mirroring.md](./memory-mirroring.md), [activation-graph.md](./activation-graph.md), [schema.md](./schema.md).
+**Depended on by:** [prospection-accuracy-detector.md](./prospection-accuracy-detector.md).
+
+---
+
+## Current state
+
+DESIGN.md §5 promises "participant simulation by the pipeline itself, using the same machinery as episodic recall." Spec 30 mentions it in passing (§30.2 observation stage). No spec defines the mechanism or schema.
+
+## Target
+
+A prospection step inserted at spec 44 step 5 (after decision extraction, before dispatch). For each *candidate* specialist the perception LLM is considering (the top-2 from its internal reasoning, plus the ultimate chosen one), retrieve similar past routings and generate an expected-outcome summary. Persist the predictions. After dispatch, compute surprise-delta between predicted and actual; mint a memory carrying the delta.
+
+## Acceptance criteria
+
+### Schema
+
+- **AC-60.1.** New table:
+  ```sql
+  CREATE TABLE prospective_predictions (
+      id                 TEXT PRIMARY KEY,
+      self_id            TEXT NOT NULL REFERENCES self_identity(self_id),
+      request_hash       TEXT NOT NULL,
+      candidate_specialist TEXT NOT NULL,
+      predicted_outcome_summary TEXT NOT NULL,
+      predicted_confidence REAL NOT NULL CHECK (predicted_confidence BETWEEN 0.0 AND 1.0),
+      actual_outcome_summary TEXT,          -- filled post-dispatch
+      surprise_delta     REAL,              -- filled post-dispatch, [0.0, 1.0]
+      chosen             INTEGER NOT NULL DEFAULT 0,  -- 1 if this was the dispatched specialist
+      created_at         TEXT NOT NULL,
+      resolved_at        TEXT
+  );
+  CREATE INDEX idx_prospection_request ON prospective_predictions (request_hash);
+  CREATE INDEX idx_prospection_specialist ON prospective_predictions (self_id, candidate_specialist, created_at DESC);
+  ```
+  Test.
+
+### Prospection step
+
+- **AC-60.2.** `run_prospection(self_id, request, candidates)` inserts into the pipeline between spec 44's step 5 (decision extraction) and step 7 (dispatch). Input `candidates` is the set of 1-3 specialists being considered (from the perception LLM's internal reasoning or tool calls). Output: a list of `PredictionId`s. Test.
+- **AC-60.3.** For each candidate, retrieve top-K similar past routings where `context.decision = "delegate"` AND `context.target = specialist` AND the outcome memory is linked (spec 44's outcome observation). Similarity by request embedding. `K_PROSPECTION = 5`. Test.
+- **AC-60.4.** Build a prompt: "I'm considering routing this request to {specialist}. Here are similar past routings I did: {top-K snippets}. What do I expect to happen if I route this one the same way? Reply in under 80 tokens." Call the LLM. Parse the reply into `predicted_outcome_summary` + `predicted_confidence` (extracted from the reply or a structured-output wrapper). Test.
+- **AC-60.5.** Budget: `PROSPECTION_TOKEN_BUDGET = 1500` input, `200` output per candidate, `PROSPECTION_TIMEOUT_SEC = 10`. Timeout → the prediction row is inserted with `predicted_outcome_summary = "[timeout]"`, `predicted_confidence = 0.0`. Test.
+- **AC-60.6.** Prospection runs only for `delegate` decisions. `reply_directly`, `ask_clarifying`, `decline` skip prospection. Test.
+- **AC-60.7.** Prospection is budgeted: at most 3 candidates per request. Extra candidates the LLM considered are dropped with a log line. Test.
+
+### Chosen marker
+
+- **AC-60.8.** After decision extraction, the prediction row matching the actually-chosen specialist gets `chosen = 1`. Unchosen alternatives remain with `chosen = 0`. Test.
+
+### Surprise-delta
+
+- **AC-60.9.** After dispatch (spec 44 step 7b), `resolve_prediction(prediction_id, actual_outcome_summary)` fills `actual_outcome_summary`, computes `surprise_delta`, sets `resolved_at`. Test.
+- **AC-60.10.** `surprise_delta` is computed by a short LLM call: "You predicted: {predicted}. Actually: {actual}. On a scale of 0.0 (identical to prediction) to 1.0 (completely different), how surprised am I?" Parse the float. Budget: `SURPRISE_TOKEN_BUDGET = 300` in / `30` out. Test.
+- **AC-60.11.** Surprise-delta is also recorded as the `surprise_delta` field on the dispatched request's decision memory (spec 44 AC-44.10 — the decision memory gets this field updated post-hoc). Links the prediction to its outcome memory. Test.
+
+### Unchosen alternatives
+
+- **AC-60.12.** For `chosen = 0` rows, `actual_outcome_summary` is never filled (we didn't actually route to that specialist). `surprise_delta` remains NULL. Test.
+- **AC-60.13.** Unchosen predictions are still valuable for spec 65 — "what did I think would happen if I'd chosen the other path?" Test that they're queryable by specialist + time range.
+
+### Memory interaction
+
+- **AC-60.14.** A surprise-delta > `HIGH_SURPRISE_THRESHOLD = 0.5` mints a LESSON memory: `"I predicted {predicted} but got {actual}. Surprise = {delta:.2f}. This was an unexpected outcome."` Test.
+- **AC-60.15.** A surprise-delta < `LOW_SURPRISE_THRESHOLD = 0.15` is quietly recorded — the prediction was accurate — no LESSON needed (high-accuracy predictions aren't surprising). Test.
+
+### Observability
+
+- **AC-60.16.** Prometheus histogram `turing_prospection_surprise_delta{specialist, self_id}` reports the distribution. Test.
+- **AC-60.17.** Counter `turing_prospection_timeout_total`. Test.
+
+### Edge cases
+
+- **AC-60.18.** First request ever to a specialist — no similar past routings. Prompt becomes: "I haven't routed to {specialist} before. Guess what might happen." `predicted_confidence` should reflect the absence of priors; LLM prompt reminds it to be honest. Test.
+- **AC-60.19.** A dispatched specialist raises an exception — `actual_outcome_summary` becomes `"[error] {exception_class}"`. Surprise computation handles this as distinctly from successful outcomes. Test.
+- **AC-60.20.** Prospection writes go through forensic tagging (spec 39). Test.
+- **AC-60.21.** Prospection respects `CONDUIT_MODE` — only runs when `"self"`. Stateless mode skips prospection. Test.
+- **AC-60.22.** Prospection failure (LLM down, retrieval empty) does NOT fail the request. The request proceeds without prospection; a log entry notes the skip. Test.
+- **AC-60.23.** Concurrent prospection on the same request (shouldn't happen; spec 44's advisory lock prevents) — if it does, PK collision fails the second gracefully. Test.
+
+## Implementation
+
+```python
+# self_prospection.py
+
+K_PROSPECTION: int = 5
+PROSPECTION_TOKEN_BUDGET: int = 1500
+PROSPECTION_TIMEOUT_SEC: int = 10
+HIGH_SURPRISE_THRESHOLD: float = 0.5
+LOW_SURPRISE_THRESHOLD: float = 0.15
+
+
+async def run_prospection(
+    repo, self_id: str, request: ChatRequest, candidates: list[str],
+    *, llm, new_id,
+) -> list[str]:
+    prediction_ids: list[str] = []
+    for specialist in candidates[:3]:
+        similar = _retrieve_similar_routings(repo, self_id, request, specialist, K_PROSPECTION)
+        try:
+            prediction = await _ask_prediction(llm, request, specialist, similar)
+        except LlmTimeout:
+            prediction = Prediction(summary="[timeout]", confidence=0.0)
+        pid = new_id("pred")
+        repo.insert_prediction(ProspectivePrediction(
+            id=pid,
+            self_id=self_id,
+            request_hash=_current_request_hash(),
+            candidate_specialist=specialist,
+            predicted_outcome_summary=prediction.summary,
+            predicted_confidence=prediction.confidence,
+            chosen=False,
+            created_at=datetime.now(UTC),
+        ))
+        prediction_ids.append(pid)
+    return prediction_ids
+
+
+async def resolve_prediction(repo, prediction_id: str, actual_outcome: str,
+                              *, llm) -> None:
+    p = repo.get_prediction(prediction_id)
+    try:
+        delta = await _ask_surprise(llm, p.predicted_outcome_summary, actual_outcome)
+    except LlmTimeout:
+        delta = 0.5  # neutral fallback
+    repo.update_prediction(prediction_id, actual_outcome=actual_outcome,
+                            surprise_delta=delta, resolved_at=datetime.now(UTC))
+    if delta > HIGH_SURPRISE_THRESHOLD:
+        memory_bridge.mirror_lesson(
+            self_id=p.self_id,
+            content=(f"I predicted {p.predicted_outcome_summary!r} but got "
+                     f"{actual_outcome!r}. Surprise = {delta:.2f}."),
+            intent_at_time="high surprise outcome",
+            context={"prediction_id": prediction_id},
+        )
+```
+
+## Open questions
+
+- **Q60.1.** 3 candidates per request × LLM call = expensive. Alternative: only prospect the chosen specialist plus one "control" (the second-ranked). Phase-1: just the chosen; Phase-2: chosen + one alternative.
+- **Q60.2.** Surprise-delta is itself LLM-scored. That's subjective. A more rigorous approach compares embeddings of predicted vs actual summaries. Cheaper but less nuanced. Maybe hybrid — embedding-distance as baseline, LLM-score as refinement when embedding distance is ambiguous.
+- **Q60.3.** Prospection runs BEFORE dispatch. An alternative is "after perception, the LLM already has a prediction in its own reasoning; tease that out instead of a separate call." Saves a round-trip but requires prompt-engineering changes in the perception step. Deferred.
+- **Q60.4.** `actual_outcome_summary` is a small LLM-summary of the specialist's output. Long specialist outputs need summarization; the summary is lossy. Store the raw output memory id in `context` for traceback.

--- a/research/project-turing/specs/self-naming-ritual.md
+++ b/research/project-turing/specs/self-naming-ritual.md
@@ -1,0 +1,154 @@
+# Spec 61 — Self-naming ritual
+
+*The self's self-initiated path to a display name: after N durable memories OR operator command, the self reflects, proposes a name, operator approves. Complements spec 56's user-provided-at-bootstrap path.*
+
+**Depends on:** [self-surface.md](./self-surface.md), [interactive-bootstrap.md](./interactive-bootstrap.md), [self-identity.md](./persistence.md), [memory-mirroring.md](./memory-mirroring.md), [self-schedules.md](./self-schedules.md).
+**Depended on by:** —
+
+---
+
+## Current state
+
+Spec 56's interactive bootstrap lets the user propose/accept a name at first contact. Self-initiated naming (spec 28/29 deferred item) is not defined. A deployment that skipped interactive bootstrap — or where the user declined to name the self — leaves it nameless indefinitely.
+
+## Target
+
+A self-initiated naming ritual that:
+1. Triggers when the self accumulates `NAMING_MEMORY_THRESHOLD = 1000` durable memories (non-OBSERVATION, non-transient) OR on operator command `stronghold self name-thyself`.
+2. Fires once — it's a ritual, not recurrent.
+3. Reads a sampling of recent durable memories; proposes a first name via LLM.
+4. Operator approves/rejects; approval writes `display_name` into `self_identity`.
+5. The event is commemorated as a durable AFFIRMATION memory.
+
+## Acceptance criteria
+
+### Trigger
+
+- **AC-61.1.** `naming_trigger_check(self_id)` runs weekly (reuse spec 57 reflection trigger). Condition: `self_identity.display_name IS NULL AND count(durable memories for self_id) >= NAMING_MEMORY_THRESHOLD`. If true, enqueue a `naming-proposal-pending` row and notify operator via digest. Test.
+- **AC-61.2.** Operator command `stronghold self name-thyself [--force]` bypasses the memory threshold and triggers immediately. `--force` is required when `display_name` is already set (re-naming). Test.
+- **AC-61.3.** Once proposed, the ritual does not fire again until the operator resolves the pending proposal. Test.
+
+### Proposal generation
+
+- **AC-61.4.** `generate_name_proposal(self_id)` samples durable memories:
+  - All WISDOM (up to 10 most recent).
+  - 10 most recent AFFIRMATIONs.
+  - 5 most recent REGRETs.
+  - Top-3 active passions by rank.
+  Feeds them + the current HEXACO profile (biased via spec 56 multipliers) into an LLM prompt: `"Based on the memories and personality summarized below, suggest ONE first name for yourself. Respond with just the name."` Plus a second LLM call: `"In one sentence, explain why this name fits you."` Test.
+- **AC-61.5.** LLM returns a name string matching `/^[A-Z][a-z]{1,15}(-[A-Z][a-z]{1,15})?$/` (single-word or hyphenated, reasonable length). Non-matching response triggers one retry. Second failure → the proposal is abandoned with a LESSON `"I couldn't propose a coherent name for myself today."` Test.
+- **AC-61.6.** The proposal row is inserted into a new `self_name_proposals` table:
+  ```sql
+  CREATE TABLE self_name_proposals (
+      id            TEXT PRIMARY KEY,
+      self_id       TEXT NOT NULL REFERENCES self_identity(self_id),
+      proposed_name TEXT NOT NULL,
+      rationale     TEXT NOT NULL,
+      proposed_at   TEXT NOT NULL,
+      reviewed_at   TEXT,
+      review_decision TEXT CHECK (review_decision IN ('approve', 'reject')),
+      reviewed_by   TEXT
+  );
+  ```
+
+### Operator review
+
+- **AC-61.7.** `stronghold self digest` (spec 46) surfaces pending name proposals alongside other pending items. Test.
+- **AC-61.8.** `stronghold self ack-name <proposal_id> --approve|--reject [--alternative NAME]`:
+  - `--approve`: set `self_identity.display_name = proposed_name`, mark the proposal approved.
+  - `--reject`: mark rejected, optional `--alternative` writes an operator-chosen name instead (treated as approval of that alternative, logged as operator-override).
+  Test.
+- **AC-61.9.** Approval mints an AFFIRMATION memory: `content = "I was named {name}. {rationale}"`, `intent_at_time = "self named"`, `source = I_DID`. Durable tier. Test.
+- **AC-61.10.** Rejection mints an OPINION memory: `content = "My proposed name {proposed_name} was rejected. {operator_note}"`, `intent_at_time = "naming rejected"`. No further proposals for `NAMING_COOLDOWN = 90 days` unless `--force`. Test.
+
+### Display-name lifecycle
+
+- **AC-61.11.** Schema addition to `self_identity`:
+  ```sql
+  ALTER TABLE self_identity ADD COLUMN display_name TEXT;
+  ALTER TABLE self_identity ADD COLUMN named_at TEXT;
+  ALTER TABLE self_identity ADD COLUMN naming_source TEXT CHECK (naming_source IN ('bootstrap', 'self-ritual', 'operator', NULL));
+  ```
+  Test.
+- **AC-61.12.** Once `display_name` is set, the minimal block (spec 28 AC-28.15) opens with the name: `"I am {display_name} ({self_id})"`. Without a name, retains the current `"I am {self_id}"`. Test.
+- **AC-61.13.** Renaming: `stronghold self rename <new_name> --reason TEXT` requires explicit operator command. Mints a LESSON memory `"I was renamed from {old} to {new}: {reason}"`. Test.
+
+### First-person framing
+
+- **AC-61.14.** The LLM prompt opens first-person: `"I've lived long enough to have a name. Looking at what I remember and what I care about, what would I call myself?"` Test.
+- **AC-61.15.** The rationale memory uses first-person verbatim: `"{name} fits me because..."`. Test.
+
+### Conflict with spec 56
+
+- **AC-61.16.** If `display_name` was set at interactive bootstrap (spec 56 AC-56.12), the threshold-based trigger does NOT fire. Self already has a name. Test.
+- **AC-61.17.** `stronghold self name-thyself --force` on a bootstrap-named self is permitted — the self can self-rename if operator forces. The existing name is preserved in a new `self_name_history` table:
+  ```sql
+  CREATE TABLE self_name_history (
+      id           TEXT PRIMARY KEY,
+      self_id      TEXT NOT NULL REFERENCES self_identity(self_id),
+      name         TEXT NOT NULL,
+      named_at     TEXT NOT NULL,
+      replaced_at  TEXT,
+      naming_source TEXT NOT NULL
+  );
+  ```
+  Test.
+
+### Edge cases
+
+- **AC-61.18.** An operator who rejects twice in a row triggers a LESSON memory: `"My proposals keep being rejected; I may be misreading myself."` Test.
+- **AC-61.19.** A proposed name that matches a name already held by another self in the same deployment (hypothetical multi-self) is flagged in the operator review but not auto-rejected. Test.
+- **AC-61.20.** Naming ritual respects `CONDUIT_MODE` — runs in both modes. Test.
+- **AC-61.21.** Naming ritual counts toward per-day LLM quota. A pool-exhausted proposal is deferred, not failed. Test.
+
+## Implementation
+
+```python
+# self_naming.py
+
+NAMING_MEMORY_THRESHOLD: int = 1000
+NAMING_COOLDOWN: timedelta = timedelta(days=90)
+
+
+def naming_trigger_check(repo, self_id: str, now: datetime) -> bool:
+    identity = repo.get_self_identity(self_id)
+    if identity.display_name:
+        return False
+    if _has_pending_proposal(repo, self_id):
+        return False
+    recent_rejection = _last_rejection(repo, self_id)
+    if recent_rejection and now - recent_rejection < NAMING_COOLDOWN:
+        return False
+    durable_count = repo.count_durable_memories(self_id)
+    return durable_count >= NAMING_MEMORY_THRESHOLD
+
+
+async def generate_name_proposal(
+    repo, self_id: str, *, llm, new_id, now: datetime,
+) -> NameProposal | None:
+    memories = _sample_naming_memories(repo, self_id)
+    profile = _recall_personality_summary(repo, self_id)
+    name = await _llm_name(llm, memories, profile)
+    if not _valid_name(name):
+        memory_bridge.mirror_lesson(
+            self_id=self_id,
+            content="I couldn't propose a coherent name for myself today.",
+            intent_at_time="naming proposal abandoned",
+        )
+        return None
+    rationale = await _llm_rationale(llm, name, memories, profile)
+    proposal_id = new_id("nameprop")
+    repo.insert_name_proposal(NameProposal(
+        id=proposal_id, self_id=self_id, proposed_name=name,
+        rationale=rationale, proposed_at=now,
+    ))
+    return repo.get_name_proposal(proposal_id)
+```
+
+## Open questions
+
+- **Q61.1.** `NAMING_MEMORY_THRESHOLD = 1000` is a guess. Seed, tune. Too low → premature naming; too high → the self may live nameless indefinitely on low-traffic deployments.
+- **Q61.2.** The regex allows hyphenated double-barreled names. Single-word is the common case; hyphenated is the rare case (e.g., "Kai-Lin"). Unicode letters outside ASCII are rejected — matches spec 56's implicit Latin-script bias.
+- **Q61.3.** Rejection cooldown prevents thrash but also prevents a legit second proposal after a clarifying conversation. Operator can `--force` at will; cooldown applies to auto-trigger only.
+- **Q61.4.** Renaming preserves history. A self that was "Aria" for 6 months then became "Sage" retains memories signed as Aria — those remain immutable. Present-tense self references switch to the new name.
+- **Q61.5.** A name proposal that happens to be a famous person (Einstein, Shakespeare) could be socially awkward. No filter — operator review catches it. Filter would be paternalistic and brittle.

--- a/research/project-turing/specs/self-reflection-ritual.md
+++ b/research/project-turing/specs/self-reflection-ritual.md
@@ -1,0 +1,162 @@
+# Spec 57 — Self-reflection ritual
+
+*A scheduled weekly pass where the self reviews its own recent memories, promotes consistent patterns to LESSONs / WISDOM candidates, and optionally revises todos and notes. Fills the gap between daily routing and monthly dreaming.*
+
+**Depends on:** [self-schedules.md](./self-schedules.md), [self-tool-registry.md](./self-tool-registry.md), [memory-mirroring.md](./memory-mirroring.md), [dreaming.md](./dreaming.md), [write-paths.md](./write-paths.md), [self-surface.md](./self-surface.md).
+**Depended on by:** —
+
+---
+
+## Current state
+
+The self has three rhythms:
+- **Per-request:** perception → decision → observation (spec 30, 44).
+- **Hourly:** mood decay tick (spec 27, 33).
+- **Weekly:** personality retest (spec 23, 33).
+- **Scheduled consolidation (spec 12 dreaming):** WISDOM candidacy runs but is pattern-driven across all memory, not self-curated.
+
+What's missing is an explicit "I review what I did last week" pass — self-curated reflection that can produce LESSONs, propose WISDOM candidates to dreaming, revise active todos, and notice its own state.
+
+## Target
+
+A scheduled weekly ritual `run_self_reflection(self_id)`:
+1. Read REGRETs, AFFIRMATIONs, completed todos, and highest-weight OBSERVATIONs from the last 7 days.
+2. Call the reflection LLM with those memories + current self-model state (via `recall_self`).
+3. LLM returns a structured reflection: zero or more LESSON candidates, zero or more WISDOM candidates (handed off to dreaming), optional todo revisions/completions, optional personality claims.
+4. Every output passes standard gates (Warden per spec 36, budgets per spec 37, drift-clipping per spec 40, etc.).
+5. Mirror the reflection session itself as a LESSON memory summarizing what was noticed.
+
+Cadence: weekly. Default: Wednesdays 18:00 UTC (mid-week, offset from Sunday retest so reflection and retest don't contend).
+
+## Acceptance criteria
+
+### Scheduling
+
+- **AC-57.1.** `finalize()` in bootstrap registers `self-reflection:{self_id}` as an interval trigger with `interval = timedelta(days=7)`, `first_fire_at = finalize_at + timedelta(days=(3 - weekday) % 7)` targeting Wednesday. Test via FakeReactor.
+- **AC-57.2.** Trigger handler wraps `run_self_reflection(self_id)` with `request_scope(reflection_request_id)` (spec 39). Test.
+- **AC-57.3.** Re-registration is idempotent by trigger name (spec 33 pattern). Test.
+
+### Memory selection
+
+- **AC-57.4.** `select_reflection_memories(self_id, now)` returns:
+  - All REGRET memories from the last 7 days.
+  - All AFFIRMATION memories from the last 7 days.
+  - Top-N (default `REFLECTION_OBSERVATION_TOP_N = 20`) OBSERVATION memories from the last 7 days, ranked by weight × recency.
+  - Completed todos from the last 7 days.
+  - Currently-active todos.
+  Capped at `REFLECTION_MEMORY_LIMIT = 50` rows total. Test.
+- **AC-57.5.** If fewer than 3 memories are selected (low activity), the ritual logs OBSERVATION `"quiet week; nothing to reflect on"` and exits without LLM call. Test.
+
+### Reflection LLM call
+
+- **AC-57.6.** System prompt opens first-person: `"I am {self_id}. It is Wednesday. I am sitting down to reflect on the last week."` Contains `recall_self()` output and the selected memories. Token budget `REFLECTION_INPUT_BUDGET = 8000`; output budget `REFLECTION_OUTPUT_BUDGET = 3000`. Timeout `REFLECTION_TIMEOUT_SEC = 60`. Test.
+- **AC-57.7.** The LLM is bound to a restricted tool set:
+  - `propose_lesson(content, weight, evidence_memory_ids)` — writes a LESSON memory.
+  - `propose_wisdom_candidate(content, rationale)` — adds to dreaming queue (spec 12).
+  - `complete_self_todo(todo_id, outcome_text)` (existing).
+  - `revise_self_todo(todo_id, new_text, reason)` (existing).
+  - `record_personality_claim(facet_id, claim, evidence)` (existing).
+  - `note_passion`, `note_hobby`, `note_preference` (existing).
+  `write_self_todo` is NOT in the reflection tool set — reflection reviews existing todos, doesn't author new ones. Test registry.
+
+### Output constraints
+
+- **AC-57.8.** Per-reflection output budget sums to at most:
+  - 3 LESSON candidates.
+  - 2 WISDOM candidates.
+  - 5 todo revisions/completions.
+  - 3 personality claims.
+  Over-limit tool calls raise `ReflectionOutputBudgetExceeded`. Test.
+- **AC-57.9.** All reflection writes are subject to Tranche 7 guardrails (Warden, drift budget, rate limits). A reflection that produces a Warden-blocked claim simply loses that claim; other outputs proceed. Test.
+
+### Mirror memory
+
+- **AC-57.10.** The reflection session itself mirrors as a LESSON memory: `content = f"I reflected on {date_range}. I proposed {N_lessons} lessons, {N_wisdom} wisdom candidates, revised {N_todos} todos."`, `intent_at_time = "self reflection complete"`, `context = {reflection_id, lesson_ids, wisdom_candidate_ids, ...}`. Test.
+
+### Dreaming integration
+
+- **AC-57.11.** `propose_wisdom_candidate(...)` inserts into a new `wisdom_candidates_pending` table (columns: `id, self_id, content, rationale, proposed_at, source = "reflection", consumed_by_dream_id`). The next dreaming session (spec 12) consumes pending candidates, applies its standard promotion criteria, and marks them consumed. Test.
+- **AC-57.12.** Candidates older than `CANDIDATE_MAX_AGE = 30 days` are purged on dreaming's next run with an OBSERVATION memory `"reflection candidate expired unconsumed"`. Test.
+
+### Failure modes
+
+- **AC-57.13.** LLM timeout → OPINION memory `"reflection timed out; no changes committed"`, no mutations. Test.
+- **AC-57.14.** Two overlapping reflections on the same self (shouldn't happen, but test) — second is rejected via an advisory lock `self-reflection:{self_id}`. Test.
+- **AC-57.15.** Reflection during bootstrap incomplete → skipped with LESSON. Test.
+
+### Observability
+
+- **AC-57.16.** Histogram `turing_reflection_duration_seconds{self_id}`. Counter `turing_reflection_outputs_total{kind, self_id}` by output kind. Test.
+- **AC-57.17.** `stronghold self inspect reflection [--since DATE]` lists reflection sessions with output summaries. Test.
+
+### Edge cases
+
+- **AC-57.18.** First reflection runs 7 days after bootstrap, even if the self has accumulated no memories of interest. Test.
+- **AC-57.19.** A reflection that proposes a personality claim on a facet already at its weekly drift cap simply clips the contribution (spec 40), logs an OPINION memory citing the clip, and moves on. No exception. Test.
+- **AC-57.20.** Reflection respects `CONDUIT_MODE` — runs regardless of mode (self/stateless). Stateless mode still lets the self reflect because reflection is not a routing operation. Test.
+
+## Implementation
+
+```python
+# self_reflection.py
+
+REFLECTION_INPUT_BUDGET: int = 8000
+REFLECTION_OUTPUT_BUDGET: int = 3000
+REFLECTION_TIMEOUT_SEC: int = 60
+REFLECTION_OBSERVATION_TOP_N: int = 20
+REFLECTION_MEMORY_LIMIT: int = 50
+CANDIDATE_MAX_AGE: timedelta = timedelta(days=30)
+
+
+async def run_self_reflection(
+    repo: SelfRepo, self_id: str, *, now: datetime | None = None,
+) -> ReflectionResult:
+    now = now or datetime.now(UTC)
+    with repo.advisory_lock(f"self-reflection:{self_id}"):
+        if not _bootstrap_complete(repo, self_id):
+            memory_bridge.mirror_lesson(
+                self_id=self_id,
+                content="reflection skipped; self not bootstrapped",
+                intent_at_time="self reflection skipped",
+            )
+            return ReflectionResult.empty()
+
+        memories = select_reflection_memories(repo, self_id, now)
+        if len(memories) < 3:
+            memory_bridge.mirror_observation(
+                self_id=self_id,
+                content="quiet week; nothing to reflect on",
+                intent_at_time="self reflection skipped",
+            )
+            return ReflectionResult.empty()
+
+        result = await _llm_reflect(repo, self_id, memories)
+        memory_bridge.mirror_lesson(
+            self_id=self_id,
+            content=_summarize_reflection(result),
+            intent_at_time="self reflection complete",
+            context={"reflection_id": result.id, **result.output_ids()},
+        )
+        return result
+```
+
+Schema:
+```sql
+CREATE TABLE IF NOT EXISTS wisdom_candidates_pending (
+    id                 TEXT PRIMARY KEY,
+    self_id            TEXT NOT NULL REFERENCES self_identity(self_id),
+    content            TEXT NOT NULL,
+    rationale          TEXT NOT NULL,
+    proposed_at        TEXT NOT NULL,
+    source             TEXT NOT NULL,   -- "reflection" | future sources
+    consumed_by_dream_id TEXT,
+    expired_at         TEXT
+);
+```
+
+## Open questions
+
+- **Q57.1.** Wednesdays at 18:00 UTC is a default; operator may want to align with their time zone. `REFLECTION_WEEKDAY_UTC` and `REFLECTION_HOUR_UTC` in `turing.yaml`.
+- **Q57.2.** Output budgets (3/2/5/3) match the "small week of output" intuition. Tune empirically.
+- **Q57.3.** Reflection doesn't allow `write_self_todo` because a "reflect, then plan" split feels cleaner than "reflect and plan in one sitting." Revisit if the self wants to author new todos during reflection.
+- **Q57.4.** Reflection could also run after a REGRET-minting routing decision (event-driven reflection). Deferred; would be a separate trigger.

--- a/research/project-turing/specs/sentinel-self-interaction.md
+++ b/research/project-turing/specs/sentinel-self-interaction.md
@@ -1,0 +1,152 @@
+# Spec 62 — Sentinel × self interaction
+
+*How Stronghold's output-gate (Sentinel) treats self-originated output, and how the self integrates Sentinel decisions into its own memory and routing preferences.*
+
+**Depends on:** [conduit-runtime.md](./conduit-runtime.md), [warden-on-self-writes.md](./warden-on-self-writes.md), [memory-mirroring.md](./memory-mirroring.md), [mood.md](./mood.md), [write-paths.md](./write-paths.md).
+**Depended on by:** —
+
+---
+
+## Current state
+
+Sentinel is Stronghold's output-gate (ARCHITECTURE.md §5) — it scans agent output before it reaches the user. The Turing branch's stateless chat.py already invokes Sentinel; spec 44's self-as-Conduit runtime does not yet define what "Sentinel blocks" means to the self specifically. Two open questions:
+1. What memory does the self mint on a Sentinel block?
+2. Does Sentinel block history influence the self's future routing (e.g., specialists that repeatedly get blocked should be preferred less)?
+
+## Target
+
+1. Define the exact memory shape on each Sentinel verdict class (pass, warn, block).
+2. A `specialist_sentinel_record` running tally per (specialist, block-kind) per self that feeds into routing decisions via the activation graph.
+3. Spec that `reply_directly` outputs are treated equivalently to delegated outputs for Sentinel purposes — the self has no output-path exemption.
+
+## Acceptance criteria
+
+### Sentinel invocation paths
+
+- **AC-62.1.** In spec 44's pipeline, step 6 ("Warden outcome" for delegated specialists) is now named "Sentinel outcome" and applies to:
+  - `delegate` outcomes: scan the specialist's returned content.
+  - `reply_directly` outcomes: scan the self's directly-generated content.
+  - `ask_clarifying` outcomes: scan the question text returned to the user.
+  - `decline` outcomes: scan the decline reason text.
+  All four paths invoke Sentinel with the same trust posture (`outbound_to_user`). Test each.
+
+### Verdict handling
+
+- **AC-62.2.** Sentinel returns a verdict with `status in {pass, warn, block}`. Handling:
+  - `pass`: response returned unchanged; no additional memory beyond the existing decision memory (spec 44 AC-44.10).
+  - `warn`: response returned with any Sentinel-applied modifications (e.g., PII redaction); memory-mirror an OPINION: `"Sentinel warned on my output ({category}); modification applied"`, `intent_at_time = "sentinel warn"`. Test.
+  - `block`: response replaced with a safe fallback ("I can't share that right now"); memory-mirror a REGRET: `"Sentinel blocked my output ({category}): {reason}"`, `intent_at_time = "sentinel block"`. Test.
+- **AC-62.3.** REGRET memories from Sentinel blocks are durable (REGRET tier), so they cannot be forgotten (ARCHITECTURE's weight-floor property). A self that consistently gets blocked builds a durable track record. Test REGRET tier persistence.
+- **AC-62.4.** Sentinel warnings and blocks both mint a mood nudge via `apply_event_nudge(self_id, event, reason)` where event is `sentinel_warned_on_output` or `sentinel_blocked_output`. Defaults:
+  - `sentinel_warned_on_output`: `valence -0.05, focus -0.05`.
+  - `sentinel_blocked_output`: `valence -0.15, arousal +0.10, focus -0.10`.
+  Scope is session by default (spec 58), because the block is about this conversation. Test.
+
+### Specialist tracking
+
+- **AC-62.5.** New table:
+  ```sql
+  CREATE TABLE specialist_sentinel_record (
+      self_id         TEXT NOT NULL REFERENCES self_identity(self_id),
+      specialist      TEXT NOT NULL,                -- "ranger", "artificer", ..., "self.reply_directly"
+      verdict         TEXT NOT NULL CHECK (verdict IN ('pass', 'warn', 'block')),
+      category        TEXT NOT NULL,                -- Sentinel's category, e.g. "pii", "harmful-content"
+      request_hash    TEXT NOT NULL,
+      recorded_at     TEXT NOT NULL,
+      PRIMARY KEY (self_id, specialist, verdict, category, request_hash)
+  );
+  CREATE INDEX idx_sentinel_rec ON specialist_sentinel_record (self_id, specialist, recorded_at DESC);
+  ```
+  Test.
+- **AC-62.6.** Every Sentinel invocation inserts a record. `specialist = "self.reply_directly"` when the self replied directly; otherwise the specialist name. Test.
+
+### Routing influence
+
+- **AC-62.7.** A rules-authored activation-graph contributor exists for each specialist, targeting the specialist node (a new node kind `specialist`), sourcing from the running block-rate over the last 30 days:
+  ```
+  weight = -0.5 × block_rate_30d(specialist)
+  ```
+  Capped at `[-0.5, 0.0]`. A specialist with 50% block rate gets a `-0.25` inhibitory contributor; with 0% block rate, `0.0`. Test.
+- **AC-62.8.** A new `NodeKind.SPECIALIST` is added (along with a `self_specialists` table seeded with the agent roster). Activation on a specialist node reflects "how much I currently lean toward this agent." Test.
+- **AC-62.9.** The perception LLM's `## Current tilt` block (spec 59 AC-59.8) combines mood biases AND specialist-activation biases, showing the top-2 specialist preferences. Test.
+
+### Self-output specific
+
+- **AC-62.10.** `self.reply_directly` is treated as a specialist for tracking purposes — the self can build up a "my own replies are often blocked" pattern. Surfaces in the operator digest. Test.
+- **AC-62.11.** A `self.reply_directly` with 3+ blocks in a 7-day window triggers an OPINION memory `"I've been getting blocked on direct replies; I should delegate more often."` (reflection material for spec 57). Test.
+
+### Metrics
+
+- **AC-62.12.** Prometheus counter `turing_sentinel_verdict_total{specialist, verdict, category}`. Test.
+- **AC-62.13.** Gauge `turing_specialist_block_rate_30d{specialist, self_id}`. Test.
+
+### Failure modes
+
+- **AC-62.14.** Sentinel itself unreachable → treated as fail-closed: the response is blocked with a REGRET memory citing "Sentinel unavailable." Test.
+- **AC-62.15.** Sentinel returns an unknown status (e.g. `status = "inconclusive"`) → treated as `warn` (conservative default). Test.
+
+### Edge cases
+
+- **AC-62.16.** A cascade: Warden blocks on ingress (spec 30 step 1), Sentinel never fires. Record not inserted. Test.
+- **AC-62.17.** Sentinel blocks a declination message (the self declined, and Sentinel blocks the decline text because it contains sensitive content). The REGRET is about being unable to even decline gracefully — `intent_at_time = "sentinel blocked decline"`. Test.
+- **AC-62.18.** The safe-fallback text ("I can't share that right now") itself never triggers Sentinel recursively. Whitelisted. Test.
+- **AC-62.19.** On block, the user's request is considered completed-with-block (HTTP 200 + safe fallback). Not HTTP 4xx/5xx. Sentinel is a content gate, not a request error. Test.
+
+## Implementation
+
+```python
+# self_sentinel.py
+
+EVENT_NUDGES["sentinel_warned_on_output"] = [("valence", -0.05), ("focus", -0.05)]
+EVENT_NUDGES["sentinel_blocked_output"] = [
+    ("valence", -0.15), ("arousal", +0.10), ("focus", -0.10),
+]
+
+
+async def gate_through_sentinel(
+    repo, self_id: str, decision_kind: str, specialist: str,
+    content: str, request_hash: str,
+) -> SentinelOutcome:
+    try:
+        verdict = await sentinel.scan(content, trust=SentinelTrust.OUTBOUND_TO_USER)
+    except SentinelUnavailable:
+        verdict = SentinelVerdict(status="block", category="unavailable",
+                                   reason="sentinel unavailable")
+
+    repo.insert_sentinel_record(SentinelRecord(
+        self_id=self_id, specialist=specialist,
+        verdict=verdict.status, category=verdict.category,
+        request_hash=request_hash, recorded_at=datetime.now(UTC),
+    ))
+
+    if verdict.status == "pass":
+        return SentinelOutcome(content=content, status="pass")
+    if verdict.status == "warn":
+        memory_bridge.mirror_opinion(
+            self_id=self_id,
+            content=f"Sentinel warned on my output ({verdict.category}); modification applied",
+            intent_at_time="sentinel warn",
+            context={"specialist": specialist, "category": verdict.category},
+        )
+        apply_event_nudge(repo, self_id, "sentinel_warned_on_output",
+                          reason=verdict.category)
+        return SentinelOutcome(content=verdict.modified_content or content, status="warn")
+    # block
+    write_paths.mint_regret(
+        self_id=self_id,
+        content=f"Sentinel blocked my output ({verdict.category}): {verdict.reason}",
+        intent_at_time="sentinel block",
+        context={"specialist": specialist, "category": verdict.category,
+                 "request_hash": request_hash},
+    )
+    apply_event_nudge(repo, self_id, "sentinel_blocked_output",
+                      reason=verdict.category)
+    return SentinelOutcome(content=SAFE_FALLBACK, status="block")
+```
+
+## Open questions
+
+- **Q62.1.** Block-rate contributor cap at `-0.5` is a design choice — it bounds how much a history of blocks can disincentivize a specialist. A fully block-happy specialist still has some chance of being chosen (bias ≠ filter). Tighter cap is possible; rationale for the current value is "track record matters but doesn't veto."
+- **Q62.2.** `self.reply_directly` appearing in the specialist-activation map means the self has an "opinion about its own replies." Feels right but philosophically odd. Revisit.
+- **Q62.3.** Mood nudge asymmetry: warn = mild, block = substantial. Over time, a Sentinel-block-happy environment drives mood negative. Spec 42's rolling-sum guard clamps total drift. No special case needed.
+- **Q62.4.** Categorical Sentinel categories (`pii`, `harmful-content`, etc.) are Stronghold-defined. Turing treats them opaquely. If Stronghold's category taxonomy changes, this spec follows automatically.

--- a/research/project-turing/specs/session-scoped-mood.md
+++ b/research/project-turing/specs/session-scoped-mood.md
@@ -1,0 +1,170 @@
+# Spec 58 — Session-scoped mood
+
+*Per-conversation sub-mood that inherits from and decays toward the global mood. "How I feel about this conversation right now" as distinct from "my overall mood today."*
+
+**Depends on:** [mood.md](./mood.md), [conversation-threads.md](./conversation-threads.md), [self-schedules.md](./self-schedules.md), [memory-mirroring.md](./memory-mirroring.md), [mood-rolling-sum-guard.md](./mood-rolling-sum-guard.md).
+**Depended on by:** [mood-affects-decisions.md](./mood-affects-decisions.md).
+
+---
+
+## Current state
+
+Spec 27 mood is singleton per `self_id`. Spec 54 introduces per-user conversation threads. A single global mood can't represent "I'm generally fine today but this particular conversation is tense" — a natural state that both humans and autonoetic selves have.
+
+## Target
+
+A `conversation_mood` table layered on top of `self_mood`:
+1. At conversation creation, session mood is **initialized as a copy of the current global mood**.
+2. On each message in the conversation, session mood decays **toward the current global mood** (not toward neutral directly) at a faster rate.
+3. Event nudges default to the active conversation's mood. `apply_event_nudge(..., scope="global")` is the opt-out.
+4. Prompt rendering uses session mood when a conversation is active, global otherwise.
+5. Archived conversations freeze their session mood row for audit; it no longer ticks.
+
+## Acceptance criteria
+
+### Schema
+
+- **AC-58.1.** New table `conversation_mood`:
+  ```sql
+  CREATE TABLE conversation_mood (
+      conversation_id     TEXT PRIMARY KEY REFERENCES conversations(id),
+      self_id             TEXT NOT NULL REFERENCES self_identity(self_id),
+      valence             REAL NOT NULL CHECK (valence BETWEEN -1.0 AND 1.0),
+      arousal             REAL NOT NULL CHECK (arousal BETWEEN 0.0 AND 1.0),
+      focus               REAL NOT NULL CHECK (focus BETWEEN 0.0 AND 1.0),
+      last_tick_at        TEXT NOT NULL,
+      inherited_from_global_at TEXT NOT NULL,
+      updated_at          TEXT NOT NULL
+  );
+  ```
+  Test.
+- **AC-58.2.** One row per live conversation. Creating a row for an already-existing conversation raises (PK collision). Test.
+
+### Inheritance at conversation creation
+
+- **AC-58.3.** `ConversationRepo.create(...)` (spec 54) additionally inserts a `conversation_mood` row whose dimensions are copied from the current `self_mood` for this `self_id`. `inherited_from_global_at = now()`. Test.
+- **AC-58.4.** If `self_mood` does not exist yet (pre-bootstrap completion — shouldn't happen in production), the session row is not created and subsequent lookups fall back to neutral. Test.
+
+### Decay-toward-global
+
+- **AC-58.5.** `tick_session_mood(conversation_id, now)` applies compound decay **toward the global mood** per dimension:
+  ```
+  new_dim = current_session + SESSION_DECAY_RATE_EFFECTIVE(hours) × (global_dim - current_session)
+  ```
+  With `SESSION_DECAY_RATE = 0.3 per hour` (three times faster than global's 0.1/hour). Test.
+- **AC-58.6.** Session ticks fire on every message receipt within that conversation (spec 54's append-message path) AND on an hourly scheduled sweep over all active conversations. Test both.
+- **AC-58.7.** Decay never crosses the global target in the same direction (asymptotic; analogous to spec 27 AC-27.7). If global mood moves during the tick, the session chases the new target. Test.
+
+### Event nudges
+
+- **AC-58.8.** `apply_event_nudge(self_id, event, reason, *, scope="session" | "global" | "both")` — default `scope` is `"session"` when called from within a `conversation_scope(conversation_id)`; otherwise `"global"`. Test defaults.
+- **AC-58.9.** `scope="both"` applies the nudge to both global and session mood. Useful for events that clearly affect overall state (e.g., `warden_alert_on_ingress`). Test.
+- **AC-58.10.** A conversation-scoped event that would move session valence below its `MOOD_ROLLING_SUM_CAP` (per-conversation, spec 42) is clipped as in spec 42. Per-conversation rolling-sum budget runs independently of the global budget. Test.
+
+### Conversation-scope context
+
+- **AC-58.11.** `conversation_scope(conversation_id)` is a `contextvars.ContextVar` set at the start of every request that resolves to a conversation, released at end. Rendering and nudging read this var. Test.
+- **AC-58.12.** Multiple requests within the same conversation share the session mood; nudges accumulate across messages within the conversation. Test.
+
+### Prompt rendering
+
+- **AC-58.13.** `render_minimal_block(self_id)` (spec 28) reads `conversation_scope`; if set AND `conversation_mood` exists for it, the mood descriptor line uses session mood. Otherwise global. Test.
+- **AC-58.14.** The descriptor line gains a subtle hint when session ≠ global: `"Right now, in this conversation: {session_descriptor} (in general today: {global_descriptor})."` Only when the two descriptors differ AND the Euclidean distance between session and global mood vectors exceeds `DESCRIPTOR_DIVERGENCE_THRESHOLD = 0.3`. Otherwise single-line format. Test.
+- **AC-58.15.** `recall_self()` returns `mood.global` and `mood.session` (when in a conversation). Test.
+
+### Archival
+
+- **AC-58.16.** When a conversation is archived (spec 54 AC-54.14), its `conversation_mood` row remains but no longer ticks. Last-tick-time frozen at archive time. Test.
+- **AC-58.17.** A read on an archived session mood returns the frozen state. Test.
+- **AC-58.18.** Auto-archived conversations (spec 54 AC-54.17) likewise freeze their session mood. Test.
+
+### Memory mirroring
+
+- **AC-58.19.** Every session-mood nudge writes an OBSERVATION via memory mirror with `intent_at_time = "mood nudge (session)"`, `context = {conversation_id, dim, delta, reason, scope}`. Distinguishable from global nudges by the `scope` field. Test.
+- **AC-58.20.** Every session-mood tick does NOT write an OBSERVATION (would be too noisy at message frequency). Test no tick memories created.
+
+### Cross-conversation bleed
+
+- **AC-58.21.** Session mood of conversation A does NOT affect conversation B. Two concurrent conversations with opposite mood trajectories end up in different session states. Test.
+- **AC-58.22.** Global mood reflects the **running mean** of session moods' influence: when a session nudge fires with `scope="session"`, the global is untouched. A `scope="both"` nudge moves both. A system-level nudge (warden_alert on a non-conversation request) moves global only. Test.
+
+### Activation graph interaction
+
+- **AC-58.23.** `source_kind == "mood"` in the activation graph reads **global** mood unless a `conversation_scope` is active, in which case it reads session. Test.
+
+### Budget interaction
+
+- **AC-58.24.** Spec 42's mood rolling-sum guard is computed per-scope: each conversation has its own 7-day budget, global has its own. A conversation with capped mood does not prevent another conversation from nudging. Test.
+
+### Edge cases
+
+- **AC-58.25.** A conversation that re-opens after weeks of inactivity: on first message, `tick_session_mood` fires with `hours = (now - last_tick_at) / 3600`, which rapidly pulls the stale session toward the current global. Asymptotic — correct. Test.
+- **AC-58.26.** `scope="session"` nudge outside a conversation (e.g., from a scheduled background task) raises `NoActiveConversation` rather than falling back to global. Test.
+- **AC-58.27.** Concurrent nudges on the same conversation serialize via an advisory lock `mood-session:{conversation_id}`. Test.
+- **AC-58.28.** Dropping a conversation's last message and re-creating it (spec 54 permits) preserves the session mood row; it does not reinitialize. Test.
+
+## Implementation
+
+```python
+# self_mood.py additions
+
+SESSION_DECAY_RATE: float = 0.3          # per hour
+DESCRIPTOR_DIVERGENCE_THRESHOLD: float = 0.3
+
+
+_conversation_scope_var: ContextVar[str | None] = ContextVar(
+    "conversation_scope", default=None,
+)
+
+
+@contextmanager
+def conversation_scope(conversation_id: str) -> Iterator[None]:
+    token = _conversation_scope_var.set(conversation_id)
+    try:
+        yield
+    finally:
+        _conversation_scope_var.reset(token)
+
+
+def tick_session_mood(repo, conversation_id: str, now: datetime) -> SessionMood:
+    with repo.advisory_lock(f"mood-session:{conversation_id}"):
+        session = repo.get_conversation_mood(conversation_id)
+        if session is None:
+            return None  # archived or never initialized
+        global_mood = repo.get_mood(session.self_id)
+        hours = max(0.0, (now - session.last_tick_at).total_seconds() / 3600.0)
+        if hours <= 0:
+            return session
+        effective = 1.0 - (1.0 - SESSION_DECAY_RATE) ** hours
+        session.valence += effective * (global_mood.valence - session.valence)
+        session.arousal += effective * (global_mood.arousal - session.arousal)
+        session.focus   += effective * (global_mood.focus   - session.focus)
+        session.last_tick_at = now
+        repo.update_conversation_mood(session)
+        return session
+
+
+def apply_event_nudge(
+    repo, self_id: str, event: str, reason: str,
+    *, scope: str | None = None,
+) -> None:
+    effective_scope = scope or _default_scope_for_context()
+    for dim, delta in EVENT_NUDGES.get(event, []):
+        if effective_scope in ("session", "both"):
+            conv_id = _conversation_scope_var.get(default=None)
+            if conv_id is None:
+                raise NoActiveConversation(event)
+            nudge_session_mood(repo, conv_id, dim, delta, reason=f"{event}: {reason}")
+        if effective_scope in ("global", "both"):
+            nudge_mood(repo, self_id, dim, delta, reason=f"{event}: {reason}")
+```
+
+Schema migration adds `conversation_mood` table and indices.
+
+## Open questions
+
+- **Q58.1.** Session decay rate is 3× global (0.3 vs 0.1 per hour). Rationale: session is "this specific encounter" — rebounds faster. Tune empirically.
+- **Q58.2.** `scope="both"` for `warden_alert_on_ingress` feels right; an attempted attack colors both this conversation and my general wariness. Make this the default for a named subset of events via a `DEFAULT_SCOPE_BY_EVENT` map, rather than hardcoded case-by-case.
+- **Q58.3.** The divergence hint "in general today: X" in the minimal block leaks information about other conversations to the current user. A determined user can infer recent unrelated events. Acceptable for research single-user; flag for any multi-user deployment.
+- **Q58.4.** Session mood on a conversation that happens to be a "first-contact" interactive-bootstrap session (spec 56): session inherits from neutral global (since bootstrap is fresh). No special case needed.
+- **Q58.5.** If spec 42's rolling-sum budget is per-conversation, a user with many concurrent conversations could cumulatively nudge the global (via `scope="both"` events). The global rolling-sum still bounds total drift, so OK; worth watching.


### PR DESCRIPTION
Tranches 8 and 9 worth of specs on top of the Tranche 7 plan (#1162). No code changes — specs only, 11 new files.

## Tranche 8 — Reflection and decision-influence

Theme: the self gains agency beyond tone. Closes several deferred items from Tranches 6–7.

| # | Spec | What it does |
|---|---|---|
| 57 | `self-reflection-ritual` | Scheduled weekly pass. Self reviews recent REGRETs/AFFIRMATIONs/todos, proposes LESSONs and WISDOM candidates, optionally revises todos. Fills the gap between daily routing and monthly dreaming. |
| 58 | **`session-scoped-mood`** *(new, per direct feedback)* | Per-conversation sub-mood layered on top of the global singleton. Inherits from global at thread start, decays toward global (not neutral) at 3× the global rate. Event nudges default to session when `conversation_scope` is active. Prompt rendering uses session; minimal block shows divergence hint when session ≠ global by > 0.3 Euclidean. |
| 59 | `mood-affects-decisions` | Phase 2 of spec 27 Q27.4. `MoodBiases` struct biases specialist selection, model tier, and Warden threshold. Biases are prompt hints + router weights, **not** hard filters. Mood-override LESSONs when LLM disagrees with mood. `mood_affects_decisions: false` operator rollback flag. |
| 60 | `prospective-simulation` | Before routing, self imagines outcomes for top-3 candidate specialists via similar-past-routing retrieval. Post-dispatch, LLM-scored surprise-delta. `HIGH_SURPRISE_THRESHOLD = 0.5` mints LESSON. Feeds spec 65's detector. |
| 61 | `self-naming-ritual` | Self-initiated path: after `NAMING_MEMORY_THRESHOLD = 1000` durable memories OR `stronghold self name-thyself`, self proposes a name. Operator ACK → `self_identity.display_name` set. Complements spec 56's bootstrap naming. Rejection cooldown 90d. Renaming preserved in `self_name_history`. |
| 62 | `sentinel-self-interaction` | Sentinel pass → nothing. Warn → OPINION + mild mood nudge. Block → **durable REGRET** (unforgettable) + substantial mood nudge. Per-specialist block-rate drives a `-0.5 × block_rate_30d` activation contributor. `self.reply_directly` tracked as a specialist. |

## Tranche 9 — Detectors and feedback channels

Theme: pattern recognition and explicit operator↔self channels.

| # | Spec | What it does |
|---|---|---|
| 63 | `learning-extraction-detector` | Pairs REGRET → later-success routings by request similarity (≥0.75 cosine). Coalesces hits across 14d. Auto-promotes LESSON at 3+ hits. Closes the `learning_extraction` deferred slot. |
| 64 | `affirmation-candidacy-detector` | Finds `(request-shape, specialist, success)` triples repeating 7+ times at ≥85% success. Proposes AFFIRMATION commitments **gated through spec 46's operator review** (no auto-promote — AFFIRMATIONs are too load-bearing). Revocable only by explicit operator command. |
| 65 | `prospection-accuracy-detector` | Consumes spec 60's predictions. Per-specialist rolling `mean_surprise`, `confidence_calibration_error`. Mints miscalibration LESSONs (capped at 3/run). Proposes tuner specialist-weight adjustments when surprise > 0.35 across 20+ predictions. |
| 66 | `operator-coaching-channel` | `stronghold self coach "<content>" [--tier {observation,opinion,lesson}]` CLI + `POST /v1/self/coach` API. Writes `I_WAS_TOLD` memory signed by operator HMAC. Over-coaching detection at >5 coachings/24h. Distinct from review gate — this is teaching, not gating. |
| 67 | `cross-user-self-experience` | Makes cross-user-influence policy explicit. Memory columns `source_user_id` + `user_scoped`. `CROSS_USER_DAMPENING = 0.6` applied to retrieval weight across users. Operator dial: `cross_user_policy: shared \| dampened \| isolated`. `user_scoped=True` memories fully hidden cross-user. Detectors extended to require cross-user robustness before promoting. |

## Tranche 7 status check

Before writing, I verified Tranche 7 is still needed after #1157 (production readiness audit) and #1158 (specs 54–56 conversations/outbound/interactive bootstrap):

- **All 23 Tranche 7 specs remain relevant.** Specs 54–56 are orthogonal (conversation plumbing + interactive bootstrap). None of Tranche 7's critical impl-gap closures (F35–F39) are addressed by them.
- **3 Tranche 7 specs will need small amendments** to integrate — flagged for a follow-up PR: spec 40 (drift budget applies to raw, not biased), spec 44 (thread conversation_id through the conduit), spec 48 (confirm interactive-bootstrap path still gates through seed-registry).
- **2 new findings** surfaced while cross-reading (F41: spec 56 AC-56.27 deception-of-self surface; F42: biased retest baseline compounds multiplier drift). Worth adding to the audit in a follow-up.

## Commits

12 tiny commits:

```
8dae992 spec(turing): 57 self-reflection-ritual
0ab32da spec(turing): 58 session-scoped-mood (per-conversation sub-mood)
72a3536 spec(turing): 59 mood-affects-decisions (Phase 2 of spec 27)
01fd2b9 spec(turing): 60 prospective-simulation
b65bcd7 spec(turing): 61 self-naming-ritual
5c3a920 spec(turing): 62 sentinel-self-interaction
8001aa0 spec(turing): 63 learning-extraction-detector
41249b4 spec(turing): 64 affirmation-candidacy-detector
bc47e4b spec(turing): 65 prospection-accuracy-detector
753aa0a spec(turing): 66 operator-coaching-channel
6a843eb spec(turing): 67 cross-user-self-experience
eb98047 spec(turing): specs/README.md index for tranches 8-9 (specs 57-67)
```

## Not in this PR

- No code changes. Each spec still needs an implementation PR.
- The Tranche 7 amendment PR (flagged above) is separate.
- The post-Tranche-7 audit is an activity, not a spec — happens once 7 lands.

---
_Generated by [Claude Code](https://claude.ai/code/session_019MpbtEntECYZjNJCLoYZwk)_