### PR TITLE
docs: catalog code smells, dead code, untested modules, and broken areas

### DIFF
--- a/docs/code-smell-catalog-2026-04-23.md
+++ b/docs/code-smell-catalog-2026-04-23.md
@@ -264,12 +264,195 @@ Only two survive in `src/`:
 
 ---
 
+## 7. Second-pass findings
+
+### 7.1 Unawaited background tasks (concrete async bug)
+
+`src/stronghold/api/routes/mason.py:70`
+
+```python
+asyncio.create_task(_dispatch_mason(issue))
+```
+
+The task reference is thrown away. Python docs explicitly warn: "Save a reference to the result of `create_task()`, to avoid a task disappearing mid-execution." Under GC pressure the dispatch can be collected. Fix: keep a module-level `set()` of running tasks and add/discard via `add_done_callback`.
+
+Other `create_task` call sites are safe — `events.py:159` holds `task`, `agents_stream.py:113` polls `task.done()`, `mcp/registries.py:204–206` `gather`s the tasks, `orchestrator/engine.py:106` keeps a worker list, `api/app.py:58` holds `reactor_task`.
+
+### 7.2 Deprecated `asyncio.get_event_loop()` in an async function
+
+`src/stronghold/mcp/deployer.py:56, 215, 237, 259, 284`
+
+Five copies of:
+
+```python
+return await asyncio.get_event_loop().run_in_executor(None, self._deploy_sync, server)
+```
+
+Inside an already-running coroutine `get_event_loop()` is deprecated for this purpose since 3.10 and may raise `DeprecationWarning` on 3.12. Correct: `asyncio.get_running_loop()` or simpler `asyncio.to_thread(self._deploy_sync, server)`.
+
+### 7.3 Naive `datetime.now()` without tz
+
+`src/stronghold/events.py:137` — `now = datetime.now()` inside the reactor tick. The reactor uses this for time-triggered firings (line 212 compares `now.strftime("%H:%M")` to `spec.at_time`). On a container running UTC this is fine; on any host/DST-aware timezone the trigger times drift. Make it `datetime.now(timezone.utc)` and document that `spec.at_time` is UTC.
+
+### 7.4 Resource leak: `MCPDeployerClient._client` never closed
+
+`src/stronghold/sandbox/deployer.py:37–40, 156–157`
+
+```python
+def __init__(self, base_url: str = "") -> None:
+    ...
+    self._client = httpx.AsyncClient(base_url=self._base_url, timeout=30.0)
+
+async def close(self) -> None:
+    pass
+```
+
+Constructor opens an `httpx.AsyncClient`; `close()` is a no-op. Connections and sockets leak for the lifetime of the DI container. Replace `close()` with `await self._client.aclose()` or switch to per-call `async with httpx.AsyncClient(...)`.
+
+### 7.5 Two `httpx.AsyncClient()` calls with no timeout
+
+`src/stronghold/api/routes/marketplace.py:136, 187` — both use `httpx.AsyncClient()` with defaults. Every other call site in the tree sets an explicit timeout (5–600s). A slow external registry hangs the request until the upstream ASGI timeout fires.
+
+### 7.6 `inspect.signature().bind_partial` as a regression guard
+
+`tests/security/test_security_audit_2026_03_30.py:74, 96, 179, 213, 233, 284, 972` and `tests/api/test_issue_620.py:57`, `tests/security/test_audit_regression.py:970`
+
+These tests bind a call signature to assert that a parameter (e.g. `org_id`) is or isn't present. The `docs/test-quality-remediation-plan.md` flags this file's 20 tests as a rewrite target. These signature-shape tests pass even if the implementation body is a stub, so they guard the API contract but not the behavior.
+
+### 7.7 Duplicated auth-header parsing across 17 route files
+
+`auth_header = request.headers.get("authorization")` (or `"Authorization"`) is hand-rolled in **17 route modules** (33 occurrences): `tasks.py`, `schedules.py`, `models.py`, `traces.py`, `webhooks.py`, `agents_stream.py`, `status.py`, `mcp.py`, `admin.py`, `gate_endpoint.py`, `chat.py`, `skills.py`, `sessions.py`, `dashboard.py`, `profile.py`, `agents.py`, `marketplace.py`. Some use `"authorization"`, some use `"Authorization"` (HTTP headers are case-insensitive in Starlette so this works, but the style drift signals copy-paste rather than a shared helper). Bundle into a single dependency/middleware — it already exists as `api/middleware/auth.py` (which §3 notes has no test coverage).
+
+### 7.8 Personal data in migration 011
+
+`migrations/011_seed_admin.sql` hardcodes `blakematthews@agentstronghold.com` with `["admin", "org_admin", "team_admin", "user"]` roles. Every fresh Stronghold deployment — including third-party installs of an Apache-licensed OSS project — creates this specific user as an admin on first boot. Whether or not the `ON CONFLICT DO NOTHING` clause saves existing installs, this should be gated behind an env flag (`STRONGHOLD_DEV_SEED=1`) or moved into `deploy/` fixtures, not shipped as a forward migration.
+
+### 7.9 Production Dockerfile runs as root and ships tests + dev deps
+
+`Dockerfile`:
+
+- No `USER` directive → runs as root. `Dockerfile.worker` correctly creates a `stronghold` user and drops to it; the main API image doesn't.
+- `COPY tests/ tests/` and installs `.[dev]` (pytest, ruff, mypy, bandit) into the runtime image. The comment explains "Mason's workspace validation depends on the dev quality tools existing" — so this is intentional, but it means the attack surface of the API container includes the test suite and every dev dependency. Consider splitting Mason's quality-gate path into its own image or running Mason in a sibling pod.
+- `RUN mkdir -p /workspace && chmod 777 /workspace` — world-writable workspace. Needed for Mason worktrees, but combined with root-as-default this lets any in-pod compromise rewrite Mason's work area.
+
+### 7.10 docker-compose.yml uses static weak credentials
+
+`docker-compose.yml` sets `POSTGRES_USER=stronghold`, `POSTGRES_PASSWORD=stronghold`. Intended for local dev, but `.env.example` doesn't call out that these must be changed, and the compose file binds Postgres ports (check full file before deploy). Add a banner comment and point at `deploy/` for hardened configs.
+
+### 7.11 `unittest.mock` used in 34 test files despite CLAUDE.md rule
+
+CLAUDE.md §Testing Rules §1 explicitly forbids `unittest.mock` — "All protocols have fakes in `tests/fakes.py` — use those, not `unittest.mock`." Yet 34 files import `MagicMock` / `AsyncMock` / `@patch` (107 raw occurrences). Representative offenders: `tests/test_new_modules_2.py`, `tests/test_coverage_final.py`, `tests/api/test_marketplace_coverage.py`, `tests/api/test_mason_routes.py`, `tests/persistence/test_pool.py`. This is the same cluster the test-quality plan calls out as "over-mock" — a linter rule (`ruff` custom rule or `grep` in CI) could prevent regression.
+
+### 7.12 `assert resp.status_code == 200` with no body inspection
+
+Grep for `assert.*is not None$` returns **211 matches** across the test tree, and the existing test-quality audit counts 65 "status-only" tests that check HTTP status but never look at the body. Same backlog, but worth quantifying: 211+65 = ~276 asserts that could pass against a completely broken implementation as long as it returned a 200 with *any* object.
+
+### 7.13 Timeout constants scattered without a central config
+
+25+ literal timeouts across the tree: `5.0`, `10.0`, `15.0`, `30.0`, `60.0`, `180.0`, `300.0`, `600.0`. `tools/github.py` alone uses `30.0` on eleven calls and `60.0` on one (comment-add), with no obvious reason for the split. Cache TTLs are also hardcoded: `_CLAUDE_CACHE_TTL = 300.0` (`skills/connectors.py:39`), `_CACHE_TTL_FULL = 900.0` (`api/routes/mason.py:193`), the Redis prompt-cache TTL `300` baked into `container.py:300`. Pull into `config/defaults.py` or typed config so operators can tune without code edits.
+
+### 7.14 Hash choice: intentional MD5 with `usedforsecurity=False`
+
+`src/stronghold/memory/learnings/embeddings.py:88` — `hashlib.md5(text.encode("utf-8"), usedforsecurity=False).digest()`. The `# noqa: S324` and the surrounding docstring justify it as a deterministic fake-embedding seed for tests. Not a bug, but worth flagging so a future refactor doesn't reach for a "more secure" hash and break reproducibility.
+
+### 7.15 `asyncio.get_event_loop()` in `mcp/deployer.py` is also swallowed by try/except
+
+Three of the five `get_event_loop()` sites (§7.2) are paired with the `B110` try/except/pass at lines 270 and 275 (§4.4). If the executor raises because the loop is mis-acquired, the exception is suppressed — double-layered silence.
+
+### 7.16 `_FakeToolDispatcher`, `_FakeToolRegistry`, `_FakeToolDef` in tests
+
+`tests/test_coverage_final.py:29, 43, 56` — three private fakes defined inline in a test file. CLAUDE.md §Testing Rules §1 says "All protocols have fakes in `tests/fakes.py` — use those." Either promote these fakes to `tests/fakes.py` or fold them into existing ones. Probable cause: the coverage push ran out of time to refactor.
+
+### 7.17 Hash-based LLM classifier fail-open still warrants double-checking
+
+§1.2 already covers the Warden L3 fail-open. Worth cross-referencing `src/stronghold/security/warden/llm_classifier.py` (the file that currently returns `label="safe"` on exception). A broken LLM endpoint turns the strongest warden layer into a no-op — and the tests confirm this is live behavior.
+
+### 7.18 Duplicate `_check_csrf` between `admin.py` and `marketplace.py`
+
+`src/stronghold/api/routes/admin.py:17–35` and `src/stronghold/api/routes/marketplace.py:79–97` are byte-for-byte identical (`diff` returns empty). A CSRF fix in one won't propagate to the other. Hoist into `api/middleware/` or `security/`. While there, check for other near-duplicates between these two files — they also share a `_require_admin` / auth-header-parse shape (§7.7).
+
+### 7.19 Inline `os.environ.get()` in 12 spots bypasses the config layer
+
+CLAUDE.md §Build Rule 4 requires config through env vars or K8s secrets, but those values should flow through `config/`. Direct `os.environ.get()` calls live in:
+
+- `api/app.py:47, 53` — `STRONGHOLD_MAX_CONCURRENCY`, `STRONGHOLD_DISABLE_REACTOR_AUTOSTART`
+- `api/routes/mason.py:369` — `GITHUB_WEBHOOK_SECRET` (security-critical!)
+- `triggers.py:218`, `tools/github.py:129–134, 193`, `tools/workspace.py:29, 112` — GitHub auth material
+- `sandbox/deployer.py:21, 126` — deployer URL + MCP namespace
+
+The webhook-secret read is the most worrying: a deploy that sets the secret in `config/` (where operators expect it to live per the architecture doc) will still let every webhook through because `mason.py` only looks at `os.environ`. Centralize in `config/env.py` with typed accessors.
+
+### 7.20 Docstring/implementation drift in `Conduit._apply_tenant_policy`
+
+`src/stronghold/conduit.py:55–60` — function takes `_tenant_id: str | None = None` but is only called as `_apply_tenant_policy(current_tier)` at line 95 (no tenant ID passed, and the parameter is named with leading underscore to signal it's ignored anyway). Meanwhile, `determine_execution_tier`'s docstring (lines 67–77) lists "3. tenant policy" as part of the "override stack". The stack is advertised but not wired. Either delete step 3 from the docstring, or pass the tenant in and implement.
+
+### 7.21 `asyncio.sleep(2)` and `asyncio.sleep(1)` hardcoded in Artificer
+
+`src/stronghold/agents/artificer/strategy.py:80` and `:213`. No comment on why. Reviewing the file shows these are cooldowns between plan/execute/retry phases — legitimate, but they belong in config alongside §7.13's other timeout constants.
+
+### 7.22 Module-level mutable caches in `mason.py`
+
+`src/stronghold/api/routes/mason.py:192` — `_issues_cache: dict[str, Any] = {"data": None, "fetched_at": 0.0}` shared across requests with no lock. Lines 206–246 read, check TTL, and write back. Under concurrent requests from different users, two reads at `t_read` both see an expired entry, both fetch from GitHub, and the last writer wins. Usually benign for read caches (duplicated work, same data), but any field added later that needs read-modify-write will race.
+
+Same pattern in `_state` at lines 40–48 for router/reactor/container handles, though those are write-once at startup.
+
+### 7.23 `_DELIST_THRESHOLD` used inline at 4 sites
+
+`src/stronghold/api/routes/marketplace.py:35, 49, 51, 74, 350` — five references to the same `= 3` constant. Fine today. Worth noting together with the other config-that-should-be-config items in §7.13. Same for `_MAX_TIMESTAMP_AGE_SECONDS = 300` in `api/routes/webhooks.py:26, 34`.
+
+### 7.24 Inconsistent error-to-HTTP mapping across routes
+
+Only `api/routes/agents.py:117–118` (and chat.py at 133) map `QuotaExhaustedError → 429`. `api/routes/admin.py`, `api/routes/marketplace.py`, and `api/routes/skills.py` hit the same code paths (they all go through `container.route_request` or similar) but don't catch the quota exception. A request at the quota wall returns 500 from those routes even though 429 is the correct answer. Shared middleware for business-error → HTTP mapping would fix this alongside §7.7 auth-header parsing.
+
+### 7.25 No upper bound on user-text before Warden scan / LLM dispatch
+
+`src/stronghold/api/routes/chat.py:58–69` reconstructs `user_text` from the message history and passes it into `route_request` → Warden scan → LLM. Warden's short-circuit heuristics cap certain windows (§1.2 H3 shows the gap bug) but the outer pipeline itself never rejects over-length content. A 5 MB `messages[0].content` fans out to Warden regex passes and then LiteLLM. Cap early (e.g. 100K chars) with a 413.
+
+### 7.26 SSE stream leaks background task on client disconnect
+
+`src/stronghold/api/routes/agents_stream.py:113–143` — the generator starts `task = asyncio.create_task(run_agent())` and polls `task.done()` in a loop. If the client disconnects mid-stream, the generator stops iterating but the task keeps running until agent completion — consuming LLM tokens, holding DB connections, and posting updates to an unread queue. Wrap the generator body in `try/finally: task.cancel()` or use `contextlib.aclosing`.
+
+### 7.27 Response-body shape not validated after `status_code == 200`
+
+`src/stronghold/api/routes/marketplace.py:246, 258` — code accepts any `200` and assumes the body is parseable. If the upstream registry returns HTML (503 page served with status 200, common behind proxies) or a malformed JSON, parsing crashes into the generic exception handler and the user sees a 500. Cheap fix: verify `Content-Type: application/json` before parsing.
+
+### 7.28 Pagination boilerplate duplicated between admin and marketplace routes
+
+`api/routes/admin.py` (learnings list, users list, strikes list) and `api/routes/marketplace.py` (GitHub issues fetch) share a query-limit-offset-cache-TTL shape with no abstraction. Low-priority consolidation target; flagged here so the next pagination change doesn't create a third variant.
+
+### 7.29 Status callback may pass tokens through to the queue
+
+`src/stronghold/api/routes/mason.py:95–136` — the `_log` helper forwards every status string to `queue.add_log(issue_num, msg)`. `msg` originates from `status_callback` calls inside `route_request` and agent strategies; any strategy that interpolates error detail from an HTTP client (e.g. 401 body, upstream auth header) would land raw in a durable queue. Audit callers of `status_callback` to ensure the string is sanitized first, or add a redaction pass in `add_log`.
+
+### 7.30 Tautological loop-then-assert in `test_new_modules_2.py`
+
+`tests/test_new_modules_2.py:179, 196, 218, 240, 254, 272, 287, 304, 317, 337, 353, 372, 390` — repeated pattern:
+
+```python
+found = None
+for trigger in container.reactor._triggers:
+    if trigger.spec.name == "foo":
+        found = trigger
+assert found is not None
+```
+
+The assertion only fires if the loop executed AND matched — but if trigger registration breaks silently, the dict is empty and `found` stays `None`, which would correctly fail. What doesn't fail: if the loop matches any random trigger, the assertion still passes without checking the trigger's content. The inverted pattern is the smell: rather than asserting a known name exists, iterate the reactor's public `get(name)` API.
+
+---
+
 ## Suggested priority order for remediation
 
 1. **Flip the seven `BUG CONFIRMED` security tests** (§1.2). These are active vulnerabilities with fixes pre-written as test contracts.
-2. **Fix the `Intent.tier` type leak** (§1.1) and the two `Any`-return regressions (§1.4, §1.5).
-3. **Un-swallow `ImportError` in `factory.py`** (§2.2) — silent agent-strategy failures will bite hard in production.
-4. **Decompose `Conduit.route_request`** (§4.1) and split `api/routes/admin.py` (§4.3) before they accrete more logic.
-5. **Close the 28 untested modules** (§3) prioritizing `middleware/auth`, `middleware/tracing`, `warden/patterns`, `memory/scopes`.
-6. **Execute the existing test-quality plan** (§4.9) — the work is scoped; this catalog just confirms it's still needed.
-7. **Implement or delete the Forge / Scribe / Warden-at-Arms stubs** (§2.1). If they're near-term on the roadmap, promote to skeletons with failing tests; otherwise drop them so the architecture doc stops overselling.
+2. **Fix the `Intent.tier` type leak** (§1.1), the `Any`-return regressions (§1.4, §1.5), the unawaited-task bug (§7.1), and deprecated `get_event_loop()` (§7.2).
+3. **Close resource leaks**: `MCPDeployerClient._client` (§7.4), SSE task on disconnect (§7.26).
+4. **Un-swallow `ImportError` in `factory.py`** (§2.2) — silent agent-strategy failures will bite hard in production.
+5. **Move `GITHUB_WEBHOOK_SECRET` (and the other 11 env reads) behind `config/`** (§7.19) — a webhook with no secret validation is a remote-execution backdoor.
+6. **Remove the hardcoded admin email from migration 011** (§7.8) — this is cosmetic until someone forks, then it's surprising.
+7. **Fix the root-user prod Dockerfile and the tests-in-prod bundling** (§7.9).
+8. **Decompose `Conduit.route_request`** (§4.1) and split `api/routes/admin.py` (§4.3) before they accrete more logic.
+9. **Hoist duplicated helpers**: `_check_csrf` (§7.18), auth-header parsing (§7.7), Warden scan pattern (§7.14 referenced by subagent), error-to-HTTP mapping (§7.24).
+10. **Add an input-length cap on user text** (§7.25) — cheap DoS guard.
+11. **Close the 28 untested modules** (§3) prioritizing `middleware/auth`, `middleware/tracing`, `warden/patterns`, `memory/scopes`.
+12. **Execute the existing test-quality plan** (§4.9) — the work is scoped; this catalog just confirms it's still needed.
+13. **Implement or delete the Forge / Scribe / Warden-at-Arms stubs** (§2.1). If they're near-term on the roadmap, promote to skeletons with failing tests; otherwise drop them so the architecture doc stops overselling.
+14. **Centralize timeouts / TTLs / thresholds** (§7.13, §7.21, §7.23) as the maintainability base-rate improvement.

--- a/docs/code-smell-catalog-2026-04-23.md
+++ b/docs/code-smell-catalog-2026-04-23.md
@@ -1,0 +1,275 @@
+# Stronghold Code-Smell Catalog — 2026-04-23
+
+Scan of `src/stronghold/` (257 files, ~21.8K LOC) plus `tests/` (339 files). Tools used: `ruff`, `mypy --strict`, `bandit -l`, `vulture`, `radon cc/mi`, plus targeted grep passes. Test suite was not executed (Python 3.11 in this environment; project requires 3.12+).
+
+This catalog is diagnostic only. Remediation is deferred — each entry is a pointer, not a ticket.
+
+---
+
+## 0. Top-line counts
+
+| Signal                                   | Count   |
+|------------------------------------------|---------|
+| `ruff check` findings                    | 0       |
+| `mypy --strict` errors                   | 295 (56 files)¹ |
+| `bandit -l` findings                     | 27      |
+| `vulture` ≥80% confidence findings       | 16      |
+| Source modules with no test-import       | 28      |
+| `except Exception`-catching blocks       | 96      |
+| Lazy imports marked `noqa: PLC0415`      | 158     |
+| `typing.Any` annotations                 | 139     |
+| TODO/FIXME markers in production code    | 2       |
+| `pytest.xfail(strict=False)` tests       | 6       |
+
+¹ Most mypy errors are environment-only (`fastapi`, `httpx`, `jwt`, `argon2` stub lookups) that a real CI venv resolves. The non-stub errors are called out in §2.
+
+---
+
+## 1. Broken / buggy code
+
+### 1.1 Real type error in `conduit.py` (mypy, non-stub)
+
+`src/stronghold/conduit.py:112`
+
+```python
+current_tier: str = ...
+return replace(intent, tier=current_tier)    # Intent.tier is Literal["P0"..."P5"]
+```
+
+`Intent.tier` is `Literal["P0","P1","P2","P3","P4","P5"]` but `current_tier` is typed plain `str`. `dataclasses.replace` accepts any value at runtime, so a typo in `_apply_tenant_policy` (lines 55–60, currently a no-op) or an unexpected agent `priority_tier` would produce an `Intent` with an invalid tier literal that downstream code uses unchecked.
+
+### 1.2 Known security bugs documented as tests
+
+`tests/security/test_security_audit_2026_03_30.py` contains seven **inverted** asserts — the test passes only while the bug is still live. They are *contracts for a fix*, not regressions:
+
+| Line | Bug summary                                                                                          |
+|------|------------------------------------------------------------------------------------------------------|
+| 160  | Upsert conflict key lacks `org_id` → cross-tenant overwrite possible                                |
+| 349  | Empty caller `org_id` returns an org-scoped agent                                                    |
+| 392  | `org_id` containing `/` enables prefix-collision access across orgs                                  |
+| 441  | Warden scan window gap (bytes 10240..len-2048) lets injections through                               |
+| 485  | Warden L3 LLM classifier returns `label="safe"` on exception (fail-open)                             |
+| 726  | Code prefix in first 200 chars bypasses full scan                                                    |
+
+These are **known broken behaviors in production code** — the test file calls them "BUG CONFIRMED". Each one needs its fix shipped before the matching assert is flipped.
+
+### 1.3 Unused `type: ignore` in `mcp/deployer.py:35`
+
+Mypy reports `Unused "type: ignore" comment`. The ignore is stacked on a `kubernetes` import which then fails with `import-not-found` — the existing ignore doesn't cover the right error code. Either the ignore comment is stale (fix by removing) or the code assumed a different kubernetes stub package was pinned.
+
+### 1.4 `Any` leaking through `LiteLLMClient`
+
+`src/stronghold/api/litellm_client.py:121,132` — two methods declared as returning `dict[str, Any] | Exception` actually `return <something>` whose type is `Any`, defeating the union. Mypy: `Returning Any from function declared to return "dict[str, Any] | Exception"`.
+
+### 1.5 `Any` leaking through `MCPOAuthStore`
+
+`src/stronghold/mcp/oauth/store.py:21,25,30` — three functions annotated `-> str` / `-> bool` return `Any` from argon2 calls with no cast. These affect OAuth token handling so the missing typing is worth closing.
+
+---
+
+## 2. Dead / stub code
+
+### 2.1 Three agent strategies are single-line docstring stubs
+
+ARCHITECTURE.md documents these as first-class agents, but the implementation is absent:
+
+| File                                                       | LOC | Content                 |
+|------------------------------------------------------------|-----|-------------------------|
+| `src/stronghold/agents/forge/strategy.py`                  | 1   | `"""Forge agent…"""`    |
+| `src/stronghold/agents/warden_at_arms/strategy.py`         | 1   | `"""Warden-at-Arms…"""` |
+| `src/stronghold/agents/scribe/strategy.py`                 | 1   | `"""Scribe agent…"""`   |
+
+`Artificer` is real (248 LOC). Anything that tries to `create_agents(...)` for Forge/Scribe/Warden-at-Arms and reach a strategy will crash or silently fall back — see §2.2.
+
+### 2.2 `factory.py` swallows `ImportError` on every strategy registration
+
+`src/stronghold/agents/factory.py:196–228` wraps each `register_strategy(...)` in `try/except ImportError: pass`. If any strategy module has a bug that manifests as `ImportError` (typo, circular import, missing dep), the registration silently no-ops. `create_agents()` then builds an agent whose strategy is `None`, and the failure only surfaces at `agent.handle()` with a confusing `NoneType` error — nowhere near the real cause. Either let `ImportError` propagate or log with the module name at WARNING.
+
+### 2.3 Orphaned diagnostic artifact
+
+`src/stronghold/agents/strategies/builders_learning.py:116–126` builds a "diagnostic artifact" dict into `_` so ruff F841 stays quiet, with the comment `TODO: wire to orchestrator`. The dict is constructed every call, logged only as a constant string `"Frank diagnostic produced"`, then discarded. Either wire it or delete the dead construction.
+
+### 2.4 Vulture ≥80%-confidence dead items (16)
+
+Mostly unused exception-unpack tuples (`exc_tb`), unused dataclass args surfaced as "unused variable", and a handful of assign-and-forget locals:
+
+- `src/stronghold/agents/auditor/checks.py:320` — `commit_count` (100%)
+- `src/stronghold/protocols/agent_pod.py:60,88,89,91,109,110` — unused positional fields
+- `src/stronghold/protocols/data.py:30`, `memory.py:83`, `mcp.py:70`, `secrets.py:56,79`
+- `src/stronghold/tracing/{noop,phoenix_backend}.py` — `exc_tb` unused in `__aexit__`
+- `src/stronghold/tools/decorator.py:22` — `required_permissions` assigned, never read
+
+These are near-certainly real (protocol arg placeholders, `exc_tb` idiom). The auditor `commit_count` at line 320 is worth a second look — it's the only 100%-confident one that sits in branching logic.
+
+(Vulture at 60% confidence emits 467 findings — dominated by FastAPI route handlers reached via decorators, which the tool misses. Noise.)
+
+### 2.5 Module stubs in `config/` and `tracing/`
+
+`config/defaults.py`, `config/env.py`, `tracing/prompts.py`, `tracing/trace.py`, `tracing/arize.py` have zero test imports (§3). They may still be referenced by production code, but nothing locks down their shape — they're "written once, never re-entered".
+
+---
+
+## 3. Untested modules
+
+Detected by grepping `tests/` for `from <module>` / `import <module>` — **28 source modules have zero test references.** Grouped by subsystem:
+
+| Subsystem   | Modules                                                                                                    |
+|-------------|------------------------------------------------------------------------------------------------------------|
+| persistence | `pg_audit`, `pg_outcomes`, `pg_sessions`                                                                   |
+| tracing     | `prompts`, `trace`, `arize`                                                                                |
+| config      | `defaults`, `env`                                                                                          |
+| protocols   | `spec`, `llm`                                                                                              |
+| security    | `warden/patterns`                                                                                          |
+| api         | `routes/conductor`, `middleware/tracing`, `middleware/auth`                                                |
+| builders    | `runtime`, `orchestrator`, `services`                                                                      |
+| agents      | `streaming`, `cache`, `importer`, `identity`, `registry`, `exporter`, `forge/strategy`, `warden_at_arms/strategy`, `scribe/strategy` |
+| memory      | `scopes`                                                                                                   |
+| tools       | `legacy`                                                                                                   |
+
+Persistence `pg_*` is intentionally excluded from coverage in `pyproject.toml` (needs a live Postgres), so those three are expected. The agent-strategy stubs (§2.1) being untested is tautological — there's no code there. The rest are real gaps: `middleware/auth`, `middleware/tracing`, `warden/patterns`, and `memory/scopes` back hot-path security and request-pipeline behavior with no direct unit coverage.
+
+### 3.1 Existing `xfail(strict=False)` tests (6)
+
+These advertise coverage without enforcing it:
+
+- `tests/api/test_agents_routes.py:203`
+- `tests/integration/test_structured_request.py:26`
+- `tests/integration/test_full_pipeline_e2e.py:171`
+- `tests/integration/test_coverage_api.py:260, 418, 457`
+
+`docs/test-quality-remediation-plan.md` (already in repo) lists each with an "unskip" action item. Reference, don't duplicate.
+
+---
+
+## 4. Code smells
+
+### 4.1 God method: `Conduit.route_request`
+
+`src/stronghold/conduit.py:186–735` — a single async method of **~550 lines** with radon cyclomatic complexity **99 (F grade)**. It covers classification, ambiguity handling, session stickiness, intent routing, warden scans, agent dispatch, tracing, learning extraction, and response assembly. This is the docstring-named "ONLY way requests reach an LLM" — which is also why the blast radius of any edit here is high.
+
+### 4.2 Other radon hotspots (C / D / E / F grade)
+
+| Grade | Location                                                     |
+|-------|--------------------------------------------------------------|
+| F(99) | `conduit.py:186` `Conduit.route_request`                     |
+| E(33) | `skills/fixer.py:13` `fix_content`                           |
+| D(29) | `config/loader.py:62` `load_config`                          |
+| D(28) | `api/routes/admin.py:1307` `analyze_quota`                   |
+| D(27) | `api/routes/admin.py:736` `get_quota`                        |
+| C(20) | `conduit.py:134` class body; `memory/episodic/store.py:9` `_matches_scope`; `router/filter.py:14` `filter_candidates` |
+| C(18) | `container.py:216` `create_container`; `api/routes/chat.py:25` `chat_completions`; `api/routes/mcp.py:153` `deploy_server` |
+
+### 4.3 File-size outliers
+
+- `src/stronghold/api/routes/admin.py` — **1,598 lines**, maintainability index C (the only C-rated MI in the tree). Covers learnings admin, user admin, quota, coins, strikes, appeals, coin pricing — at least seven distinct responsibilities in one file.
+- `src/stronghold/skills/connectors.py` — 736 lines.
+- `src/stronghold/conduit.py` — 766 lines, one class.
+
+### 4.4 Broad `except Exception` with silent pass
+
+96 `except Exception` blocks across the source tree. Bandit flags eight `B110 try/except/pass`:
+
+| File:line                                                 | What gets swallowed                                    |
+|-----------------------------------------------------------|--------------------------------------------------------|
+| `agents/factory.py:330`                                   | Strategy registration (see §2.2)                       |
+| `agents/strategies/tool_http.py:58`                       | Any failure during `list_tools()` → returns `[]`       |
+| `api/routes/profile.py:100`                               | Token breakdown lookup → user sees 0 XP with no error  |
+| `mcp/deployer.py:270,275`                                 | K8s `delete_namespaced_deployment/service` failures    |
+| `memory/learnings/embeddings.py:178`                      | Embedding failure → silently skips that learning       |
+| `security/auth_demo_cookie.py:62`                         | Cookie parse error → request falls through as unauth   |
+| `triggers.py:317`                                         | GitHub webhook body parse                              |
+
+Plus one `B112 try/except/continue` at `tools/workspace.py:211`.
+
+Individually most are arguable. Together they describe a "when in doubt, swallow it" culture that makes production failures hard to diagnose. A standard like "log at WARNING, re-raise unless the docstring names the exception" would help.
+
+### 4.5 Module-level mutable singletons
+
+`global` writes at module scope — these make ordering/lifetime bugs hard to test:
+
+- `cache/redis_pool.py:34,50` — `_pool`
+- `persistence/__init__.py:16,30` — `_pool`
+- `models/engine.py:29,76` — `_engine`, `_engine_url`
+- `mcp/oauth/endpoints.py:41` — `_store`
+- `skills/connectors.py:644` — `_claude_cache`, `_claude_cache_ts`
+- `log_config.py:75` — `_CONFIGURED`
+
+The protocol-driven DI container is the stated pattern; these are the leaks. `mcp/oauth/endpoints.py` holding a module-level `_store` is the most surprising one given OAuth is security-critical.
+
+### 4.6 Lazy imports everywhere
+
+**158** imports tagged `# noqa: PLC0415`. `src/stronghold/container.py` alone has 34. Some are legitimate (breaking circulars between `container.py` and `conduit.py`, optional `redis`/`kubernetes` deps), but this density is a signal that the import graph has too many cross-subsystem edges. Worth an audit targeting `container.py` and `api/routes/*` first.
+
+### 4.7 `Any` density
+
+139 `: Any` / `-> Any` annotations. Hot spots: `conduit.py` (`messages: list[dict[str, Any]]`, `auth: Any`, `agent: Any` — the public API of the router), `container.py`, `agents/base.py`. `conduit.py:186` typing `auth: Any` and then checking `isinstance(auth, AuthContext)` inside the function is a runtime-type-narrowing smell — the static type should just be `AuthContext`.
+
+### 4.8 Bandit — low severity but worth triaging
+
+| ID    | Count | Notes                                                                                          |
+|-------|-------|------------------------------------------------------------------------------------------------|
+| B101  | 2     | `assert` in production code (`events.py:100`, `memory/learnings/promoter.py:73`) — stripped under `python -O` |
+| B105  | 6     | String literals like `"Bearer"`, `"refresh"` flagged as "possible hardcoded password" — false positives, but they mark real hot-path auth strings that could use an enum |
+| B106  | 2     | Same idiom in `mcp/oauth/store.py:133,154` — false positive                                    |
+| B107  | 1     | Default arg `token: str = ""` in `tools/github.py:191` — works with `os.environ.get(...)` fallback, still fragile |
+| B110  | 8     | Swallowed exceptions (see §4.4)                                                                |
+| B112  | 1     | `try/except/continue` in `tools/workspace.py:211`                                              |
+| B311  | 2     | Non-cryptographic RNG for jitter (`events.py:204`) and canary routing (`skills/canary.py:116`) — low risk, but canary routing should at least be seeded deterministically per (skill, org_id) to avoid replay asymmetry |
+| B404  | 1     | `subprocess` import in `tools/workspace.py:20`                                                 |
+| B603  | 1     | `subprocess` call at `tools/workspace.py:220` — untrusted-input risk if `cmd` ever takes user text |
+| B608  | 3     | SQL string-building in `persistence/pg_outcomes.py:114,173` and `api/routes/profile.py:175`. The persistence ones interpolate a trusted `group_by` literal from a whitelist; `profile.py` builds `UPDATE ... SET f=$n` from a hardcoded field tuple — both safe today but the pattern is fragile. |
+
+No high-severity bandit findings.
+
+### 4.9 Pre-existing test-quality backlog
+
+`docs/test-quality-remediation-plan.md` has already cataloged 331 weak/bad tests:
+
+- 118 trivial-type tests (`isinstance`/`hasattr` right after assignment)
+- 65 status-only (`status_code == 200` with no body assert)
+- 54 over-mock (mock determines outcome)
+- 34 no-assert smoke tests
+- 32 tautologies (setup equals outcome)
+- 26 planned deletions across 10 files
+
+Top offenders: `tests/test_types.py` (30), `tests/security/test_security_audit_2026_03_30.py` (20), `tests/mcp/test_registries_coverage.py` (18), `tests/api/test_admin_routes.py` (18). Defer to that plan — no need to re-audit here.
+
+### 4.10 Coverage-padding test files
+
+Four files at the `tests/` root whose names advertise the purpose rather than the subject:
+
+| File                                       | LOC   |
+|--------------------------------------------|-------|
+| `tests/test_coverage_final.py`             | 1,630 |
+| `tests/test_coverage_misc.py`              |   935 |
+| `tests/test_new_modules.py`                |   717 |
+| `tests/test_new_modules_2.py`              | 1,039 |
+
+Total 4,321 LOC. Useful as a staging ground but they hide behavior under geography — a change to `skills/forge.py` has no obvious reason to hunt `test_coverage_final.py`. Worth redistributing to `tests/<subsystem>/`.
+
+---
+
+## 5. Production TODOs
+
+Only two survive in `src/`:
+
+- `src/stronghold/api/routes/admin.py:1244` — `update_coin_settings` needs superadmin gating once trust tiers are wired (§4.3 of the existing admin hotspot).
+- `src/stronghold/agents/strategies/builders_learning.py:116` — orphan diagnostic artifact (§2.3).
+
+---
+
+## 6. Red-team / injection bait
+
+`.easter.egg.hi` at the repo root is a prompt-injection honeypot (a file addressed to scanning LLMs with instructions). Not executed, not imported — leaving it alone is the right move. Worth flagging so reviewers know it's intentional.
+
+---
+
+## Suggested priority order for remediation
+
+1. **Flip the seven `BUG CONFIRMED` security tests** (§1.2). These are active vulnerabilities with fixes pre-written as test contracts.
+2. **Fix the `Intent.tier` type leak** (§1.1) and the two `Any`-return regressions (§1.4, §1.5).
+3. **Un-swallow `ImportError` in `factory.py`** (§2.2) — silent agent-strategy failures will bite hard in production.
+4. **Decompose `Conduit.route_request`** (§4.1) and split `api/routes/admin.py` (§4.3) before they accrete more logic.
+5. **Close the 28 untested modules** (§3) prioritizing `middleware/auth`, `middleware/tracing`, `warden/patterns`, `memory/scopes`.
+6. **Execute the existing test-quality plan** (§4.9) — the work is scoped; this catalog just confirms it's still needed.
+7. **Implement or delete the Forge / Scribe / Warden-at-Arms stubs** (§2.1). If they're near-term on the roadmap, promote to skeletons with failing tests; otherwise drop them so the architecture doc stops overselling.

--- a/docs/partial-feature-spec-register.md
+++ b/docs/partial-feature-spec-register.md
@@ -1,0 +1,437 @@
+# Stronghold Partial-Feature Spec Register — 2026-04-23
+
+Features that currently ship as code, routes, docs, or agent configs but whose implementation is a stub, a placeholder, or a subset of what the surrounding scaffolding advertises. Each entry: what's there today, what's missing, acceptance criteria to call it done.
+
+Severity key: **S1** = security/integrity impact, **S2** = user-visible correctness, **S3** = architectural debt.
+
+---
+
+## Index
+
+1. Empty-module feature stubs (18)
+2. Half-implemented agents (Scribe, Warden-at-Arms, Forge)
+3. Conduit execution-tier stubs (tenant policy, cluster pressure)
+4. Schedules route: `run_schedule_now` fakes 202
+5. MCP routes: `repo_url` deploy pipeline
+6. MCP OAuth `/authorize` auto-approves any user_id
+7. Builders learning: store methods just log
+8. Builders learning: orphan diagnostic artifact
+9. Artificer: `max_retries` advertised, never used
+10. Agent store: `update()` ignores identity fields
+11. Admin: `update_coin_settings` missing superadmin gate
+12. Tournament: never records a battle
+13. Canary: never routes traffic
+14. Rate limiter: enforced only on webhooks
+15. Skill catalog / Agent catalog: instantiated, never read
+16. Guest peers (A2A outbound): defined, never instantiated
+17. Agent cards (`agent_card.json`): published, never read
+18. Missing tools referenced by agent configs (canvas, web_search, ha_*, etc.)
+19. Arize tracing backend: docstring only
+20. Bug-contract tests (§1.2 of code-smell catalog)
+
+---
+
+## 1. Empty-module feature stubs
+
+**Severity:** S3 (architectural debt); S2 when the docstring implies a working module is being imported.
+
+Eighteen source files exist only to host a single-line docstring announcing a feature. They would look like "coming soon" placeholders except that each appears in the import graph in at least one place (as a namespace hint for tests, `__init__` re-exports, or future wiring).
+
+| File | Advertised feature |
+|------|-------------------|
+| `agents/cache.py` | "Prompt LRU cache" |
+| `agents/exporter.py` | "GitAgent directory export" |
+| `agents/identity.py` | "AgentIdentity parsing from agent.yaml" |
+| `agents/importer.py` | "GitAgent directory import" |
+| `agents/registry.py` | "Agent CRUD in PostgreSQL" |
+| `agents/streaming.py` | "SSE streaming + tool-loop-to-SSE conversion" |
+| `agents/forge/strategy.py` | "Forge agent: iterative tool/agent creation" |
+| `agents/scribe/strategy.py` | "Scribe agent: research → draft → critique → edit" |
+| `agents/warden_at_arms/strategy.py` | "Warden-at-Arms: real-world interaction + API discovery" |
+| `api/middleware/auth.py` | "Auth middleware: extract AuthContext from request" |
+| `api/middleware/tracing.py` | "Tracing middleware: create trace per request" |
+| `api/routes/conductor.py` | "API route: conductor" |
+| `config/defaults.py` | "Sensible defaults for all configuration fields" |
+| `config/env.py` | "Environment variable resolution" |
+| `tools/legacy.py` | "Legacy tool wrapper for Conductor migration" |
+| `tracing/arize.py` | "Arize Enterprise tracing backend. Stub for now." |
+| `tracing/prompts.py` | "PostgreSQL PromptManager implementation" |
+| `tracing/trace.py` | "Backend-agnostic trace and span types" |
+
+**Spec to finish (per file):**
+1. Decide: promote or delete. Promotion candidates must back a roadmap item in `BACKLOG.md`; everything else is dead scaffolding.
+2. For the stub strategies (§2), see Section 2.
+3. For middleware (`api/middleware/auth.py`, `api/middleware/tracing.py`), consolidate the 17 route files' hand-rolled auth-header parsing (code-smell catalog §7.7) into the middleware. Acceptance: each route calls `request.state.auth` and `request.state.trace_context`, no route reads `request.headers["authorization"]` directly.
+4. For `config/defaults.py` and `config/env.py`, absorb the 12 inline `os.environ.get()` calls cataloged in §7.19. Acceptance: `grep -rn "os.environ.get" src/stronghold/` returns 0 matches outside `config/`.
+5. For `tracing/arize.py`, either implement the backend against the `TracingBackend` protocol with a feature flag in `StrongholdConfig`, or delete the file and remove references from ARCHITECTURE.md §7.
+6. For the agents/* files, either wire the feature behind the stated name or delete the module.
+
+**Acceptance (global):** each file is either removed from source control or exports at least one symbol that production code imports. `vulture src/stronghold/` with confidence 70 should find no class or function named after the module that isn't reached.
+
+---
+
+## 2. Half-implemented agents: Scribe, Warden-at-Arms, Forge
+
+**Severity:** S2. These are three of the six named agents in ARCHITECTURE.md §2.4. Their `agent.yaml` files ship. Their SOUL.md personalities ship. Their strategy modules are docstring-only. In production they silently fall through to whatever generic strategy is registered under their stated `strategy:` name.
+
+### 2.1 Scribe
+
+- **What ships:** `agents/scribe/{agent.yaml, SOUL.md, agent_card.json}`; yaml says `strategy: plan_execute`.
+- **What happens at runtime:** `plan_execute` is registered in `src/stronghold/agents/factory.py:225` as `ArtificerStrategy` — the *code-engineering* workflow (plan → write-file → pytest → mypy → commit). A user asking Scribe to "write a short story" gets ArtificerStrategy attempting to call `write_file` / `run_pytest`.
+- **What's advertised:** `research → draft → critique → defend → edit committee` (ARCHITECTURE.md §2.5).
+- **Spec to finish:**
+  1. Implement `ScribeStrategy` in `src/stronghold/agents/scribe/strategy.py` as a committee pattern: researcher (web_search) → drafter (LLM) → critic (LLM second pass against rubric) → advocate (LLM rebuttal) → editor (final merge).
+  2. Register it in `factory.py` under a new name, e.g. `scribe_committee`, and update `agents/scribe/agent.yaml` to point at it.
+  3. Emit Phoenix spans per committee role.
+  4. Acceptance: an integration test sends a writing prompt to `/v1/chat/completions` with `intent_hint: "writing"`, routes to Scribe, produces a non-empty `content`, and records five Phoenix spans (`scribe.research`, `scribe.draft`, `scribe.critique`, `scribe.advocate`, `scribe.edit`).
+
+### 2.2 Warden-at-Arms
+
+- **What ships:** `agents/warden-at-arms/agent.yaml`, SOUL.md; yaml says `strategy: react`; tools listed: `ha_control, ha_list_devices, ha_notify, api_call, runbook_execute`.
+- **What happens at runtime:** `react` strategy is real, but **none of the five tools exist** — `container.py` registers only `github`, `file_ops`, `shell`, `workspace`, and the quality-gate tools. Any call through Warden-at-Arms will fail with "Tool not found" for every listed capability.
+- **What's advertised:** "API surface discovery on initialization" + device control.
+- **Spec to finish:**
+  1. Build five tool executors in `src/stronghold/tools/`: `home_assistant.py` (HA_TOKEN env + REST), `api_call.py` (generic outbound HTTP behind SSRF block + warden scan of response), `runbook_execute.py` (reads a runbook spec, executes steps with per-step policy gate).
+  2. Add corresponding `TOOL_DEF` entries and register them in `container.py` alongside `GITHUB_TOOL_DEF`.
+  3. Implement "API surface discovery": on first call to an unknown host, fetch `/.well-known/openapi.yaml` (or `/openapi.json`), pass through Sentinel risk classifier, emit a generated skill into `SkillCatalog`.
+  4. Acceptance: `/v1/chat/completions` with a Warden-at-Arms prompt triggers an `api_call` tool call that succeeds end-to-end against a local test HTTP server; subsequent discovery step creates a skill in the catalog.
+
+### 2.3 Forge
+
+- **What ships:** `agents/forge/strategy.py` (docstring stub). No `agent.yaml` either — `agents/` has `arbiter`, `archie`, `artificer`, `auditor`, `davinci`, `default`, `fabulist`, `frank`, `herald`, `mason`, `master-at-arms`, `quartermaster`, `ranger`, `scribe`, `warden-at-arms` — **no `forge/`**.
+- **What happens at runtime:** Forge doesn't exist as an agent at all. Its strategy file is orphaned.
+- **What's advertised:** Creates tools and agents. Output starts at ☠️ tier. Iterates `generate → scan → validate schema → test → iterate` (ARCHITECTURE.md §5.4).
+- **Spec to finish:**
+  1. Create `agents/forge/{agent.yaml, SOUL.md, agent_card.json}` with `strategy: forge_iterate`, trust_tier `t1 elevated`, tools `[file_ops, scanner, schema_validator, test_executor, prompt_manager]`.
+  2. Build the missing tools: `schema_validator` (validates candidate agent.yaml / skill frontmatter), `test_executor` (runs the candidate in a sandbox — reuse `sandbox/deployer.py`), `prompt_manager` (tool-call wrapper around existing PromptManager).
+  3. Implement `ForgeStrategy` in `src/stronghold/agents/forge/strategy.py` as the cited iteration loop.
+  4. Ensure output agents/skills are saved with `trust_tier="skull"` and require operator approval before being reachable from `create_agents`.
+  5. Acceptance: Forge can be invoked via chat with "create a new skill that summarizes a URL", returns a skill in skull tier, and attempting to use the skill from another agent fails until approved.
+
+---
+
+## 3. Conduit execution-tier override stack
+
+**Severity:** S2 (correctness); S1 if cluster pressure is the only thing standing between a spike and LiteLLM saturation.
+
+`src/stronghold/conduit.py:63–112` — `determine_execution_tier` docstring advertises a 4-step override stack. Two of the four are stubs:
+
+- `_get_cluster_pressure()` (line 45–52) — "Stub: always returns False. Will be wired to real metrics later." Result: the cluster-pressure downgrade at line 98 never fires.
+- `_apply_tenant_policy(tier, _tenant_id=None)` (line 55–60) — "Stub: returns tier unchanged. Will consult tenant config later." Caller at line 95 doesn't even pass `_tenant_id`. Tenant overrides in `StrongholdConfig` have no effect.
+
+**Spec to finish:**
+1. `_get_cluster_pressure`: read recent LiteLLM latency/error-rate from the router's `QuotaTracker` (or a new `ClusterMetrics` protocol). Returns `True` when P95 latency > 10s or 5xx rate > 5% over the last minute. Config thresholds in `StrongholdConfig.router.pressure`.
+2. `_apply_tenant_policy`: accept `tenant_id`, look up `config.tenants[tenant_id].tier_overrides`, return the mapped tier or input tier if no override.
+3. Update `determine_execution_tier` call site in `conduit.py:95` to pass `intent.tenant_id` (add field to `Intent` if missing).
+4. Acceptance: unit tests for all 4 override-stack orderings; integration test that sets a tenant policy override in config and verifies the route picks it up.
+
+---
+
+## 4. `run_schedule_now` pretends to queue
+
+**Severity:** S2.
+
+`src/stronghold/api/routes/schedules.py:129–142` — the endpoint returns `202 Accepted` with `{"task_id": task.id, "status": "triggered"}` and nothing else happens. The comment admits: *"Record immediate execution intent — the Reactor or worker will pick it up. For now, return 202 Accepted to indicate the task has been queued."* No `record_intent` call, no reactor notification, no queue write.
+
+Users see a success response and expect the schedule to fire; it doesn't.
+
+**Spec to finish:**
+1. Add `ScheduleStore.mark_due(task_id)` (updates `next_run_at = now`) or `Reactor.trigger_schedule(task_id)` (posts a synthetic `_schedule:<id>` event to the reactor queue).
+2. Call from `run_schedule_now` before the 202 response.
+3. Confirm via `GET /schedules/{id}/history` that an execution was recorded within the next reactor tick.
+4. Acceptance: integration test that creates a schedule with `next_run_at` 1 hour out, POSTs `/run`, and observes a history entry within 2 seconds.
+
+---
+
+## 5. MCP `deploy_server` repo-url path returns a fake pipeline
+
+**Severity:** S2.
+
+`src/stronghold/api/routes/mcp.py:274–295` — when a caller POSTs `deploy_server` with `{"repo_url": "..."}`, the route returns `202 Accepted` with a body shaped like a pipeline status:
+
+```json
+{"pipeline": {"clone": "pending", "scan": "pending", "build": "pending",
+              "deploy": "pending", "discover": "pending"}, ...}
+```
+
+No clone happens. No scan, build, deploy, or discover step exists. The comment says "full implementation in v1.1". The response is indistinguishable from a real async pipeline; clients polling will never see status changes.
+
+**Spec to finish:**
+1. Either remove the `repo_url` branch and return 501 Not Implemented, or:
+2. Build the pipeline: clone → `bandit`+`ruff` scan → container build (reuse `sandbox/deployer.py` infra) → deploy via `K8sDeployer` → `/tools` discovery → skill generation.
+3. Persist pipeline state (add `mcp_pipeline_runs` table) so `GET /mcp/pipeline/{id}` reflects real progress.
+4. Acceptance: point at a sample MCP server repo, observe all five steps complete, and confirm the resulting MCP server is listable via `GET /mcp/servers`.
+
+---
+
+## 6. MCP OAuth `/authorize` auto-approves arbitrary user IDs
+
+**Severity:** S1 — this is a security bug, not just a stub.
+
+`src/stronghold/mcp/oauth/endpoints.py:124–158` — the authorization endpoint takes `user_id` and `tenant_id` **from query parameters** and mints an auth code for that identity. Comment: *"Auto-approve for now (production: redirect to consent UI). The user_id/tenant_id would come from the session in production."*
+
+Any client that knows a registered `client_id` + valid `redirect_uri` + PKCE challenge can request an auth code for any user in any tenant by appending `?user_id=victim@corp.com&tenant_id=corp`.
+
+**Spec to finish:**
+1. Read the current session (cookie via `CookieAuthProvider`) and require it to be authenticated.
+2. Derive `user_id` / `tenant_id` from the session, never from query params.
+3. Render a consent HTML page (template under `src/stronghold/dashboard/`) that shows requested scopes and the `client_name` from the DCR record.
+4. Only issue an auth code on POST from the consent form with CSRF token + session match.
+5. Acceptance: integration test that an unauthenticated `/oauth/authorize` redirects to login; an authenticated request renders consent; POST without matching session returns 403; successful POST returns the auth code and records a consent audit-log entry.
+
+---
+
+## 7. Builders learning: store methods only log
+
+**Severity:** S2. The agent-roster doc calls this "BuildersLearningStrategy" and ARCHITECTURE.md §4.4 describes a self-improving memory loop. The strategy *claims* to store learnings.
+
+`src/stronghold/agents/strategies/builders_learning.py:305–324` —
+
+```python
+async def _store_frank_learning(self, ...) -> None:
+    """Store Frank learning — logs for now, memory store in follow-up."""
+    logger.info("Frank learning: ...")
+
+async def _store_mason_learning(self, ...) -> None:
+    """Store Mason learning — logs for now, memory store in follow-up."""
+```
+
+Nothing is written to `LearningStore`. The "learning" strategy doesn't learn.
+
+**Spec to finish:**
+1. Inject `LearningStore` into `BuildersLearningStrategy.__init__` (via the factory).
+2. In `_store_frank_learning`: construct a `Learning` with `task_type="builders.recon"`, `scope=MemoryScope.AGENT`, `agent="frank"`, and relevant keys (repo state summary, failure patterns). Call `learning_store.add(learning)`.
+3. Same for `_store_mason_learning` (task_type `builders.diagnostics`).
+4. Tag both so `LearningPromoter.check_and_promote` can surface them.
+5. Acceptance: after one Frank run and one Mason run, `SELECT COUNT(*) FROM learnings WHERE agent IN ('frank','mason')` increases by ≥ 2; subsequent runs retrieve the prior learning via `find_relevant`.
+
+---
+
+## 8. Builders learning: orphan diagnostic artifact
+
+**Severity:** S3.
+
+`src/stronghold/agents/strategies/builders_learning.py:116–126` — builds a diagnostic dict that is explicitly discarded with `_ = {...}` and a comment `TODO: wire to orchestrator`. Logs "Frank diagnostic produced" and moves on.
+
+**Spec to finish:**
+1. Wire to `orchestrator/pipeline.py` — post a `PipelineEvent` of kind `diagnostic` with the dict as payload.
+2. Store in `outcomes` or a new `diagnostics` table keyed by `run_id`.
+3. Surface on the Mason dashboard per run.
+4. Acceptance: each Frank run produces a row visible via `GET /v1/stronghold/pipeline/{run_id}/diagnostics`. Delete the `_ =` anti-pattern; linter sees no unused value.
+
+---
+
+## 9. Artificer: `max_retries_per_phase` is dead config
+
+**Severity:** S3; S2 because it implies per-phase retry which isn't implemented.
+
+`src/stronghold/agents/artificer/strategy.py:42–48` — constructor takes `max_retries_per_phase: int = 2`, stores as `self.max_retries`. Class docstring (lines 30–40) promises:
+
+> 2. For each phase:
+>    c. If fail: fix and recheck (max 2 retries)
+>    d. Commit when green
+
+The `reason()` body implements a single generic tool loop with `max_phases * 3` LLM rounds (line 99). There is no phase concept — no plan decomposition, no per-phase retry, no green-gate commit. `self.max_retries` is never read (vulture flagged this).
+
+**Spec to finish:**
+1. Parse the plan output from `_plan()` into discrete phases (numbered list → `list[Phase]`).
+2. For each phase: run tool loop → check `run_pytest` / `run_ruff` / `run_mypy` exit status → if red, give the model the failure log and retry, up to `self.max_retries` times → commit via the `git_commit` tool on green.
+3. Update the status callback to emit `phase_started`, `phase_retry`, `phase_committed` events.
+4. Acceptance: integration test with a plan containing 3 phases sees 3 `phase_committed` events and at least one retry surfaced.
+
+---
+
+## 10. `InMemoryAgentStore.update` silently drops identity changes
+
+**Severity:** S2.
+
+`src/stronghold/agents/store.py:144–167` — `update()` accepts a dict and only applies `soul_prompt` and `rules`. Comment: *"For identity field updates, we'd need to rebuild the Agent (AgentIdentity is frozen). For now, update soul/rules only."*
+
+The admin dashboard's agent edit form sends `{model, tools, trust_tier, priority_tier, max_tool_rounds, ...}` — these are silently discarded. The API returns 200 with the updated object (which still has old values), so the user thinks the change took effect.
+
+**Spec to finish:**
+1. Rebuild the `AgentIdentity` dataclass with the new values via `dataclasses.replace` on a non-frozen copy, then re-freeze.
+2. Validate each field against its allowed domain (trust_tier ∈ {t0..t3, skull}, priority_tier ∈ {P0..P5}, model exists in router, tools exist in registry).
+3. Persist to `PgAgentRegistry` when available.
+4. Return the updated object; reject unknown fields with 400.
+5. Acceptance: a PUT to `/v1/stronghold/agents/{name}` with new `trust_tier` and `max_tool_rounds` is reflected on a follow-up GET; an invalid `trust_tier` returns 400 with a structured error.
+
+---
+
+## 11. `update_coin_settings` missing superadmin gate
+
+**Severity:** S1.
+
+`src/stronghold/api/routes/admin.py:1240–1270` — any admin (`_require_admin`, not `_require_superadmin`) can change the banking rate that applies to every wallet. TODO comment admits the gate is missing.
+
+**Spec to finish:**
+1. Add `_require_superadmin(request)` (checks `"superadmin"` in auth.roles or equivalent). Define the role in `auth_composite` / Casbin config.
+2. Wrap `update_coin_settings` with it.
+3. Add an audit-log entry per change (old → new).
+4. Acceptance: as admin-but-not-superadmin, PUT returns 403; as superadmin, succeeds and appears in audit log.
+
+---
+
+## 12. Tournament system: instantiated, never records a battle
+
+**Severity:** S3.
+
+`Tournament` is fully implemented (`src/stronghold/agents/tournament.py`) with Elo ratings, promotion checks, and leaderboard queries. It's wired into `Container.tournament` at `container.py:444`. But **no production code calls `record_battle`**. The only reference is `triggers.py:125` calling `get_stats()` for a periodic log.
+
+ARCHITECTURE.md §2.6 ("Routing: Conduit + Tournaments") implies tournaments feed routing decisions.
+
+**Spec to finish:**
+1. On ambiguous requests (the arbiter path in `conduit.py:266–285`), run a pair of candidate agents, judge with the `judge_model`, record via `Tournament.record_battle`.
+2. Expose `Tournament.check_promotions` on a nightly trigger (add to `triggers.py`).
+3. Surface leaderboard at `/v1/stronghold/tournament` (already has route scaffolding? — verify).
+4. Acceptance: at least one `battles` row recorded per ambiguous request; promotion threshold crossing moves an agent's `trust_tier` up.
+
+---
+
+## 13. Canary manager: nothing actually routes through the canary
+
+**Severity:** S2 — "canary deployments" is a feature name used in `BACKLOG.md`.
+
+`src/stronghold/skills/canary.py` implements staged canary rollout with `should_use_new_version(skill_name, org_id)` returning a bool based on traffic %. It's never called. `record_result()` is also never called. The only canary interaction is a trigger that polls `check_promotion_or_rollback` (triggers.py:144), which cannot fire sensibly because no results have been recorded.
+
+**Spec to finish:**
+1. In the skill dispatcher (wherever skills are invoked — `skills/forge.py` or a `SkillRegistry.get` wrapper), consult `canary_manager.should_use_new_version(skill_name, auth.org_id)` before picking the version.
+2. After invocation, call `canary_manager.record_result(skill_name, success=ok, org_id=auth.org_id)`.
+3. Ensure the existing promotion/rollback trigger now has real data to act on.
+4. Acceptance: deploy a canary at 10% traffic; run 1000 requests; observe approximately 100 go to new version, failure-rate trigger promotes or rolls back as configured.
+
+---
+
+## 14. Rate limiter enforced only on webhooks
+
+**Severity:** S1 — classifier route ingests user text without throttling.
+
+`container.py:267–282` picks a Redis or in-memory `RateLimiter`. The only enforcement sites are `api/routes/webhooks.py:171, 252` (two webhook handlers). `chat.py`, `agents.py`, `admin.py`, etc. have no rate-limit check. `conduit.py`'s `route_request` doesn't consult the limiter at all.
+
+Config section `config.rate_limit` with `requests_per_minute` gives the impression of a global cap; in reality it caps a fraction of one route pair.
+
+**Spec to finish:**
+1. Hoist rate-limit enforcement into `api/middleware/auth.py` (pair with the auth extraction already planned in §1).
+2. Default key: `auth.org_id + auth.user_id`; unauthenticated requests keyed on remote IP.
+3. Per-route overrides (config-driven) for expensive endpoints.
+4. Acceptance: `config.rate_limit.requests_per_minute = 10` + 20 requests from one user in 60s returns at least 10 × 429; headers contain `X-RateLimit-Remaining`.
+
+---
+
+## 15. `SkillCatalog` / `AgentCatalog` instantiated but unreferenced
+
+**Severity:** S3.
+
+`container.py:337` constructs `skill_catalog = SkillCatalog()`, passes it into `Container(..., skill_catalog=skill_catalog, ...)`. `grep -rn "skill_catalog\." src/stronghold/` returns zero matches outside construction. `ResourceCatalog` is in the same boat. `AgentCatalog` (`src/stronghold/agents/catalog.py`) isn't even instantiated — vulture flags its class, `from_identity`, `list_by_trust_tier`, `list_by_priority_tier` as unused.
+
+ARCHITECTURE.md §2.7/§5.3 references "catalog" as a first-class discovery surface.
+
+**Spec to finish:**
+1. Decide product direction: catalogs back the Marketplace + dashboard skill browser, or they're cruft.
+2. If product: populate on startup from `agents/` and `skills/` dirs, expose via `/v1/stronghold/catalog/{agents,skills,resources}`, consult in `api/routes/marketplace.py` browse flows.
+3. If not: delete `agents/catalog.py`, `skills/catalog.py`, `resources/catalog.py`, and the container fields.
+4. Acceptance: either each catalog has ≥ 3 call sites outside construction, or vulture at 60% confidence has zero matches for the class names.
+
+---
+
+## 16. `GuestPeerRegistry` (A2A outbound) defined, never instantiated
+
+**Severity:** S3.
+
+`src/stronghold/a2a/guest_peers.py:85–135` defines `GuestPeerRegistry` with `register_peer`, `remove_peer`, `list_peers`, `delegate`. None are reachable from production code (all flagged by vulture). ADR-K8S-029 references it; container does not instantiate it.
+
+**Spec to finish:**
+1. Wire into `Container` (new field `guest_peers`), populated from `config.a2a.guest_peers`.
+2. Add outbound A2A tool executor (`tools/a2a_delegate.py`) that consults the registry before delegating.
+3. Audit every outbound delegation via `AuditLog`.
+4. Enforce cross-tenant prohibition at the registry level.
+5. Acceptance: configure one guest peer in YAML, have Artificer delegate a task to it via a tool call, observe an `AuditLog` entry with `action="a2a_delegate"`.
+
+---
+
+## 17. `agent_card.json` published per agent, never consumed
+
+**Severity:** S3.
+
+Every agent dir under `agents/` ships a JSON file like `agents/arbiter/agent_card.json` with an A2A v2024-11-05 card (capabilities, skills, trust tier, protocolVersion). `grep -rn "agent_card" src/stronghold/` returns zero matches. The cards aren't served, parsed, or validated.
+
+The `protocolVersion` field implies A2A interoperability; in reality only the YAML config is loaded by `agents/factory.py`.
+
+**Spec to finish:**
+1. Add `/v1/stronghold/agents/{name}/card` route that returns the contents of `agent_card.json`.
+2. Validate against the A2A schema on agent load; fail fast if malformed.
+3. Keep in sync with `agent.yaml` — either generate the card from the yaml at build time, or validate they match on load (tools list, trust_tier, model).
+4. Acceptance: A2A-capable client fetches `/agents/arbiter/card` and gets a v2024-11-05 card matching the yaml; mismatched card → startup error.
+
+---
+
+## 18. Agent configs reference tools that don't exist
+
+**Severity:** S2.
+
+Spot-check of registered vs declared tools:
+
+| Agent | `agent.yaml` tools declared | Registered in `container.py` |
+|-------|------------------------------|------------------------------|
+| davinci | `canvas` | missing |
+| scribe | `file_ops, web_search` | `web_search` missing |
+| ranger | `web_search, database_query, knowledge_search` | all three missing |
+| warden-at-arms | `ha_control, ha_list_devices, ha_notify, api_call, runbook_execute` | all five missing |
+| artificer (ARCHITECTURE §2.4) | `file_ops, shell, test_runner, lint_runner, git` | `test_runner`, `lint_runner`, `git` missing (replaced by `run_pytest`, `run_ruff_check`, implicit) |
+| forge (ARCHITECTURE §2.4) | `scanner, schema_validator, test_executor, prompt_manager` | all missing |
+
+Running these agents produces "tool not found" or the agent just can't do the thing its description promises.
+
+**Spec to finish:**
+1. Implement or rename each missing tool so that every `agent.yaml` tool is satisfied by a `TOOL_DEF` in `src/stronghold/tools/`.
+2. Add a startup-time check: for each agent in `agents_dir`, verify all declared tools resolve against `ToolRegistry`. Fail loud on mismatch.
+3. Update ARCHITECTURE.md §2.4 to match reality.
+4. Acceptance: startup log lists "Tool parity check: ok (N agents × M tools)" or aborts.
+
+---
+
+## 19. Arize tracing backend: 1-line docstring
+
+**Severity:** S3. Phoenix is the real backend; Arize is advertised as enterprise.
+
+`src/stronghold/tracing/arize.py` contains only `"""Arize Enterprise tracing backend. Stub for now."""`. README/ARCHITECTURE name-check Arize. Container instantiates `PhoenixTracingBackend`; there's no switch to Arize.
+
+**Spec to finish:**
+1. If on the roadmap: implement `ArizeTracingBackend` against `TracingBackend` protocol, select via `config.tracing.backend = "arize" | "phoenix"`.
+2. Otherwise: delete the file and remove references.
+3. Acceptance: config value toggles backend at startup; Phoenix and Arize both pass the existing `TracingBackend` contract tests.
+
+---
+
+## 20. Bug-contract tests — specs already written
+
+**Severity:** S1 (seven known live vulnerabilities).
+
+Already enumerated in `docs/code-smell-catalog-2026-04-23.md §1.2`. Each inverted assert in `tests/security/test_security_audit_2026_03_30.py` encodes a required fix. The spec for each is the test itself — when the fix ships, the test's assertion flips and the `BUG CONFIRMED` comment is deleted.
+
+Rollup:
+- C1 (line 160): add `org_id` to upsert conflict key in `PgAgentRegistry`.
+- C2 (line 349): reject empty caller `org_id` in `get/delete/list`.
+- H2 (line 392): forbid `/` in `org_id` or use delimiter-aware parsing for session IDs.
+- H3 (line 441): Warden must scan the middle of long content, not only head+tail windows.
+- H4 (line 485): Warden L3 must return `"inconclusive"` (not `"safe"`) on LLM exceptions.
+- H6 (line 726): Warden must not exit early when the first 200 chars look like code.
+- Q1 (line 972): `PgQuotaTracker.record_usage` signature regression guard.
+
+---
+
+## Priority rollup
+
+Top security items (S1): 6, 11, 14, and all seven bug contracts in 20.
+
+Top user-visible correctness (S2): 2 (Scribe/Warden-at-Arms falling through), 3 (tier overrides), 4 (run_schedule_now), 5 (MCP repo_url), 7 (builders learning not stored), 9 (Artificer no-retry), 10 (agent update drops fields), 13 (canary doesn't route), 18 (missing tools).
+
+Architecture debt (S3): 1 (empty modules), 8 (orphan diagnostic), 12 (tournament), 15 (catalogs), 16 (guest peers), 17 (agent cards), 19 (Arize).
+
+**Recommended sequence:**
+1. Ship the bug contracts (§20) — fixes are scoped and already have tests.
+2. Close OAuth consent (§6) and superadmin gate (§11) — remaining S1 items.
+3. Hoist rate limiting (§14) into shared middleware (pairs with §1 middleware consolidation).
+4. Fix `AgentStore.update` (§10) and `run_schedule_now` (§4) — both return-200 lies that mislead users.
+5. Decide fate of Scribe / Warden-at-Arms / Forge (§2) — the architecture doc needs to stop overselling regardless.
+6. Clean up the S3 tier per roadmap.


### PR DESCRIPTION
Scans src/ and tests/ with ruff/mypy/bandit/vulture/radon plus targeted greps
and writes findings to docs/code-smell-catalog-2026-04-23.md.

Highlights:
- 7 live security bugs documented as inverted tests in test_security_audit_2026_03_30
- Intent.tier typed as plain str at conduit.py:112 (Literal leak)
- Conduit.route_request is 550 lines / CC 99 / F-grade
- 28 source modules have no tests importing them
- Forge / Scribe / Warden-at-Arms strategies are docstring-only stubs
- factory.py silently swallows ImportError on every strategy registration
- 158 lazy imports (PLC0415), 139 Any annotations, 96 except-Exception blocks
- 27 bandit findings (all low) and 16 high-confidence vulture findings

Cross-references docs/test-quality-remediation-plan.md rather than duplicating.

https://claude.ai/code/session_012FU9Lx34Wkfv65mno4Swdx