### PR TITLE
fix(ci): RedisSessionStore max_messages=0 + drift-check false positive

### DIFF
--- a/.github/workflows/drift-check.yml
+++ b/.github/workflows/drift-check.yml
@@ -46,28 +46,32 @@ jobs:
         continue-on-error: true
         run: |
           ruff check src/stronghold/ 2>&1 | tee /tmp/ruff-check.txt
-          echo "errors=$(grep -c 'Found [0-9]' /tmp/ruff-check.txt || echo 0)" >> "$GITHUB_OUTPUT"
+          ERRORS=$(grep -c 'Found [0-9]' /tmp/ruff-check.txt || true)
+          echo "errors=${ERRORS:-0}" >> "$GITHUB_OUTPUT"
 
       - name: Ruff format (full)
         id: ruff_format
         continue-on-error: true
         run: |
           ruff format --check src/stronghold/ 2>&1 | tee /tmp/ruff-format.txt
-          echo "errors=$(grep -c 'would be reformatted' /tmp/ruff-format.txt || echo 0)" >> "$GITHUB_OUTPUT"
+          ERRORS=$(grep -c 'would be reformatted' /tmp/ruff-format.txt || true)
+          echo "errors=${ERRORS:-0}" >> "$GITHUB_OUTPUT"
 
       - name: Mypy strict (full)
         id: mypy
         continue-on-error: true
         run: |
           mypy src/stronghold/ --strict 2>&1 | tee /tmp/mypy.txt
-          echo "errors=$(grep -c 'error:' /tmp/mypy.txt || echo 0)" >> "$GITHUB_OUTPUT"
+          ERRORS=$(grep -c 'error:' /tmp/mypy.txt || true)
+          echo "errors=${ERRORS:-0}" >> "$GITHUB_OUTPUT"
 
       - name: Bandit (full)
         id: bandit
         continue-on-error: true
         run: |
           bandit -r src/stronghold/ -ll --skip B608 2>&1 | tee /tmp/bandit.txt
-          echo "errors=$(grep -c 'Issue:' /tmp/bandit.txt || echo 0)" >> "$GITHUB_OUTPUT"
+          ERRORS=$(grep -c 'Issue:' /tmp/bandit.txt || true)
+          echo "errors=${ERRORS:-0}" >> "$GITHUB_OUTPUT"
 
       - name: Check for drift
         id: summary

--- a/src/stronghold/cache/session_store.py
+++ b/src/stronghold/cache/session_store.py
@@ -59,9 +59,12 @@ class RedisSessionStore:
                 f"got bare id: {session_id[:20]!r}"
             )
             raise ValueError(err)
-        limit = max_messages or self._max
+        limit = max_messages if max_messages is not None else self._max
         ttl = ttl_seconds or self._ttl
         cutoff = time.time() - ttl
+
+        if limit == 0:
+            return []
 
         rkey = self._key(session_id)
         raw: list[Any] = await self._redis.lrange(rkey, 0, -1)  # type: ignore[misc]


### PR DESCRIPTION
## Summary

Two CI fixes for the integration → main pipeline:

1. **RedisSessionStore `max_messages=0` bug** — `get_history(max_messages=0)` returned all messages instead of `[]` because `0 or self._max` evaluates to `self._max`. Fixed with explicit `None` check + early return for `limit == 0` (Python slice `[-0:]` returns full list).

2. **drift-check.yml false positive** — `grep -c` exits with code 1 on no match, causing `|| echo 0` to also run. Inside `$(...)`, both outputs are captured, writing a bare `0` line to `$GITHUB_OUTPUT` → `Invalid format '0'` error → step marked as failure despite checks passing clean. Fixed by using `|| true` and separate variable assignment.

## Testing

- 4189 passed, 0 failed locally
- Closes false-positive issue #1196